### PR TITLE
Update README to use absolute path for hook command

### DIFF
--- a/claude_code_hooks/biome_format/README.md
+++ b/claude_code_hooks/biome_format/README.md
@@ -13,14 +13,15 @@ JavaScriptおよびTypeScriptファイルの編集時に自動的にBiomeフォ�
 
 ### 1. スクリプトの配置
 
-このディレクトリの `biome_format.sh` を任意の場所にコピーします。
-今回はプロジェクトディレクトリ直下の`.claude/hooks/biome_format.sh`に保存する前提で説明します。
-
-コピー後、実行権限を付与してください。
+このディレクトリの `biome_format.sh` を `~/bin/` ディレクトリにコピーします。
 
 ```bash
-$ chmod a+x .claude/hooks/biome_format.sh
+$ mkdir -p ~/bin
+$ cp biome_format.sh ~/bin/
+$ chmod +x ~/bin/biome_format.sh
 ```
+
+**注意**: Claude Code hookは相対パスで指定するとカレントディレクトリが不定であるため正しく実行できないケースがあります。必ず絶対パス（`~/bin/biome_format.sh`）を使用してください。
 
 ### 2. Claude Code hookの設定
 
@@ -35,7 +36,7 @@ Claude Codeの設定で以下のhookを追加してください：
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/biome_format.sh"
+            "command": "~/bin/biome_format.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
Claude Code hookで相対パスを使用するとカレントディレクトリが不定であるため正しく実行できないケースに対応するため、READMEを更新しました。

## Changes
- スクリプトの配置先を`~/bin/`に変更
- 相対パスの問題について注意書きを追加
- hookの設定例を絶対パス(`~/bin/biome_format.sh`)に更新
- セットアップ手順を明確化（mkdir、cp、chmodを含む）

## Benefits
- どのプロジェクトからでも同じスクリプトを確実に実行可能
- カレントディレクトリに依存しない安定した動作
- セットアップ手順がより明確でわかりやすい

🤖 Generated with [Claude Code](https://claude.com/claude-code)