### PR TITLE
Update README to use /plugin commands and add official documentation references

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,21 +16,31 @@ Claude Code用の開発支援ツールとプラグインのコレクションで
 
 Claude Codeのマーケットプレイス機能を使用して、プラグインを簡単にインストールできます。
 
-1. マーケットプレイスにこのリポジトリを追加:
+1. Claude Code上でマーケットプレイスにこのリポジトリを追加:
 
-```bash
-# Claude Codeの設定ファイル（~/.config/claude/config.json）に以下を追加
-{
-  "marketplaces": [
-    {
-      "name": "xtone-ai-development-tools",
-      "url": "https://raw.githubusercontent.com/xtone/ai_development_tools/main/.claude-plugin/marketplace.json"
-    }
-  ]
-}
+```
+/plugin marketplace add git@github.com:xtone/ai_development_tools.git
 ```
 
-2. Claude Codeのマーケットプレイスからプラグインをインストール:
+または、HTTPSを使用する場合:
+
+```
+/plugin marketplace add xtone/ai_development_tools
+```
+
+2. プラグインをインストール:
+
+インタラクティブにプラグインを選択してインストール:
+
+```
+/plugin
+```
+
+または、直接プラグイン名を指定してインストール:
+
+```
+/plugin install biome-format@xtone-ai-development-tools
+```
 
 プラグインをインストールすると、以下が自動的に行われます:
 - 必要なスクリプトがインストールディレクトリにコピーされる
@@ -40,6 +50,9 @@ Claude Codeのマーケットプレイス機能を使用して、プラグイン
 ### Method 2: 手動インストール
 
 個別のプラグインを手動でセットアップする場合は、各プラグインのREADMEを参照してください。
+
+**参考文献:**
+- [Claude Code Plugins - 公式ドキュメント](https://docs.claude.com/en/docs/claude-code/plugins)
 
 ## このリポジトリをマーケットプレイスに追加する方法
 
@@ -129,13 +142,12 @@ git add your_plugin/hooks/your_script.sh
 git update-index --chmod=+x your_plugin/hooks/your_script.sh
 ```
 
-### 6. マーケットプレイスURLの公開
+### 6. リポジトリの公開
 
-リポジトリをGitHubにプッシュ後、以下のURLをマーケットプレイスURLとして公開します:
+リポジトリをGitHubにプッシュすることで、他のユーザーがマーケットプレイスを追加できるようになります。
 
-```
-https://raw.githubusercontent.com/yourusername/yourrepo/main/.claude-plugin/marketplace.json
-```
+**参考文献:**
+- [Claude Code Plugins - Develop More Complex Plugins](https://docs.claude.com/en/docs/claude-code/plugins#develop-more-complex-plugins)
 
 ## ライセンス
 


### PR DESCRIPTION
## 概要

README.mdをClaude Codeの公式ドキュメントに準拠した形式に更新し、参考文献リンクを追加しました。

## 変更内容

### 1. プラグインのインストール方法を/pluginコマンドに変更

**変更前:**
- 設定ファイル（~/.config/claude/config.json）を手動で編集する方法を記載

**変更後:**
- `/plugin marketplace add` コマンドを使用する方法（推奨）
  ```
  /plugin marketplace add git@github.com:xtone/ai_development_tools.git
  ```
  または
  ```
  /plugin marketplace add xtone/ai_development_tools
  ```

- プラグインインストールコマンドを追加:
  - インタラクティブ: `/plugin`
  - 直接指定: `/plugin install biome-format@xtone-ai-development-tools`

### 2. 公式ドキュメントへの参考文献リンクを追加

**プラグインのインストール方法セクション:**
- 参考文献として[Claude Code Plugins - 公式ドキュメント](https://docs.claude.com/en/docs/claude-code/plugins)を追加

**プラグイン開発セクション:**
- 「6. リポジトリの公開」の説明を追加
- 参考文献として[Claude Code Plugins - Develop More Complex Plugins](https://docs.claude.com/en/docs/claude-code/plugins#develop-more-complex-plugins)を追加

## メリット

✅ **簡単なインストール**: 設定ファイルの手動編集が不要
✅ **公式準拠**: Claude Codeの公式ドキュメントに準拠した方法
✅ **参考情報へのアクセス**: ユーザーが公式ドキュメントを簡単に参照可能
✅ **開発者フレンドリー**: プラグイン開発者向けの詳細情報へのアクセス改善

## 影響範囲

- README.mdのみ
- 既存のプラグインやスクリプトには影響なし

## 参照

- [Claude Code Plugin Marketplaces - 公式ドキュメント](https://docs.claude.com/en/docs/claude-code/plugin-marketplaces)
- [Claude Code Plugins - 公式ドキュメント](https://docs.claude.com/en/docs/claude-code/plugins)

🤖 Generated with [Claude Code](https://claude.com/claude-code)