### PR TITLE
Add iOS development skills directory

### DIFF
--- a/ios_development/README.md
+++ b/ios_development/README.md
@@ -1,0 +1,13 @@
+# iOS Development Skills
+
+iOS/SwiftUI開発用のClaude Codeスキル集。
+
+## スキル一覧
+
+- **swift-ios-migration**: Swift/iOSマイグレーションガイド
+- **swiftui-accessibility**: アクセシビリティ実装ガイド
+- **swiftui-code-review-checklist**: コードレビューチェックリスト
+- **swiftui-coding-guidelines**: コーディングガイドライン
+- **swiftui-components**: UIコンポーネントカタログ
+- **swiftui-ssot**: 状態管理（SSOT）ガイド
+

--- a/ios_development/skills/swift-ios-migration/SKILL.md
+++ b/ios_development/skills/swift-ios-migration/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: swift-ios-migration
+description: Migration guide for Swift and iOS. Use when migrating ObservableObject to @Observable (iOS 17), enabling Swift 6/6.2 Strict Concurrency, fixing @MainActor/Sendable warnings, adopting Approachable Concurrency (Swift 6.2), or handling iPadOS 26 windowing system changes (UIRequiresFullScreen deprecation). Covers breaking changes and version upgrade tasks.
+---
+
+# Swift/iOS マイグレーションガイド
+
+既存コードの移行作業やバージョンアップに伴う破壊的変更への対応ガイド。
+
+## ディレクトリ構成
+
+```
+swift-ios-migration/
+├── SKILL.md (このファイル)
+└── references/
+    ├── ios17-observable.md   # @Observable移行パターン
+    ├── swift6-concurrency.md # Swift 6並行処理対応
+    ├── swift62-changes.md    # Swift 6.2 / Xcode 26
+    └── ipados26-windowing.md # iPadOS 26ウィンドウシステム
+```
+
+## リファレンスファイル
+
+### references/ios17-observable.md
+iOS 17+ @Observableマクロへの移行ガイド：
+- **移行パターン**: ObservableObject → @Observable
+- **@Bindable**: @Published/@Bindingの代替
+- **@Environment変更**: 環境値の新しい渡し方
+- **パフォーマンス向上**: プロパティ単位の監視
+- **注意点**: 互換性、既存コードとの共存
+
+### references/swift6-concurrency.md
+Swift 6並行処理対応ガイド：
+- **@MainActor**: ViewModel全体への適用、UI保護
+- **Sendable**: データモデル設計、アクター境界
+- **移行チェックリスト**: Strict Concurrency Checking有効化
+- **よくある警告と解決策**:
+  - "Non-sendable type captured"
+  - "Actor-isolated property cannot be mutated"
+- **Actor**: カスタムActorでスレッドセーフ保証
+
+### references/swift62-changes.md
+Swift 6.2 / Xcode 26 移行ガイド：
+- **Approachable Concurrency**: より使いやすい並行処理
+- **Default Actor Isolation**: MainActorをデフォルトに
+- **@concurrent**: 明示的なバックグラウンド実行
+- **Xcode 26新機能**: AI Coding Tools、Playground強化
+- **デバッグ改善**: LLDB強化、並行処理デバッグ
+
+### references/ipados26-windowing.md
+iPadOS 26 ウィンドウシステム移行ガイド：
+- **UIRequiresFullScreen廃止**: Info.plistからの削除、Auto Layout対応
+- **シーンジオメトリ**: UIWindowScene.Geometry、effectiveGeometry、リサイズ検知
+- **サイズ制限**: UISceneSizeRestrictions、minimumSize/maximumSize設定
+- **方向ロック**: prefersInterfaceOrientationLocked、方向変更監視
+- **メニューバー対応**: SwiftUI Commands、UIMenuBuilder、キーボードショートカット
+- **マルチウィンドウ**: UIApplicationSupportsMultipleScenes、新規ウィンドウ作成
+- **Trait Collection**: サイズクラス対応、自動トラッキング
+
+## 使用方法
+
+### iOS 17 @Observable移行時
+1. `references/ios17-observable.md`で移行パターン確認
+2. 新規コードから`@Observable`を使用開始
+3. 既存の小さなViewModelから段階的に移行
+4. 大きなViewModelは慎重に移行
+
+### Swift 6移行時
+1. `references/swift6-concurrency.md`でチェックリスト確認
+2. Strict Concurrency Checkingを有効化
+3. ViewModelに`@MainActor`を追加
+4. データモデルを`Sendable`に対応
+5. 警告を順次解消
+
+### Swift 6.2移行時
+1. `references/swift62-changes.md`で新機能確認
+2. Xcode 26にアップデート
+3. Approachable Concurrencyを有効化
+4. Default Actor IsolationをMainActorに設定
+5. 必要な箇所に`@concurrent`を追加
+6. 既存のSwift 6コードを簡略化
+
+### iPadOS 26ウィンドウシステム対応時
+1. `references/ipados26-windowing.md`で移行チェックリスト確認
+2. `UIRequiresFullScreen`をInfo.plistから削除
+3. Auto Layoutでサイズ適応レイアウトを実装
+4. `UISceneSizeRestrictions`で最小サイズを設定
+5. メニューバー対応（外部キーボード使用時）
+
+## 移行優先順位
+
+### Swift 6.2（推奨順）
+1. Build SettingsでApproachable Concurrencyを有効化
+2. Default Actor IsolationをMainActorに設定
+3. 必要な箇所に`@concurrent`を追加
+4. 既存のSwift 6コードを簡略化
+
+### Swift 6（推奨順）
+1. ViewModelに`@MainActor`を追加
+2. データモデルを`Sendable`に対応
+3. 非同期処理を`async/await`に統一
+
+### iOS 17 @Observable（推奨順）
+1. 新規コードから`@Observable`を使用
+2. 既存の小さなViewModelから移行
+3. 大きなViewModelは慎重に移行
+
+### iPadOS 26（推奨順）
+1. Xcode 26でビルド・テスト
+2. UIRequiresFullScreenを削除
+3. Auto Layout対応を確認
+4. メニューバー実装
+
+## バージョン対応表
+
+| 機能 | Swift 5.9 | Swift 6 | Swift 6.2 |
+|------|-----------|---------|-----------|
+| Strict Concurrency | Opt-in | Default | Default |
+| @MainActor | ✅ | ✅ | ✅ |
+| Default Actor Isolation | - | - | ✅ |
+| @concurrent | - | - | ✅ |
+| Approachable Concurrency | - | - | ✅ |
+
+| 機能 | iOS 16 | iOS 17 | iOS 18 | iOS 26 |
+|------|--------|--------|--------|--------|
+| @Observable | - | ✅ | ✅ | ✅ |
+| iPadOS新ウィンドウシステム | - | - | - | ✅ |
+
+## 関連スキル
+
+- **swiftui-components**: UIコンポーネントカタログ
+- **swiftui-coding-guidelines**: 基本的なベストプラクティス
+- **swiftui-ssot**: 状態管理の設計
+- **swiftui-accessibility**: アクセシビリティ実装
+

--- a/ios_development/skills/swift-ios-migration/references/ios17-observable.md
+++ b/ios_development/skills/swift-ios-migration/references/ios17-observable.md
@@ -1,0 +1,248 @@
+# iOS 17+ @Observable マクロガイド
+
+## 概要
+
+iOS 17で導入された`@Observable`マクロは、SwiftUIの状態管理を大幅に簡素化し、パフォーマンスを向上させる。
+
+## 移行パターン
+
+### 基本的な変更
+
+| iOS 13-16 | iOS 17+ |
+|-----------|---------|
+| `ObservableObject` + `@Published` | `@Observable`（`@Published`不要） |
+| `@StateObject` | `@State` |
+| `@ObservedObject` | ラッパー不要（直接渡す） |
+| `@EnvironmentObject` | `@Environment(MyType.self)` |
+
+### Before: ObservableObject（iOS 13-16）
+
+```swift
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        // ...
+    }
+}
+
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleViewModel()
+    
+    var body: some View {
+        ChildView(viewModel: viewModel)
+    }
+}
+
+struct ChildView: View {
+    @ObservedObject var viewModel: ArticleViewModel
+    // ...
+}
+```
+
+### After: @Observable（iOS 17+）
+
+```swift
+@Observable
+class ArticleViewModel {
+    var articles: [Article] = []
+    var isLoading = false
+    var errorMessage: String?
+    
+    func fetch() async {
+        isLoading = true
+        defer { isLoading = false }
+        // ...
+    }
+}
+
+struct ArticleListView: View {
+    @State private var viewModel = ArticleViewModel()
+    
+    var body: some View {
+        ChildView(viewModel: viewModel)
+    }
+}
+
+struct ChildView: View {
+    var viewModel: ArticleViewModel // ラッパー不要
+    // ...
+}
+```
+
+## @Bindableの使用
+
+子ビューで双方向バインディングが必要な場合は`@Bindable`を使用。
+
+```swift
+@Observable
+class FormData {
+    var name = ""
+    var email = ""
+}
+
+struct FormView: View {
+    @State private var formData = FormData()
+    
+    var body: some View {
+        FormContent(formData: formData)
+    }
+}
+
+struct FormContent: View {
+    @Bindable var formData: FormData
+    
+    var body: some View {
+        Form {
+            TextField("Name", text: $formData.name)
+            TextField("Email", text: $formData.email)
+        }
+    }
+}
+```
+
+## Environment経由の注入
+
+```swift
+// iOS 13-16
+struct ContentView: View {
+    @EnvironmentObject var settings: AppSettings
+}
+
+// iOS 17+
+@Observable
+class AppSettings {
+    var theme: Theme = .light
+}
+
+struct ContentView: View {
+    @Environment(AppSettings.self) var settings
+    
+    var body: some View {
+        // 双方向バインディングが必要な場合
+        @Bindable var settings = settings
+        Toggle("Dark Mode", isOn: $settings.isDarkMode)
+    }
+}
+
+// 注入
+ContentView()
+    .environment(AppSettings())
+```
+
+## パフォーマンス向上
+
+### 選択的な監視
+
+`@Observable`は使用されるプロパティのみを監視し、不要な再描画を防止。
+
+```swift
+@Observable
+class ViewModel {
+    var name = ""      // NameViewのみが監視
+    var count = 0      // CountViewのみが監視
+    var items: [Item] = []  // ItemsViewのみが監視
+}
+
+struct NameView: View {
+    var viewModel: ViewModel
+    
+    var body: some View {
+        // nameが変更された時のみ再描画
+        // countやitemsの変更では再描画されない
+        Text(viewModel.name)
+    }
+}
+
+struct CountView: View {
+    var viewModel: ViewModel
+    
+    var body: some View {
+        // countが変更された時のみ再描画
+        Text("\(viewModel.count)")
+    }
+}
+```
+
+### ObservableObjectとの比較
+
+```swift
+// ObservableObject: すべての@Publishedプロパティの変更で全ビューが再描画
+class OldViewModel: ObservableObject {
+    @Published var name = ""
+    @Published var count = 0
+}
+
+// @Observable: 使用しているプロパティの変更のみで再描画
+@Observable
+class NewViewModel {
+    var name = ""
+    var count = 0
+}
+```
+
+## 注意点
+
+### @State vs @StateObject の違い
+
+```swift
+// ⚠️ 注意: @Stateは@StateObjectと異なる動作をする可能性
+
+// @StateObject: ビュー再生成時も同じインスタンスを維持
+@StateObject private var viewModel = ViewModel()
+
+// @State with @Observable: 条件付きビューでは再初期化の可能性
+@State private var viewModel = ViewModel()
+```
+
+**Jesse Squiresの記事より**:
+- `@State`で`@Observable`オブジェクトを使用する場合、ビューの条件付き表示で予期しない再初期化が起こる可能性
+- 複雑なナビゲーションやモーダル表示では注意が必要
+
+### 監視の除外
+
+特定のプロパティを監視対象から除外する場合:
+
+```swift
+@Observable
+class ViewModel {
+    var trackedProperty = ""
+    
+    @ObservationIgnored
+    var ignoredProperty = ""  // 変更しても再描画されない
+}
+```
+
+## 移行チェックリスト
+
+1. [ ] `ObservableObject`を`@Observable`に変更
+2. [ ] `@Published`を削除
+3. [ ] `@StateObject`を`@State`に変更
+4. [ ] `@ObservedObject`を削除（直接渡す）
+5. [ ] `@EnvironmentObject`を`@Environment(Type.self)`に変更
+6. [ ] 双方向バインディングが必要な箇所に`@Bindable`を追加
+7. [ ] `@ObservationIgnored`で監視不要なプロパティをマーク
+8. [ ] 条件付きビューでの状態維持を確認
+
+## 後方互換性
+
+iOS 17未満をサポートする場合:
+
+```swift
+#if swift(>=5.9)
+@Observable
+class ViewModel {
+    var items: [Item] = []
+}
+#else
+class ViewModel: ObservableObject {
+    @Published var items: [Item] = []
+}
+#endif
+```
+
+または、iOS 17+のみで`@Observable`を使用し、iOS 16以下では従来のパターンを維持。

--- a/ios_development/skills/swift-ios-migration/references/ipados26-windowing.md
+++ b/ios_development/skills/swift-ios-migration/references/ipados26-windowing.md
@@ -1,0 +1,475 @@
+# iPadOS 26 ウィンドウシステム
+
+iPadOS 26では、iPadが本格的なウィンドウシステムを採用し、macOSに近いマルチタスク体験を提供するようになりました。このドキュメントでは、新しいウィンドウシステムへの対応方法を解説します。
+
+## 主要な変更点
+
+### UIRequiresFullScreen の廃止
+
+iPadOS 26より、`UIRequiresFullScreen` Info.plistキーとその関連する互換モードは非推奨となり、将来のリリースで無視されるようになります。
+
+**重要**: このキーに依存しているアプリは、システムがマルチタスクシナリオに対応するためにシーンをリサイズする際に、以下の問題が発生する可能性があります：
+- レイアウトの崩れ
+- UI要素の位置ずれ  
+- コンテンツの切り詰め
+
+### 新しいウィンドウモード
+
+iPadOS 26では、より柔軟なウィンドウ管理が可能になりました：
+- 自由なウィンドウサイズ変更
+- 複数ウィンドウの重なり表示
+- すべてのiPadモデルでStage Managerが利用可能
+- メニューバーのサポート強化
+
+---
+
+## 移行手順
+
+### 1. UIRequiresFullScreen の削除
+
+リサイズ可能なシーンをサポートするために、アプリが以下の条件を満たすことを確認してください：
+
+1. **Launch Storyboardの提供** - Info.plistで起動画面を指定
+2. **すべてのサイズクラスのサポート** - Compact/Regularの両方に対応
+3. **UIRequiresFullScreen キーの削除** - Info.plistまたはビルド設定から削除
+
+```xml
+<!-- 削除すべきエントリ -->
+<key>UIRequiresFullScreen</key>
+<true/>
+```
+
+### 2. Auto Layoutへの移行
+
+固定サイズのレイアウトから、制約ベースのレイアウトに移行してください。
+
+```swift
+// ❌ 避けるべき: 固定フレーム
+view.frame = CGRect(x: 0, y: 0, width: 1024, height: 768)
+
+// ✅ 推奨: Auto Layout制約
+NSLayoutConstraint.activate([
+    contentView.leadingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leadingAnchor),
+    contentView.trailingAnchor.constraint(equalTo: view.safeAreaLayoutGuide.trailingAnchor),
+    contentView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+    contentView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor)
+])
+```
+
+---
+
+## シーンジオメトリの監視
+
+### UIWindowSceneDelegate でのジオメトリ変更検知
+
+`windowScene(_:didUpdateEffectiveGeometry:)` を使用して、シーンのジオメトリ変更を監視します。
+
+```swift
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    var previousSceneSize = CGSize.zero
+    
+    func windowScene(
+        _ windowScene: UIWindowScene,
+        didUpdateEffectiveGeometry previousGeometry: UIWindowScene.Geometry
+    ) {
+        let geometry = windowScene.effectiveGeometry
+        let sceneSize = geometry.coordinateSpace.bounds.size
+        
+        // インタラクティブリサイズ中かどうかを確認
+        if !geometry.isInteractivelyResizing && sceneSize != previousSceneSize {
+            previousSceneSize = sceneSize
+            // リサイズ完了後の処理
+            updateLayoutForSize(sceneSize)
+        }
+    }
+    
+    private func updateLayoutForSize(_ size: CGSize) {
+        // レイアウト更新処理
+    }
+}
+```
+
+### UIWindowScene.Geometry プロパティ
+
+| プロパティ | 型 | 説明 |
+|-----------|-----|------|
+| `systemFrame` | `CGRect` | システム座標でのシーンフレーム |
+| `coordinateSpace` | `UICoordinateSpace` | シーンの座標空間 |
+| `interfaceOrientation` | `UIInterfaceOrientation` | 現在のインターフェース方向 |
+| `isInterfaceOrientationLocked` | `Bool` | 方向がロックされているか |
+| `isInteractivelyResizing` | `Bool` | リサイズ操作中かどうか |
+| `minimumSize` | `CGSize` | 最小サイズ |
+| `maximumSize` | `CGSize` | 最大サイズ |
+| `resizingRestrictions` | `UIWindowSceneResizingRestrictions` | リサイズ制限 |
+
+---
+
+## シーンサイズ制限の設定
+
+### UISceneSizeRestrictions
+
+`UISceneSizeRestrictions` を使用して、ウィンドウの最小・最大サイズを指定します。
+
+```swift
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+    
+    func scene(
+        _ scene: UIScene,
+        willConnectTo session: UISceneSession,
+        options connectionOptions: UIScene.ConnectionOptions
+    ) {
+        guard let windowScene = scene as? UIWindowScene else { return }
+        
+        // 最小サイズの設定
+        windowScene.sizeRestrictions?.minimumSize = CGSize(width: 500, height: 400)
+        
+        // 最大サイズの設定（オプション）
+        windowScene.sizeRestrictions?.maximumSize = CGSize(width: 1200, height: 900)
+        
+        // フルスクリーン許可の設定
+        windowScene.sizeRestrictions?.allowsFullScreen = true
+    }
+}
+```
+
+### SwiftUI での設定
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .frame(minWidth: 500, maxWidth: 1200, 
+                       minHeight: 400, maxHeight: 900)
+        }
+        .windowResizability(.contentMinSize)
+    }
+}
+```
+
+#### windowResizability オプション
+
+| 値 | 説明 |
+|----|------|
+| `.automatic` | システムが自動的に決定 |
+| `.contentSize` | コンテンツサイズに基づく |
+| `.contentMinSize` | コンテンツの最小サイズを使用 |
+
+---
+
+## インターフェース方向のロック
+
+特定の状況で方向をロックする必要がある場合（例：ゲーム、カメラアプリ）：
+
+```swift
+class MyViewController: UIViewController {
+    
+    var isDriving: Bool = false {
+        didSet {
+            if isDriving != oldValue {
+                setNeedsUpdateOfPrefersInterfaceOrientationLocked()
+            }
+        }
+    }
+    
+    override var prefersInterfaceOrientationLocked: Bool {
+        return isDriving
+    }
+}
+```
+
+### 方向ロック状態の監視
+
+```swift
+func windowScene(
+    _ windowScene: UIWindowScene,
+    didUpdateEffectiveGeometry previousGeometry: UIWindowScene.Geometry
+) {
+    let wasLocked = previousGeometry.isInterfaceOrientationLocked
+    let isLocked = windowScene.effectiveGeometry.isInterfaceOrientationLocked
+    
+    if wasLocked != isLocked {
+        // 方向ロック状態が変化した
+        handleOrientationLockChange(isLocked: isLocked)
+    }
+}
+```
+
+---
+
+## SwiftUI でのリサイズ対応
+
+### onInteractiveResizeChange
+
+```swift
+struct ContentView: View {
+    @State private var isResizing = false
+    
+    var body: some View {
+        GeometryReader { geometry in
+            MainContent(size: geometry.size)
+                .overlay {
+                    if isResizing {
+                        ResizeOverlay()
+                    }
+                }
+        }
+        .onInteractiveResizeChange { isResizing in
+            self.isResizing = isResizing
+        }
+    }
+}
+```
+
+### GeometryReader でのサイズ適応
+
+```swift
+struct AdaptiveLayout: View {
+    var body: some View {
+        GeometryReader { geometry in
+            if geometry.size.width > 600 {
+                HStack {
+                    Sidebar()
+                    MainContent()
+                }
+            } else {
+                VStack {
+                    MainContent()
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## メニューバー対応
+
+iPadOS 26では、外部キーボード接続時にメニューバーが表示されるようになりました。
+
+### SwiftUI でのメニューバー構築
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+        .commands {
+            // サイドバーコマンド
+            SidebarCommands()
+            
+            // カスタムメニュー
+            CommandMenu("Actions") {
+                Button("Run", systemImage: "play.fill") {
+                    // アクション
+                }
+                .keyboardShortcut("R")
+                
+                Button("Stop", systemImage: "stop.fill") {
+                    // アクション
+                }
+                .keyboardShortcut(".")
+            }
+            
+            // 既存メニューの拡張
+            CommandGroup(after: .newItem) {
+                Button("New from Template...") {
+                    // アクション
+                }
+            }
+        }
+    }
+}
+```
+
+### UIKit でのメニュー構築
+
+```swift
+class AppDelegate: UIResponder, UIApplicationDelegate {
+    
+    override func buildMenu(with builder: UIMenuBuilder) {
+        super.buildMenu(with: builder)
+        
+        guard builder.system == .main else { return }
+        
+        // カスタムメニューの追加
+        let actionsMenu = UIMenu(
+            title: "Actions",
+            children: [
+                UIKeyCommand(
+                    title: "Run",
+                    action: #selector(runAction),
+                    input: "R",
+                    modifierFlags: .command
+                ),
+                UIKeyCommand(
+                    title: "Stop",
+                    action: #selector(stopAction),
+                    input: ".",
+                    modifierFlags: .command
+                )
+            ]
+        )
+        
+        builder.insertSibling(actionsMenu, afterMenu: .view)
+    }
+    
+    @objc func runAction() { }
+    @objc func stopAction() { }
+}
+```
+
+---
+
+## マルチウィンドウ対応
+
+### 複数シーンのサポート有効化
+
+Info.plist で `UIApplicationSupportsMultipleScenes` を `true` に設定：
+
+```xml
+<key>UIApplicationSceneManifest</key>
+<dict>
+    <key>UIApplicationSupportsMultipleScenes</key>
+    <true/>
+    <key>UISceneConfigurations</key>
+    <dict>
+        <key>UIWindowSceneSessionRoleApplication</key>
+        <array>
+            <dict>
+                <key>UISceneConfigurationName</key>
+                <string>Default Configuration</string>
+                <key>UISceneDelegateClassName</key>
+                <string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+            </dict>
+        </array>
+    </dict>
+</dict>
+```
+
+### 新規ウィンドウの作成
+
+```swift
+// UIKit
+func createNewWindow() {
+    let activity = NSUserActivity(activityType: "com.example.newWindow")
+    
+    UIApplication.shared.requestSceneSessionActivation(
+        nil,
+        userActivity: activity,
+        options: nil
+    )
+}
+
+// SwiftUI
+@Environment(\.openWindow) private var openWindow
+
+Button("New Window") {
+    openWindow(id: "secondary")
+}
+```
+
+---
+
+## Trait Collection による適応
+
+### 自動トラッキング
+
+iOS 17以降では、トレイトの自動トラッキングが利用可能です：
+
+```swift
+class MyViewController: UIViewController {
+    
+    override func viewWillLayoutSubviews() {
+        super.viewWillLayoutSubviews()
+        
+        // 自動的にトレイトの変更を検知
+        updateLayoutForTraits()
+    }
+    
+    private func updateLayoutForTraits() {
+        let horizontalClass = traitCollection.horizontalSizeClass
+        let verticalClass = traitCollection.verticalSizeClass
+        
+        switch (horizontalClass, verticalClass) {
+        case (.compact, .regular):
+            // iPhone縦向き / iPad Split View狭幅
+            configureCompactLayout()
+        case (.regular, .regular):
+            // iPad全画面 / iPad Split View広幅
+            configureRegularLayout()
+        default:
+            configureDefaultLayout()
+        }
+    }
+}
+```
+
+### トレイト変更の手動登録
+
+```swift
+override func viewDidLoad() {
+    super.viewDidLoad()
+    
+    registerForTraitChanges([
+        UITraitHorizontalSizeClass.self,
+        UITraitVerticalSizeClass.self
+    ]) { (self: Self, previousTraitCollection) in
+        self.updateLayoutForTraits()
+    }
+}
+```
+
+---
+
+## 移行チェックリスト
+
+### 必須対応
+
+- [ ] `UIRequiresFullScreen` をInfo.plistから削除
+- [ ] Launch Storyboardを設定
+- [ ] すべてのサイズクラスでのレイアウトをテスト
+- [ ] Auto Layoutまたはサイズ適応レイアウトを使用
+
+### 推奨対応
+
+- [ ] `windowScene(_:didUpdateEffectiveGeometry:)` でジオメトリ変更を監視
+- [ ] `UISceneSizeRestrictions` で適切な最小サイズを設定
+- [ ] メニューバー対応（外部キーボード使用時）
+- [ ] マルチウィンドウシナリオのテスト
+
+### テスト項目
+
+- [ ] Split View（50/50、75/25、25/75）
+- [ ] Slide Over
+- [ ] Stage Manager（対応デバイス）
+- [ ] 外部ディスプレイ接続
+- [ ] 画面回転
+- [ ] フルスクリーン⇔ウィンドウ切り替え
+
+---
+
+## 関連リソース
+
+### Apple ドキュメント
+
+- [TN3192: Migrating your iPad app from the deprecated UIRequiresFullScreen key](https://developer.apple.com/documentation/technotes/tn3192-migrating-your-app-from-the-deprecated-uirequiresfullscreen-key/)
+- [Multitasking on iPad, Mac, and Apple Vision Pro](https://developer.apple.com/documentation/uikit/multitasking-on-ipad-mac-and-apple-vision-pro/)
+- [Supporting multiple windows on iPad](https://developer.apple.com/documentation/uikit/supporting-multiple-windows-on-ipad/)
+- [UIWindowScene.Geometry](https://developer.apple.com/documentation/uikit/uiwindowscene/geometry/)
+- [UISceneSizeRestrictions](https://developer.apple.com/documentation/uikit/uiscenesizerestrictions/)
+- [Building and customizing the menu bar with SwiftUI](https://developer.apple.com/documentation/swiftui/building-and-customizing-the-menu-bar-with-swiftui/)
+
+### WWDC25 セッション
+
+- [WWDC25 Session 282: UIKit scenes and container view controllers](https://developer.apple.com/videos/play/wwdc2025/282/) - シーンとコンテナビューコントローラの活用
+- [WWDC25 Session 284: Updating UIKit apps for the new design](https://developer.apple.com/videos/play/wwdc2025/284/) - UIKitアプリの新デザイン対応
+
+### Human Interface Guidelines
+
+- [Multitasking](https://developer.apple.com/design/human-interface-guidelines/multitasking/)
+- [The menu bar](https://developer.apple.com/design/human-interface-guidelines/the-menu-bar/)

--- a/ios_development/skills/swift-ios-migration/references/swift6-concurrency.md
+++ b/ios_development/skills/swift-ios-migration/references/swift6-concurrency.md
@@ -1,0 +1,362 @@
+# Swift 6 並行処理対応ガイド
+
+Swift 6では並行処理の安全性（Data Race Safety）がコンパイラによって厳密に保証される。SwiftUIアプリの設計に直接的な影響を与える。
+
+## @MainActor によるUI保護
+
+### ViewModelへの適用（推奨パターン）
+
+```swift
+// ✅ 推奨: ViewModel全体に@MainActorを付与
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    @Published var error: Error?
+    
+    private let service: ArticleServiceProtocol
+    
+    init(service: ArticleServiceProtocol = ArticleService()) {
+        self.service = service
+    }
+    
+    func fetchArticles() async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            // バックグラウンドで実行されるが、
+            // 結果の代入は自動的にメインスレッドで行われる
+            articles = try await service.fetch()
+        } catch {
+            self.error = error
+        }
+    }
+}
+```
+
+**メリット**:
+- プロパティ更新が自動的にメインスレッドで実行
+- `DispatchQueue.main.async` が不要
+- コンパイラが安全性を保証
+
+### iOS 17+ @Observable での適用
+
+```swift
+@MainActor
+@Observable
+class ArticleListViewModel {
+    var articles: [Article] = []
+    var isLoading = false
+    var error: Error?
+    
+    func fetchArticles() async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            articles = try await service.fetch()
+        } catch {
+            self.error = error
+        }
+    }
+}
+```
+
+### 部分的な@MainActor適用
+
+特定のメソッドのみUIに関連する場合：
+
+```swift
+class DataProcessor {
+    private var cache: [String: Data] = [:]
+    
+    // バックグラウンドで実行可能
+    func processData(_ input: Data) async -> ProcessedData {
+        // 重い処理
+        await heavyComputation(input)
+    }
+    
+    // UI更新を伴うメソッドのみ@MainActor
+    @MainActor
+    func updateUI(with result: ProcessedData) {
+        // UI更新処理
+    }
+}
+```
+
+## Sendable プロトコル
+
+### アクター境界を超えるデータ
+
+```swift
+// ✅ 値型（Struct）は自動的にSendable
+struct Article: Sendable, Identifiable {
+    let id: UUID
+    let title: String
+    let content: String
+    let publishedAt: Date
+}
+
+// ✅ Enumも自動的にSendable
+enum LoadingState: Sendable {
+    case idle
+    case loading
+    case loaded([Article])
+    case error(Error)  // ErrorはSendableではないので注意
+}
+
+// ⚠️ Errorを含む場合
+enum LoadingState<T: Sendable>: Sendable {
+    case idle
+    case loading
+    case loaded(T)
+    case error(String)  // Errorの代わりにStringを使用
+}
+```
+
+### クラスをSendableにする
+
+```swift
+// 方法1: finalクラス + 不変プロパティ
+final class ImmutableConfig: Sendable {
+    let apiKey: String
+    let baseURL: URL
+    
+    init(apiKey: String, baseURL: URL) {
+        self.apiKey = apiKey
+        self.baseURL = baseURL
+    }
+}
+
+// 方法2: @unchecked Sendable（手動で安全性を保証）
+final class ThreadSafeCache: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage: [String: Data] = [:]
+    
+    func get(_ key: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage[key]
+    }
+    
+    func set(_ key: String, value: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        storage[key] = value
+    }
+}
+```
+
+**⚠️ `@unchecked Sendable` は慎重に使用**
+- コンパイラのチェックを無効化
+- 手動でスレッドセーフティを保証する責任
+
+## 非同期タスクのパターン
+
+### View内でのTask使用
+
+```swift
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+    
+    var body: some View {
+        List(viewModel.articles) { article in
+            ArticleRow(article: article)
+        }
+        .task {
+            // ViewModelが@MainActorなら安全
+            await viewModel.fetchArticles()
+        }
+        .refreshable {
+            await viewModel.fetchArticles()
+        }
+    }
+}
+```
+
+### 明示的なアクター切り替え
+
+```swift
+@MainActor
+class ViewModel: ObservableObject {
+    @Published var result: String = ""
+    
+    func process() async {
+        // メインアクターから離脱してバックグラウンドで実行
+        let processed = await Task.detached(priority: .userInitiated) {
+            await self.heavyComputation()
+        }.value
+        
+        // 自動的にメインアクターに戻る（ViewModelが@MainActorのため）
+        result = processed
+    }
+    
+    // nonisolatedでメインアクター外で実行可能に
+    nonisolated func heavyComputation() async -> String {
+        // CPU集約的な処理
+        return "result"
+    }
+}
+```
+
+## Swift 6移行チェックリスト
+
+### 1. Strict Concurrency Checkingを有効化
+
+Build Settings → Swift Compiler - Upcoming Features → `Strict Concurrency Checking` を `Complete` に設定
+
+### 2. ViewModel
+
+- [ ] `@MainActor` を付与
+- [ ] `@Published` プロパティの更新がメインスレッドで行われることを確認
+- [ ] 非同期メソッドが適切に `async` マークされている
+
+### 3. データモデル
+
+- [ ] 値型（Struct/Enum）を優先使用
+- [ ] `Sendable` 準拠を確認
+- [ ] アクター境界を超えるデータの安全性確認
+
+### 4. サービス/リポジトリ層
+
+- [ ] API通信などは `async` 関数として実装
+- [ ] 結果型は `Sendable` 準拠
+
+### 5. 警告の解消
+
+```swift
+// ⚠️ 警告: Capture of 'self' with non-sendable type
+Task {
+    await self.doSomething()  // 警告
+}
+
+// ✅ 解決: @MainActorを付与するか、Sendable準拠
+@MainActor
+class ViewModel: ObservableObject {
+    func start() {
+        Task {
+            await self.doSomething()  // OK
+        }
+    }
+}
+```
+
+## よくある警告と解決策
+
+### 1. "Non-sendable type captured"
+
+```swift
+// ❌ 警告
+class MyClass {
+    func process() {
+        Task {
+            print(self)  // Non-sendable type captured
+        }
+    }
+}
+
+// ✅ 解決策1: @MainActorを付与
+@MainActor
+class MyClass { ... }
+
+// ✅ 解決策2: Sendable準拠
+final class MyClass: Sendable { ... }
+
+// ✅ 解決策3: 必要な値だけキャプチャ
+class MyClass {
+    let id: String
+    
+    func process() {
+        let id = self.id  // Sendableな値をキャプチャ
+        Task {
+            print(id)
+        }
+    }
+}
+```
+
+### 2. "Actor-isolated property cannot be mutated"
+
+```swift
+// ❌ エラー
+class ViewModel: ObservableObject {
+    @Published var data: String = ""
+    
+    func update() async {
+        data = await fetchData()  // エラー: メインアクター外から更新
+    }
+}
+
+// ✅ 解決: @MainActorを付与
+@MainActor
+class ViewModel: ObservableObject {
+    @Published var data: String = ""
+    
+    func update() async {
+        data = await fetchData()  // OK
+    }
+}
+```
+
+### 3. "Call to main actor-isolated method in a synchronous context"
+
+```swift
+// ❌ エラー
+@MainActor
+class ViewModel {
+    func doUIWork() { }
+}
+
+func somewhere() {
+    let vm = ViewModel()
+    vm.doUIWork()  // エラー
+}
+
+// ✅ 解決: asyncコンテキストで呼び出し
+func somewhere() async {
+    let vm = await ViewModel()
+    await vm.doUIWork()
+}
+```
+
+## Actor の活用
+
+### カスタムActorでスレッドセーフを保証
+
+```swift
+actor ImageCache {
+    private var cache: [URL: UIImage] = [:]
+    
+    func image(for url: URL) -> UIImage? {
+        cache[url]
+    }
+    
+    func setImage(_ image: UIImage, for url: URL) {
+        cache[url] = image
+    }
+    
+    func clearCache() {
+        cache.removeAll()
+    }
+}
+
+// 使用
+class ImageLoader {
+    private let cache = ImageCache()
+    
+    func loadImage(from url: URL) async -> UIImage? {
+        // actorのメソッドはawaitが必要
+        if let cached = await cache.image(for: url) {
+            return cached
+        }
+        
+        guard let image = await downloadImage(from: url) else {
+            return nil
+        }
+        
+        await cache.setImage(image, for: url)
+        return image
+    }
+}
+```

--- a/ios_development/skills/swift-ios-migration/references/swift62-changes.md
+++ b/ios_development/skills/swift-ios-migration/references/swift62-changes.md
@@ -1,0 +1,228 @@
+# Swift 6.2 / Xcode 26 移行ガイド
+
+## 概要
+
+Swift 6.2（Xcode 26同梱）では「Approachable Concurrency」が導入され、Swift 6の厳格な並行処理チェックをより使いやすくする機能が追加された。
+
+---
+
+## Approachable Concurrency
+
+### 背景
+
+Swift 6のStrict Concurrencyは安全だが、多くのボイラープレートと急な学習曲線が問題だった。Swift 6.2では以下のアプローチで解決：
+
+1. **シングルスレッドコードから開始** - デフォルトでMainActorに分離
+2. **必要に応じて並行処理を導入** - 明示的にオプトイン
+3. **`@concurrent`で明示的にバックグラウンド実行**
+
+---
+
+## デフォルトアクター分離
+
+### Build Settings設定
+
+```
+// Xcode 26 Build Settings
+Swift Compiler - Upcoming Features:
+  - Approachable Concurrency: Yes
+  - Default Actor Isolation: MainActor
+```
+
+### 効果
+
+```swift
+// Swift 6.2 + Default Actor Isolation = MainActor
+
+// @MainActorを明示的に書く必要がない
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+
+    // 暗黙的に@MainActor
+    func refresh() async {
+        articles = await fetchArticles()
+    }
+}
+```
+
+### 従来のSwift 6との比較
+
+```swift
+// Swift 6: 明示的な@MainActorが必要
+@MainActor
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+
+    func refresh() async {
+        articles = await fetchArticles()
+    }
+}
+
+// Swift 6.2: Default Actor IsolationがMainActorなら省略可能
+class ArticleViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+
+    func refresh() async {
+        articles = await fetchArticles()
+    }
+}
+```
+
+---
+
+## @concurrent
+
+バックグラウンドで実行したい関数に明示的にマーク。
+
+### 基本的な使用法
+
+```swift
+// バックグラウンドで実行
+@concurrent
+func processData(_ data: Data) async -> ProcessedData {
+    // 重い処理
+    return heavyComputation(data)
+}
+
+// 呼び出し側
+func updateUI() async {
+    let result = await processData(rawData)
+    // 結果はMainActorに自動的に戻る（Default Actor IsolationがMainActorの場合）
+    displayResult(result)
+}
+```
+
+### ユースケース
+
+```swift
+class ImageProcessor {
+    // 画像処理はバックグラウンドで実行
+    @concurrent
+    func processImage(_ image: UIImage) async -> UIImage {
+        // フィルター適用、リサイズなど
+    }
+
+    // UI更新はMainActorで（デフォルト）
+    func applyFilter() async {
+        let processed = await processImage(originalImage)
+        self.displayedImage = processed  // MainActorで実行
+    }
+}
+```
+
+---
+
+## 移行チェックリスト
+
+### Swift 6 → Swift 6.2
+
+1. [ ] Xcode 26にアップデート
+2. [ ] Build SettingsでApproachable Concurrencyを有効化
+3. [ ] Default Actor IsolationをMainActorに設定
+4. [ ] 既存の`@MainActor`を確認（削除可能な場合あり）
+5. [ ] バックグラウンド処理が必要な関数に`@concurrent`を追加
+6. [ ] 既存のSwift 6コードをレビュー・簡略化
+
+### 新規プロジェクト
+
+1. [ ] Xcode 26で新規プロジェクト作成
+2. [ ] Approachable Concurrencyがデフォルトで有効
+3. [ ] 必要に応じて`@concurrent`を使用
+
+---
+
+## Xcode 26 新機能
+
+### AI Coding Tools
+
+- **ChatGPT統合**: Xcode内でChatGPTを直接使用
+- **サードパーティLLM対応**: APIキーで他のLLMも利用可能
+- **ローカルモデル実行**: オンデバイスでのAI処理
+- **コード生成・バグ修正・ドキュメント生成**
+
+### Playground強化
+
+- **インラインPlayground**: 通常プロジェクト内にPlaygroundコードブロックを埋め込み
+- **ライブインタラクション**: Previewのような即時フィードバック
+- **APIテストとデモ作成に最適**
+
+### パフォーマンス改善
+
+- **プロジェクト読み込み40%高速化**
+- **モジュラー設計**: 必要な部分のみダウンロード
+- **Voice Control改善**: Swiftコードのディクテーション精度向上
+
+---
+
+## デバッグ改善
+
+### LLDB強化
+
+- 非同期関数内でスレッド切り替え後も実行継続
+- コンパイルモジュールの再利用で評価高速化
+
+### 並行処理デバッグ
+
+- アクター境界を超えるデータフローの可視化
+- デッドロック検出の改善
+
+---
+
+## その他のSwift 6.2新機能
+
+### Subprocess パッケージ
+
+スクリプティング用のプロセス実行API。
+
+```swift
+import Subprocess
+
+let result = try await Subprocess.run(
+    executing: .init(at: "/bin/ls"),
+    arguments: ["-la"]
+)
+print(result.standardOutput)
+```
+
+### Swift Testing強化
+
+- **カスタムアタッチメント**: テスト結果に追加データを添付
+- **Exit tests**: 終了コードの検証
+
+```swift
+@Test
+func testProcess() async throws {
+    await #expect(exitsWith: .success) {
+        // プロセス終了をテスト
+    }
+}
+```
+
+### 相互運用性の改善
+
+- C/C++/Objective-C/Java相互運用の改善
+- より多くの型の自動ブリッジング
+
+---
+
+## 互換性
+
+### 対応環境
+
+- Xcode 26以降
+- iOS 26 / iPadOS 26 / macOS 26 / watchOS 26 / tvOS 26 / visionOS 26
+- 下位バージョンへのデプロイも可能（ただし一部機能制限あり）
+
+### 既存コードとの互換性
+
+- Swift 6コードはそのまま動作
+- Approachable Concurrencyは段階的に採用可能
+- 既存の`@MainActor`は引き続き有効
+
+---
+
+## 関連ドキュメント
+
+- [What's new in Swift - WWDC25](https://developer.apple.com/videos/play/wwdc2025/245)
+- [Swift 6.2 Release Notes](https://swift.org/blog/)
+- [Xcode 26 Release Notes](https://developer.apple.com/documentation/xcode-release-notes/)

--- a/ios_development/skills/swiftui-accessibility/SKILL.md
+++ b/ios_development/skills/swiftui-accessibility/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: swiftui-accessibility
+description: Accessibility implementation guide for SwiftUI apps. Use when implementing VoiceOver support, adding accessibilityLabel/Hint/Value, supporting Dynamic Type, ensuring color contrast, testing accessibility, or reviewing accessibility in PRs. Covers iOS accessibility APIs, WCAG guidelines, and testing tools.
+---
+
+# SwiftUI Accessibility Guide
+
+SwiftUIアプリのアクセシビリティ実装ガイド。
+
+## ディレクトリ構成
+
+```
+swiftui-accessibility/
+├── SKILL.md (このファイル)
+└── references/
+    └── accessibility.md
+```
+
+## リファレンスファイル
+
+### references/accessibility.md
+アクセシビリティ実装ガイド：
+- **VoiceOver対応**:
+  - accessibilityLabel: 要素の説明
+  - accessibilityHint: 操作のヒント
+  - accessibilityValue: 現在の値
+  - accessibilityTraits: 要素の種類
+- **Dynamic Type**: 
+  - フォントスケーリング
+  - レイアウト対応
+- **色のコントラスト**:
+  - WCAG基準
+  - ダークモード対応
+- **モーション**:
+  - reduceMotion対応
+  - アニメーション代替
+- **テストとツール**:
+  - Accessibility Inspector
+  - VoiceOverテスト方法
+
+## 使用方法
+
+### アクセシビリティ実装時
+1. `references/accessibility.md`で実装パターンを確認
+2. VoiceOverでテスト
+3. Dynamic Typeでレイアウト確認
+
+### PRレビュー時
+1. アクセシビリティラベルの有無を確認
+2. 画像にaltテキストがあるか確認
+3. タップ領域が十分か確認
+
+## クイック実装ガイド
+
+### VoiceOver基本
+
+```swift
+// ラベル（必須）
+Image(systemName: "heart.fill")
+    .accessibilityLabel("お気に入り")
+
+// ヒント（操作説明）
+Button("削除") { }
+    .accessibilityHint("この項目を削除します")
+
+// 値（現在の状態）
+Slider(value: $volume)
+    .accessibilityValue("\(Int(volume))パーセント")
+```
+
+### Dynamic Type対応
+
+```swift
+// 推奨: システムフォント
+Text("Hello")
+    .font(.body)
+
+// カスタムフォントのスケーリング
+Text("Hello")
+    .font(.custom("MyFont", size: 16, relativeTo: .body))
+```
+
+### reduceMotion対応
+
+```swift
+@Environment(\.accessibilityReduceMotion) var reduceMotion
+
+var body: some View {
+    content
+        .animation(reduceMotion ? nil : .default, value: isExpanded)
+}
+```
+
+## チェックリスト
+
+- [ ] 全てのインタラクティブ要素にaccessibilityLabelがあるか
+- [ ] 画像に適切な説明があるか
+- [ ] Dynamic Typeでレイアウトが崩れないか
+- [ ] 色だけに依存した情報伝達がないか
+- [ ] タップ領域は44pt以上あるか
+
+## 関連スキル
+
+- **swiftui-coding-guidelines**: 基本的なベストプラクティス
+- **swiftui-code-review-checklist**: PRレビュー時のアクセシビリティチェック

--- a/ios_development/skills/swiftui-accessibility/references/accessibility.md
+++ b/ios_development/skills/swiftui-accessibility/references/accessibility.md
@@ -1,0 +1,304 @@
+# SwiftUI アクセシビリティガイド
+
+## 主要なモディファイア
+
+### accessibilityLabel
+
+要素の説明ラベル。VoiceOverが読み上げる内容。
+
+```swift
+// 画像のみのボタンには必須
+Button(action: { }) {
+    Image(systemName: "heart.fill")
+}
+.accessibilityLabel("お気に入りに追加")
+
+// アイコン付きテキスト
+HStack {
+    Image(systemName: "star.fill")
+    Text("4.5")
+}
+.accessibilityElement(children: .combine)
+.accessibilityLabel("評価 4.5")
+```
+
+### accessibilityHint
+
+追加情報（アクション結果等）。ラベルの後に読み上げられる。
+
+```swift
+Button("削除") {
+    deleteItem()
+}
+.accessibilityLabel("アイテムを削除")
+.accessibilityHint("ダブルタップで削除します")
+```
+
+### accessibilityValue
+
+現在の値（スライダー、トグル、カスタムコントロール等）。
+
+```swift
+Slider(value: $volume, in: 0...100)
+    .accessibilityValue("\(Int(volume))パーセント")
+
+// カスタム進捗表示
+ProgressCircle(progress: 0.75)
+    .accessibilityLabel("ダウンロード進捗")
+    .accessibilityValue("75パーセント完了")
+```
+
+### accessibilityAddTraits
+
+要素の特性を追加。
+
+```swift
+// onTapGestureを使う場合はボタン特性を追加
+Text("タップしてください")
+    .onTapGesture { /* ... */ }
+    .accessibilityAddTraits(.isButton)
+
+// 見出しとしてマーク
+Text("設定")
+    .font(.title)
+    .accessibilityAddTraits(.isHeader)
+
+// 選択状態
+Text(item.title)
+    .accessibilityAddTraits(item.isSelected ? [.isSelected] : [])
+```
+
+主な特性:
+- `.isButton`: ボタンとして動作
+- `.isHeader`: 見出し（ナビゲーションで使用）
+- `.isSelected`: 選択中
+- `.isImage`: 画像
+- `.playsSound`: 音を再生
+- `.isModal`: モーダル
+- `.updatesFrequently`: 頻繁に更新
+
+### accessibilityElement
+
+複数要素のグループ化。
+
+```swift
+// 複数要素を1つにまとめる
+HStack {
+    Image("avatar")
+    VStack(alignment: .leading) {
+        Text("山田太郎")
+        Text("エンジニア")
+    }
+}
+.accessibilityElement(children: .combine)
+
+// 子要素を無視
+DecorativeView()
+    .accessibilityElement(children: .ignore)
+
+// 子要素を含める（デフォルト）
+Container()
+    .accessibilityElement(children: .contain)
+```
+
+## VoiceOver対応
+
+### 画像のみボタン
+
+```swift
+// ❌ ラベルなし
+Button(action: { }) {
+    Image(systemName: "trash")
+}
+
+// ✅ ラベル付き
+Button(action: { }) {
+    Image(systemName: "trash")
+}
+.accessibilityLabel("削除")
+```
+
+### カスタムアクション
+
+```swift
+ArticleRow(article: article)
+    .accessibilityAction(named: "お気に入りに追加") {
+        addToFavorites(article)
+    }
+    .accessibilityAction(named: "共有") {
+        shareArticle(article)
+    }
+```
+
+### ローター用カスタムコンテンツ
+
+```swift
+List(articles) { article in
+    ArticleRow(article: article)
+        .accessibilityCustomContent("著者", article.author)
+        .accessibilityCustomContent("公開日", article.formattedDate)
+}
+```
+
+## Dynamic Type対応
+
+### システムフォント使用
+
+```swift
+// ✅ 自動対応
+Text("タイトル")
+    .font(.title)
+
+Text("本文テキスト")
+    .font(.body)
+
+// ❌ 固定サイズ（避ける）
+Text("テキスト")
+    .font(.system(size: 16))
+```
+
+### 現在のサイズカテゴリ取得
+
+```swift
+struct AdaptiveView: View {
+    @Environment(\.sizeCategory) var sizeCategory
+    
+    var body: some View {
+        if sizeCategory >= .accessibilityMedium {
+            // 大きいテキストサイズ向けレイアウト
+            VStack { /* ... */ }
+        } else {
+            // 通常レイアウト
+            HStack { /* ... */ }
+        }
+    }
+}
+```
+
+### スケーラブルテキスト
+
+```swift
+Text("テキスト")
+    .dynamicTypeSize(.small ... .accessibility3)
+    // small〜accessibility3の範囲でスケール
+```
+
+## 色のコントラスト
+
+### システムカラー使用
+
+```swift
+// ✅ 推奨: システムカラー
+Text("テキスト")
+    .foregroundColor(.primary)
+
+Text("補足テキスト")
+    .foregroundColor(.secondary)
+
+// ダークモード自動対応
+Color(.systemBackground)
+Color(.secondarySystemBackground)
+```
+
+### 色だけで情報を伝えない
+
+```swift
+// ❌ 色のみ
+Circle()
+    .fill(status == .error ? .red : .green)
+
+// ✅ 色 + アイコン/テキスト
+HStack {
+    Image(systemName: status == .error ? "xmark.circle" : "checkmark.circle")
+    Text(status == .error ? "エラー" : "成功")
+}
+.foregroundColor(status == .error ? .red : .green)
+```
+
+## reduce Motion対応
+
+```swift
+struct AnimatedView: View {
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    
+    var body: some View {
+        Button("タップ") { /* ... */ }
+            .animation(reduceMotion ? nil : .spring(), value: isExpanded)
+    }
+}
+```
+
+## テストとツール
+
+### VoiceOverテスト
+
+1. 設定 → アクセシビリティ → VoiceOver を有効化
+2. 実機でアプリを操作
+3. すべての要素が適切に読み上げられるか確認
+4. ナビゲーションが論理的か確認
+
+### Accessibility Inspector
+
+Xcode → Open Developer Tool → Accessibility Inspector
+
+- 各要素のアクセシビリティ情報を確認
+- コントラスト比のチェック
+- 問題の特定
+
+### チェックリスト
+
+- [ ] すべての画像ボタンにaccessibilityLabel設定
+- [ ] onTapGestureにはaccessibilityTraits追加
+- [ ] 関連要素をグループ化
+- [ ] 見出しに.isHeader特性
+- [ ] カスタムコントロールにaccessibilityValue
+- [ ] Dynamic Type対応（システムフォント使用）
+- [ ] 色だけで情報を伝えていない
+- [ ] VoiceOverで実機テスト済み
+- [ ] reduce Motion対応
+
+## 実装例: アクセシブルなカード
+
+```swift
+struct ArticleCard: View {
+    let article: Article
+    let onFavorite: () -> Void
+    let onShare: () -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // 画像
+            AsyncImage(url: article.imageURL) { image in
+                image.resizable().aspectRatio(contentMode: .fill)
+            } placeholder: {
+                Color.gray
+            }
+            .frame(height: 200)
+            .accessibilityHidden(true) // 装飾的な画像
+            
+            // コンテンツ
+            VStack(alignment: .leading, spacing: 4) {
+                Text(article.title)
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+                
+                Text(article.author)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                
+                Text(article.formattedDate)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("\(article.title)、\(article.author)、\(article.formattedDate)")
+        }
+        .accessibilityAction(named: "お気に入りに追加") {
+            onFavorite()
+        }
+        .accessibilityAction(named: "共有") {
+            onShare()
+        }
+    }
+}
+```

--- a/ios_development/skills/swiftui-code-review-checklist/SKILL.md
+++ b/ios_development/skills/swiftui-code-review-checklist/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: swiftui-code-review-checklist
+description: Code review checklist for SwiftUI and Swift PRs. Use when reviewing pull requests, checking code quality, verifying Swift/SwiftUI implementations, or conducting PR reviews. Provides prioritized checklist covering state management, performance, component design, data flow, async handling, UI/UX, accessibility, security, and testing.
+---
+
+# SwiftUI Code Review Checklist
+
+SwiftUI PRレビュー用の包括的チェックリスト。
+
+## ディレクトリ構成
+
+```
+swiftui-code-review-checklist/
+├── SKILL.md (このファイル)
+└── references/
+    └── code-review-checklist.md
+```
+
+## リファレンスファイル
+
+### references/code-review-checklist.md
+コードレビュー用チェックリスト（優先度別）：
+
+**🔴 Critical（必須）**
+- 状態管理: SSOT違反、不適切なProperty Wrapper
+- パフォーマンス: 不要な再描画、メモリリーク
+- セキュリティ: 機密情報の露出
+
+**🟡 Important（重要）**
+- コンポーネント設計: 責務分離、再利用性
+- データフロー: Binding、環境値の使用
+- 非同期処理: Task管理、エラーハンドリング
+
+**🟢 Nice to Have（推奨）**
+- UI/UX: アニメーション、レイアウト
+- アクセシビリティ: VoiceOver、Dynamic Type
+- テスト: プレビュー、ユニットテスト
+
+## 使用方法
+
+### PRレビュー時
+1. `references/code-review-checklist.md`を開く
+2. 優先度順（🔴→🟡→🟢）でチェック
+3. 問題があれば具体的な改善案を提示
+
+### セルフレビュー時
+1. PR作成前にチェックリストを確認
+2. 自分のコードを検証
+
+## クイックチェック項目
+
+### 状態管理
+- [ ] @Stateは適切に使われているか
+- [ ] 状態の重複はないか
+- [ ] Bindingの向きは正しいか
+
+### パフォーマンス
+- [ ] 不要な再描画が発生していないか
+- [ ] LazyStack/Gridを適切に使っているか
+- [ ] 重い処理はバックグラウンドで実行されているか
+
+### コンポーネント設計
+- [ ] Viewの責務は単一か
+- [ ] 再利用可能な設計か
+- [ ] モディファイアの順序は正しいか
+
+## 関連スキル
+
+- **swiftui-coding-guidelines**: ベストプラクティス・アンチパターン
+- **swiftui-ssot**: 状態管理の詳細
+- **swiftui-accessibility**: アクセシビリティチェック

--- a/ios_development/skills/swiftui-code-review-checklist/references/code-review-checklist.md
+++ b/ios_development/skills/swiftui-code-review-checklist/references/code-review-checklist.md
@@ -1,0 +1,157 @@
+# SwiftUI コードレビューチェックリスト
+
+## 優先度: 必須（Must）
+
+### 状態管理
+
+- [ ] **SSOT遵守**: 各データは唯一の情報源から管理されているか
+- [ ] **導出状態なし**: 計算で求められる状態を`@State`で持っていないか
+- [ ] **プロパティラッパー適切**: `@State`（値型ローカル）、`@StateObject`（参照型所有）、`@ObservedObject`（参照型非所有）
+- [ ] **@State private**: `@State`は`private`になっているか
+- [ ] **iOS 17+ @Observable**: 適切に移行されているか（該当する場合）
+
+```swift
+// ❌ 導出状態を保持
+@State private var items: [Item] = []
+@State private var count: Int = 0  // items.countで計算可能
+
+// ✅ 計算プロパティを使用
+@State private var items: [Item] = []
+private var count: Int { items.count }
+```
+
+### パフォーマンス
+
+- [ ] **Lazyコンテナ**: 大量データに`LazyVStack`/`LazyHStack`/`LazyVGrid`使用
+- [ ] **body内計算**: 重い計算をbody内で実行していないか
+- [ ] **GeometryReader最小限**: 必要な箇所のみで使用しているか
+
+### エラーハンドリング
+
+- [ ] **エラー状態表示**: ネットワークエラー等のUI表示があるか
+- [ ] **空状態表示**: データなし時のプレースホルダーがあるか
+- [ ] **ローディング状態**: 非同期処理中のインジケータがあるか
+
+## 優先度: 推奨（Should）
+
+### コンポーネント設計
+
+- [ ] **Root/Content分離**: ロジック（Root）とUI（Content）が分離されているか
+- [ ] **適切なサイズ**: 1ビューが10-15サブビュー以下か
+- [ ] **単一責任**: 各コンポーネントが単一の責任を持つか
+- [ ] **ViewModifier活用**: 再利用可能なスタイルがモディファイアになっているか
+
+```swift
+// ✅ Root/Content分離
+struct ArticleListView: View {  // Root: ロジック
+    @StateObject private var viewModel = ArticleListViewModel()
+    
+    var body: some View {
+        ArticleListContent(  // Content: UI
+            articles: viewModel.articles,
+            isLoading: viewModel.isLoading
+        )
+    }
+}
+```
+
+### 非同期処理
+
+- [ ] **.task使用**: `onAppear`ではなく`.task`モディファイアを使用（iOS 15+）
+- [ ] **@MainActor**: UI更新メソッドに`@MainActor`が付いているか
+- [ ] **キャンセル考慮**: 長時間処理のキャンセルが考慮されているか
+
+```swift
+// ✅ .taskモディファイア
+.task {
+    await viewModel.fetchData()
+}
+
+// ✅ idパラメータで再実行
+.task(id: selectedCategory) {
+    await viewModel.fetchData(category: selectedCategory)
+}
+```
+
+### ナビゲーション（iOS 16+）
+
+- [ ] **NavigationStack使用**: `NavigationView`ではなく`NavigationStack`使用
+- [ ] **型安全ルート**: 文字列ではなくenumでルート定義
+- [ ] **navigationDestination**: 宣言的にルート定義
+
+### アクセシビリティ
+
+- [ ] **画像ボタンにラベル**: `accessibilityLabel`設定
+- [ ] **onTapGestureに特性**: `.accessibilityAddTraits(.isButton)`
+- [ ] **見出しマーク**: タイトルに`.accessibilityAddTraits(.isHeader)`
+- [ ] **グループ化**: 関連要素を`accessibilityElement(children: .combine)`
+
+### プレビュー
+
+- [ ] **複数状態**: 空、ローディング、エラー、データありのプレビュー
+- [ ] **ダーク/ライト**: 両モードでプレビュー
+- [ ] **Dynamic Type**: 異なるサイズでプレビュー
+
+## 優先度: 提案（Nice to have）
+
+### 最適化
+
+- [ ] **Equatable**: 高コストビューに`Equatable`実装
+- [ ] **_printChanges()**: パフォーマンス問題時のデバッグ
+
+### コードスタイル
+
+- [ ] **命名規則**: SwiftAPIデザインガイドライン準拠
+- [ ] **モディファイア順序**: 意図を理解した順序
+- [ ] **ファイル構成**: 機能別に整理
+
+### ドキュメント
+
+- [ ] **公開APIコメント**: 公開メソッドにドキュメントコメント
+- [ ] **複雑なロジック説明**: 非自明な処理にコメント
+
+## アンチパターンチェック
+
+### 絶対に避けるべき
+
+- [ ] `@State`で参照型（class）を使用していない
+- [ ] body内で毎回重い計算を実行していない
+- [ ] 状態の重複がない
+- [ ] `NavigationView`を使用していない（iOS 16+）
+
+### 注意が必要
+
+- [ ] GeometryReaderの過剰使用
+- [ ] 深いネスト構造
+- [ ] UIKitとSwiftUIの不要な混在
+- [ ] Combineの不適切な使用（async/awaitで代替可能な場合）
+
+## レビューコメント例
+
+### 状態管理
+
+```
+🔴 [必須] この`@State var count`は`items.count`から導出可能です。
+計算プロパティに変更してください。
+```
+
+### パフォーマンス
+
+```
+🟡 [推奨] このForEach内の処理はLazyVStackでラップすると
+パフォーマンスが向上します（30-40%のメモリ削減）。
+```
+
+### アクセシビリティ
+
+```
+🟡 [推奨] この画像ボタンにaccessibilityLabelを追加してください。
+VoiceOverユーザーが機能を理解できません。
+```
+
+### 非同期処理
+
+```
+🟡 [推奨] onAppear内のTask{}は.taskモディファイアに変更すると
+自動キャンセルが効くため、メモリリーク防止になります。
+```

--- a/ios_development/skills/swiftui-coding-guidelines/SKILL.md
+++ b/ios_development/skills/swiftui-coding-guidelines/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: swiftui-coding-guidelines
+description: Core coding guidelines for iOS, iPadOS, macOS, watchOS, tvOS, and visionOS app development using SwiftUI and Swift. Use when implementing Views, working with @State/@Binding/@Observable/@StateObject, using NavigationStack/List/LazyVStack, designing components, or asking about SwiftUI patterns (infinite scroll, pull-to-refresh, search). Covers best practices, implementation patterns, and anti-patterns to avoid.
+---
+
+# SwiftUI Coding Guidelines
+
+SwiftUIの日常的な開発で参照するコアガイドライン。
+
+## ディレクトリ構成
+
+```
+swiftui-coding-guidelines/
+├── SKILL.md (このファイル)
+└── references/
+    ├── best-practices.md      # ベストプラクティス
+    ├── patterns-list.md       # 1-x: リスト・データ表示系
+    ├── patterns-navigation.md # 2-x: ナビゲーション・画面遷移系
+    ├── patterns-forms.md      # 3-x: フォーム・入力系
+    ├── patterns-views.md      # 4-x: View構築・レイアウト系
+    └── anti-patterns.md       # アンチパターン
+```
+
+## リファレンスファイル
+
+### references/best-practices.md
+SwiftUIのベストプラクティス集：
+- **状態管理**: プロパティラッパー（@State、@Binding、@StateObject等）
+- **パフォーマンス最適化**: View構造、LazyスタックとGrid、Equatable
+- **コンポーネント設計**: 責務分離、Root Views vs Content Views、ViewModifier
+- **非同期処理**: .taskモディファイア、async/await、@MainActor
+- **ナビゲーション**: NavigationStack（iOS 16+）、型安全ルーティング
+- **Layoutプロトコル**: GeometryReaderの代替（iOS 16+）
+- **Preview駆動開発**: 複数状態プレビュー
+
+### references/patterns-list.md（1-x: リスト・データ表示系）
+| 番号 | パターン |
+|------|---------|
+| 1-1 | 無限スクロール（Pagination） |
+| 1-2 | プルトゥリフレッシュ |
+| 1-3 | フィルタリング・ソート |
+| 1-4 | スワイプアクション |
+| 1-5 | コンテキストメニュー |
+
+### references/patterns-navigation.md（2-x: ナビゲーション・画面遷移系）
+| 番号 | パターン |
+|------|---------|
+| 2-1 | タブビュー |
+| 2-2 | ナビゲーション（NavigationStack） |
+| 2-3 | モーダル表示（Sheet / FullScreenCover） |
+| 2-4 | アラート・ダイアログ |
+
+### references/patterns-forms.md（3-x: フォーム・入力系）
+| 番号 | パターン |
+|------|---------|
+| 3-1 | 検索機能（デバウンス付き） |
+| 3-2 | フォーム入力（バリデーション付き） |
+| 3-3 | 認証画面（ログイン / 新規登録 / OTP） |
+
+### references/patterns-views.md（4-x: View構築・レイアウト系）
+| 番号 | パターン |
+|------|---------|
+| 4-1 | AsyncImage（キャッシュ付き） |
+| 4-2 | 空状態・エラー状態 |
+| 4-3 | アニメーション |
+| 4-4 | View重なり（ZStack / overlay / background） |
+| 4-5 | ContentUnavailableView（iOS 17+） |
+
+### references/anti-patterns.md
+アンチパターンと解決策：
+- 状態管理、パフォーマンス、ビジネスロジック
+- 非同期処理、ナビゲーション、メモリ管理
+- ViewのIdentity: 不安定なID、ForEachでのインデックス使用
+- AnyView: 型消去によるパフォーマンス低下
+- コンポーネント設計: スペーシング管理、opacity vs if文
+
+## 使用方法
+
+### 新規実装時
+1. 該当する`patterns-*.md`で実装パターン確認
+2. `best-practices.md`で関連ベストプラクティス確認
+3. `anti-patterns.md`で避けるべきパターン確認
+
+### 問題解決時
+1. `anti-patterns.md`で該当パターン検索
+2. `best-practices.md`で推奨実装確認
+
+## 重要な原則
+
+1. **状態の最小化**: 導出可能な状態は持たない
+2. **責務の分離**: Root Views（ロジック）とContent Views（UI）を分離
+3. **パフォーマンス**: Lazy、Equatable、非同期処理の適切な使用
+4. **ViewのIdentity**: 安定したIDを使用、ForEachでインデックス禁止
+5. **スペーシングは親が管理**: 子コンポーネントはpaddingでスペースを作らない
+
+## 関連スキル
+
+- **swiftui-ssot**: 状態管理（SSOT）の詳細設計
+- **swiftui-code-review-checklist**: PRレビュー用チェックリスト
+- **swift-ios-migration**: iOS 17/18、Swift 6移行
+- **swiftui-accessibility**: アクセシビリティ対応

--- a/ios_development/skills/swiftui-coding-guidelines/references/anti-patterns.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/anti-patterns.md
@@ -1,0 +1,900 @@
+# SwiftUI アンチパターン集
+
+## 1. 状態管理のアンチパターン
+
+### 1.1 @Stateで参照型を使用
+
+```swift
+// ❌ アンチパターン: @Stateで参照型
+@State private var viewModel = MyViewModel() // classの場合
+
+// 問題点:
+// - 変更が検知されない
+// - メモリリーク、パフォーマンス低下
+// - 予期しない動作
+
+// ✅ 解決策: @StateObjectを使用
+@StateObject private var viewModel = MyViewModel()
+```
+
+### 1.2 導出可能な状態の保持
+
+```swift
+// ❌ アンチパターン: 導出可能な状態
+@State private var items: [Item] = []
+@State private var count: Int = 0 // items.countで計算可能
+@State private var isEmpty: Bool = true // items.isEmptyで計算可能
+
+// 問題点:
+// - 状態の同期が必要
+// - バグの温床
+// - SSOT違反
+
+// ✅ 解決策: 計算プロパティを使用
+@State private var items: [Item] = []
+private var count: Int { items.count }
+private var isEmpty: Bool { items.isEmpty }
+```
+
+### 1.3 @StateObjectと@ObservedObjectの混同
+
+```swift
+// ❌ アンチパターン: 親で@ObservedObject
+struct ParentView: View {
+    @ObservedObject var viewModel = MyViewModel() // 新規作成
+    // ビュー再描画のたびに再作成される可能性
+}
+
+// ✅ 解決策: 所有者は@StateObject
+struct ParentView: View {
+    @StateObject private var viewModel = MyViewModel()
+}
+
+struct ChildView: View {
+    @ObservedObject var viewModel: MyViewModel // 受け取る場合はOK
+}
+```
+
+### 1.4 状態の過剰な分散
+
+```swift
+// ❌ アンチパターン: 状態があちこちに
+struct View1: View {
+    @State private var user: User?
+}
+struct View2: View {
+    @State private var user: User? // 重複
+}
+
+// ✅ 解決策: 共有状態はEnvironmentまたは親から渡す
+class UserStore: ObservableObject {
+    @Published var user: User?
+}
+
+struct RootView: View {
+    @StateObject private var userStore = UserStore()
+    
+    var body: some View {
+        ContentView()
+            .environmentObject(userStore)
+    }
+}
+```
+
+## 2. パフォーマンスのアンチパターン
+
+### 2.1 body内での重い計算
+
+```swift
+// ❌ アンチパターン: 毎回実行される
+var body: some View {
+    let sortedItems = items.sorted { $0.date > $1.date } // 毎回ソート
+    let filteredItems = sortedItems.filter { $0.isActive } // 毎回フィルタ
+    
+    List(filteredItems) { item in
+        ItemRow(item: item)
+    }
+}
+
+// ✅ 解決策: 計算を事前に実行
+@State private var items: [Item] = []
+@State private var processedItems: [Item] = []
+
+var body: some View {
+    List(processedItems) { item in
+        ItemRow(item: item)
+    }
+    .onChange(of: items) { _, newItems in
+        processedItems = newItems
+            .sorted { $0.date > $1.date }
+            .filter { $0.isActive }
+    }
+}
+```
+
+### 2.2 Lazyを使わない大量データ
+
+```swift
+// ❌ アンチパターン: 全アイテムを即座にレンダリング
+ScrollView {
+    VStack {
+        ForEach(items) { item in // 1000アイテムすべて即座に
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ✅ 解決策: LazyVStackを使用（30-40%メモリ削減）
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+```
+
+### 2.3 GeometryReaderの過剰使用
+
+```swift
+// ❌ アンチパターン: リスト内でGeometryReader
+List(items) { item in
+    GeometryReader { geo in // 各行で再計算
+        ItemRow(item: item, width: geo.size.width)
+    }
+}
+
+// ✅ 解決策: 外側で1回だけ使用
+GeometryReader { geo in
+    List(items) { item in
+        ItemRow(item: item, width: geo.size.width)
+    }
+}
+```
+
+### 2.4 不要な再レンダリング
+
+```swift
+// ❌ アンチパターン: 関係ない変更で再レンダリング
+class ViewModel: ObservableObject {
+    @Published var items: [Item] = []
+    @Published var searchText = "" // 変更で全ビューが再描画
+}
+
+// ✅ 解決策 (iOS 17+): @Observableで選択的監視
+@Observable
+class ViewModel {
+    var items: [Item] = [] // 使用するビューのみ再描画
+    var searchText = ""
+}
+```
+
+## 3. ビジネスロジックのアンチパターン
+
+### 3.1 View内にビジネスロジック
+
+```swift
+// ❌ アンチパターン: View内でロジック
+struct ArticleListView: View {
+    @State private var articles: [Article] = []
+    
+    var body: some View {
+        List(articles) { ... }
+            .onAppear {
+                // ネットワーク処理がView内に
+                URLSession.shared.dataTask(with: url) { data, _, _ in
+                    if let data = data {
+                        let decoded = try? JSONDecoder().decode([Article].self, from: data)
+                        DispatchQueue.main.async {
+                            articles = decoded ?? []
+                        }
+                    }
+                }.resume()
+            }
+    }
+}
+
+// ✅ 解決策: ViewModelに分離
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    
+    func fetchArticles() async {
+        do {
+            articles = try await articleService.fetch()
+        } catch {
+            // エラーハンドリング
+        }
+    }
+}
+
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+    
+    var body: some View {
+        List(viewModel.articles) { ... }
+            .task {
+                await viewModel.fetchArticles()
+            }
+    }
+}
+```
+
+### 3.2 ハードコードされた依存
+
+```swift
+// ❌ アンチパターン: 直接依存
+class ViewModel: ObservableObject {
+    private let service = ArticleService() // テスト不可
+}
+
+// ✅ 解決策: プロトコルと依存性注入
+protocol ArticleServiceProtocol {
+    func fetch() async throws -> [Article]
+}
+
+class ViewModel: ObservableObject {
+    private let service: ArticleServiceProtocol
+    
+    init(service: ArticleServiceProtocol = ArticleService()) {
+        self.service = service
+    }
+}
+```
+
+## 4. 非同期処理のアンチパターン
+
+### 4.1 onAppearでの非同期処理
+
+```swift
+// ❌ アンチパターン: onAppear + Task
+.onAppear {
+    Task {
+        await viewModel.fetchData()
+    }
+    // ビュー消失時にキャンセルされない
+}
+
+// ✅ 解決策: .taskモディファイア（自動キャンセル）
+.task {
+    await viewModel.fetchData()
+}
+```
+
+### 4.2 メインスレッドでの重い処理
+
+```swift
+// ❌ アンチパターン: UIスレッドをブロック
+func processImages() {
+    let processed = images.map { image in
+        heavyImageProcessing(image) // UIが固まる
+    }
+    self.processedImages = processed
+}
+
+// ✅ 解決策: バックグラウンドで実行
+func processImages() async {
+    let processed = await Task.detached(priority: .userInitiated) {
+        images.map { heavyImageProcessing($0) }
+    }.value
+    
+    await MainActor.run {
+        self.processedImages = processed
+    }
+}
+```
+
+### 4.3 逐次的なawait
+
+```swift
+// ❌ アンチパターン: 順番に待機
+func fetchAllData() async {
+    let users = await fetchUsers()    // 待機
+    let posts = await fetchPosts()    // 待機
+    let comments = await fetchComments() // 待機
+    // 合計: 3つの待機時間の和
+}
+
+// ✅ 解決策: 並列実行
+func fetchAllData() async {
+    async let users = fetchUsers()
+    async let posts = fetchPosts()
+    async let comments = fetchComments()
+    
+    let (u, p, c) = await (users, posts, comments)
+    // 合計: 最長の待機時間のみ
+}
+```
+
+## 5. ナビゲーションのアンチパターン
+
+### 5.1 NavigationViewの使用（iOS 16+）
+
+```swift
+// ❌ アンチパターン: 非推奨API
+NavigationView {
+    List(items) { item in
+        NavigationLink(destination: DetailView(item: item)) {
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ✅ 解決策: NavigationStack
+NavigationStack {
+    List(items) { item in
+        NavigationLink(value: item) {
+            ItemRow(item: item)
+        }
+    }
+    .navigationDestination(for: Item.self) { item in
+        DetailView(item: item)
+    }
+}
+```
+
+### 5.2 複数のナビゲーション状態
+
+```swift
+// ❌ アンチパターン: 分散したナビゲーション状態
+@State private var showDetail = false
+@State private var showSettings = false
+@State private var showProfile = false
+
+// ✅ 解決策: NavigationPathで一元管理
+enum Route: Hashable {
+    case detail(Item)
+    case settings
+    case profile
+}
+
+@State private var path = NavigationPath()
+```
+
+## 6. モディファイアのアンチパターン
+
+### 6.1 スタイルの重複
+
+```swift
+// ❌ アンチパターン: 同じスタイルを繰り返し
+Text("Title1")
+    .font(.headline)
+    .foregroundColor(.primary)
+    .padding()
+    .background(Color.gray.opacity(0.1))
+    .cornerRadius(8)
+
+Text("Title2")
+    .font(.headline)
+    .foregroundColor(.primary)
+    .padding()
+    .background(Color.gray.opacity(0.1))
+    .cornerRadius(8)
+
+// ✅ 解決策: ViewModifierで共通化
+struct CardTitleStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .font(.headline)
+            .foregroundColor(.primary)
+            .padding()
+            .background(Color.gray.opacity(0.1))
+            .cornerRadius(8)
+    }
+}
+
+extension View {
+    func cardTitleStyle() -> some View {
+        modifier(CardTitleStyle())
+    }
+}
+
+Text("Title1").cardTitleStyle()
+Text("Title2").cardTitleStyle()
+```
+
+### 6.2 モディファイア順序の無視
+
+```swift
+// 順序で結果が変わる
+Text("Hello")
+    .padding()
+    .background(Color.red) // paddingの外側が赤
+
+Text("Hello")
+    .background(Color.red)
+    .padding() // テキストの背景のみ赤、paddingは透明
+```
+
+## 7. エラーハンドリングのアンチパターン
+
+### 7.1 エラーの無視
+
+```swift
+// ❌ アンチパターン: エラーを握りつぶす
+func fetchData() async {
+    do {
+        data = try await service.fetch()
+    } catch {
+        // 何もしない
+    }
+}
+
+// ✅ 解決策: エラー状態を管理
+@Published var error: Error?
+
+func fetchData() async {
+    do {
+        data = try await service.fetch()
+        error = nil
+    } catch {
+        self.error = error
+    }
+}
+
+// View側
+if let error = viewModel.error {
+    ErrorView(error: error, onRetry: { Task { await viewModel.fetchData() } })
+}
+```
+
+## 8. メモリ管理のアンチパターン
+
+### 8.1 循環参照
+
+```swift
+// ❌ アンチパターン: クロージャで強参照
+class ViewModel: ObservableObject {
+    var onComplete: (() -> Void)?
+    
+    func setup() {
+        onComplete = {
+            self.doSomething() // 循環参照
+        }
+    }
+}
+
+// ✅ 解決策: [weak self]を使用
+func setup() {
+    onComplete = { [weak self] in
+        self?.doSomething()
+    }
+}
+```
+
+### 8.2 Combineのキャンセル忘れ
+
+```swift
+// ❌ アンチパターン: キャンセルしない
+class ViewModel: ObservableObject {
+    func subscribe() {
+        publisher.sink { value in
+            // 処理
+        }
+        // AnyCancellableを保持していない
+    }
+}
+
+// ✅ 解決策: cancellablesで保持
+private var cancellables = Set<AnyCancellable>()
+
+func subscribe() {
+    publisher
+        .sink { [weak self] value in
+            self?.handle(value)
+        }
+        .store(in: &cancellables)
+}
+```
+
+## 9. AnyViewのアンチパターン
+
+### 9.1 AnyViewによる型消去
+
+```swift
+// ❌ アンチパターン: AnyViewの使用
+func makeView(for type: ViewType) -> AnyView {
+    switch type {
+    case .text:
+        return AnyView(Text("Hello"))
+    case .image:
+        return AnyView(Image(systemName: "star"))
+    case .button:
+        return AnyView(Button("Tap") { })
+    }
+}
+
+var body: some View {
+    makeView(for: currentType)
+}
+```
+
+**問題点**:
+- 型情報が消去され、SwiftUIの差分検出（Diffing）が非効率になる
+- パフォーマンス低下（SwiftUIがView階層を正しく追跡できない）
+- アニメーションが正しく動作しない可能性
+
+```swift
+// ✅ 解決策1: @ViewBuilderを使用
+@ViewBuilder
+func makeView(for type: ViewType) -> some View {
+    switch type {
+    case .text:
+        Text("Hello")
+    case .image:
+        Image(systemName: "star")
+    case .button:
+        Button("Tap") { }
+    }
+}
+
+// ✅ 解決策2: Groupを使用
+var body: some View {
+    Group {
+        switch currentType {
+        case .text:
+            Text("Hello")
+        case .image:
+            Image(systemName: "star")
+        case .button:
+            Button("Tap") { }
+        }
+    }
+}
+
+// ✅ 解決策3: ジェネリクスを使用
+struct ContainerView<Content: View>: View {
+    let content: Content
+    
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
+    
+    var body: some View {
+        content
+    }
+}
+```
+
+### 9.2 冗長なビューラッピング
+
+```swift
+// ❌ アンチパターン: 不要なラッピング
+VStack {
+    Color.red
+}
+
+// ✅ 解決策: 直接使用
+Color.red
+```
+
+## 10. ViewのIdentity（同一性）のアンチパターン
+
+SwiftUIは「ある時点のView」と「次の時点のView」が同じか判断するためにIdentityを使用。
+
+### Identity の種類
+
+**明示的Identity (Explicit Identity)**
+- `id()` モディファイア、`ForEach` の引数で明示的に指定
+- データベースの主キーのように機能
+
+**構造的Identity (Structural Identity)**
+- View階層内での位置（パス）によって決定
+- `if-else` 分岐は異なる構造的IDを持つ
+
+### 10.1 ForEachでのインデックス使用（🔴 重大）
+
+```swift
+// ❌ アンチパターン: インデックスをIDとして使用
+struct ItemListView: View {
+    @State private var items = ["A", "B", "C"]
+    
+    var body: some View {
+        List {
+            ForEach(0..<items.count, id: \.self) { index in
+                Text(items[index])
+            }
+        }
+    }
+}
+// 問題: 要素削除時にインデックスとデータがずれる
+// → 状態消失、クラッシュ、アニメーション崩壊
+
+// ✅ 解決策: 安定した一意のIDを持つモデルを使用
+struct Item: Identifiable {
+    let id = UUID()
+    var name: String
+}
+
+struct ItemListView: View {
+    @State private var items = [Item(name: "A"), Item(name: "B"), Item(name: "C")]
+    
+    var body: some View {
+        List {
+            ForEach(items) { item in
+                Text(item.name)
+            }
+        }
+    }
+}
+```
+
+### 10.2 不安定なIDによる状態リセット
+
+```swift
+// ❌ アンチパターン: 毎回新しいIDを生成
+struct ContentView: View {
+    @State private var text = ""
+    
+    var body: some View {
+        TextField("Input", text: $text)
+            .id(UUID())  // 毎回新しいID → 状態がリセットされる
+    }
+}
+
+// ✅ 解決策: 安定したIDを使用
+struct ContentView: View {
+    @State private var text = ""
+    let textFieldId = "mainTextField"
+    
+    var body: some View {
+        TextField("Input", text: $text)
+            .id(textFieldId)  // 安定したID
+    }
+}
+```
+
+### 10.3 条件分岐による意図しないIdentity変更
+
+```swift
+// ⚠️ 注意: if-elseは構造的に異なるViewを生成
+var body: some View {
+    if isLoggedIn {
+        HomeView()  // 構造的ID: "true分岐"
+    } else {
+        LoginView() // 構造的ID: "false分岐"
+    }
+}
+// → isLoggedInが変わると完全に別のViewとして扱われる
+// → @Stateなどの状態は保持されない（これは通常は期待通りの動作）
+
+// 同じViewで状態を保持したい場合
+var body: some View {
+    ContentView(isLoggedIn: isLoggedIn)
+        .id("content")  // 明示的IDで同一性を維持
+}
+```
+
+### 10.4 リスト内でのIdentity問題
+
+```swift
+// ❌ アンチパターン: Hashableだが不安定
+struct Article {
+    var title: String
+    var content: String
+}
+
+extension Article: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(title)  // titleが変わるとIDが変わる
+    }
+}
+
+// ✅ 解決策: Identifiableで安定したID
+struct Article: Identifiable {
+    let id = UUID()  // 不変のID
+    var title: String
+    var content: String
+}
+```
+
+## 11. その他のアンチパターン
+
+### 11.1 Computed Propertyでの重い処理
+
+```swift
+// ❌ アンチパターン: body内で毎回実行
+var body: some View {
+    let formatter = DateFormatter()  // 毎回生成（高コスト）
+    formatter.dateStyle = .medium
+    
+    return Text(formatter.string(from: date))
+}
+
+// ✅ 解決策: staticでキャッシュ
+struct DateView: View {
+    let date: Date
+    
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        return f
+    }()
+    
+    var body: some View {
+        Text(Self.formatter.string(from: date))
+    }
+}
+```
+
+### 11.2 onAppearへの過度な依存
+
+```swift
+// ❌ アンチパターン: NavigationStackで重複実行
+struct DetailView: View {
+    @State private var data: Data?
+    
+    var body: some View {
+        content
+            .onAppear {
+                // 戻る→進むで毎回実行される
+                loadData()
+            }
+    }
+}
+
+// ✅ 解決策: taskで初回のみ、または冪等性を担保
+struct DetailView: View {
+    @State private var data: Data?
+    
+    var body: some View {
+        content
+            .task {
+                // Viewのライフサイクルに連動、自動キャンセル
+                guard data == nil else { return }  // 冪等性
+                data = await fetchData()
+            }
+    }
+}
+```
+
+## 12. コンポーネント設計のアンチパターン
+
+### 12.1 🔴 子コンポーネントでスペーシングを管理
+
+子Viewで`padding`を使って間隔を設定すると、再利用性が低下し、レイアウトの一貫性が失われる。
+
+```swift
+// ❌ アンチパターン: 子がスペーシングを持つ
+VStack(spacing: 0) {
+    Image(systemName: "swift")
+        .padding(.bottom, 8)  // 子がスペーシングを制御
+    Text("Swift")
+        .padding(.bottom, 8)  // 毎回padding指定が必要
+    Text("Programming")
+}
+
+// ❌ 問題点:
+// - 再利用時に余計なスペースが付いてくる
+// - 最後の要素だけpaddingを外す条件分岐が必要
+// - レイアウト変更時に全ての子を修正する必要がある
+
+// ✅ 解決策: 親がスペーシングを管理
+VStack(spacing: 8) {  // 親が一括管理
+    Image(systemName: "swift")
+    Text("Swift")
+    Text("Programming")
+}
+
+// ✅ 異なるスペーシングが必要な場合
+VStack(spacing: 0) {
+    // グループ1
+    VStack(spacing: 4) {
+        Image(systemName: "swift")
+        Text("Swift")
+    }
+    
+    Spacer().frame(height: 16)  // グループ間のスペース
+    
+    // グループ2
+    VStack(spacing: 4) {
+        Image(systemName: "apple.logo")
+        Text("Apple")
+    }
+}
+```
+
+**原則**: スペーシングは親コンポーネントの責務。子コンポーネントは自身のコンテンツのみに責任を持つ。
+
+### 12.2 🟡 if文でViewを表示/非表示（Identity変更）
+
+条件分岐でViewを切り替えると、Structural Identityが変わり状態がリセットされる。
+
+```swift
+// ❌ アンチパターン: if文で切り替え（Identityが変わる）
+struct ProblematicView: View {
+    @State private var isVisible = true
+    
+    var body: some View {
+        VStack {
+            if isVisible {
+                // isVisibleがfalse→trueになると、TextFieldの入力内容がリセット
+                InputView()
+            }
+            
+            Toggle("表示", isOn: $isVisible)
+        }
+    }
+}
+
+struct InputView: View {
+    @State private var text = ""  // 親のif文でIdentityが変わると消える
+    
+    var body: some View {
+        TextField("入力", text: $text)
+    }
+}
+
+// ✅ 解決策1: opacityで非表示（Identityを維持）
+struct BetterView: View {
+    @State private var isVisible = true
+    
+    var body: some View {
+        VStack {
+            InputView()
+                .opacity(isVisible ? 1 : 0)  // 状態を維持したまま非表示
+            
+            Toggle("表示", isOn: $isVisible)
+        }
+    }
+}
+
+// ✅ 解決策2: hidden()モディファイアを使用
+InputView()
+    .hidden(!isVisible)  // iOS 17.5+、hidden(true)で非表示
+
+// ✅ 解決策3: カスタムモディファイア
+extension View {
+    @ViewBuilder
+    func visible(_ isVisible: Bool) -> some View {
+        if isVisible {
+            self
+        } else {
+            self.hidden()
+        }
+    }
+}
+```
+
+**使い分け**:
+| パターン | 状態 | 用途 |
+|---------|------|------|
+| `if` 文 | リセット | 状態リセットが望ましい場合 |
+| `opacity(0)` | 維持 | フォーカス・入力状態を保持したい場合 |
+| `hidden()` | 維持 | レイアウトスペースも維持したい場合 |
+
+### 12.3 ユーザー入力の勝手な書き換え
+
+TextFieldなどの入力コンポーネントで、ユーザーの入力値を親が勝手に変更するとUXが悪化。
+
+```swift
+// ❌ アンチパターン: 入力中に値を強制変更
+struct BadInputView: View {
+    @Binding var text: String
+    
+    var body: some View {
+        TextField("金額", text: $text)
+            .onChange(of: text) { _, newValue in
+                // 入力中にフォーマットすると、カーソル位置がずれる
+                text = formatCurrency(newValue)
+            }
+    }
+}
+
+// ✅ 解決策: フォーカスが外れたときにフォーマット
+struct GoodInputView: View {
+    @Binding var text: String
+    @FocusState private var isFocused: Bool
+    
+    var body: some View {
+        TextField("金額", text: $text)
+            .focused($isFocused)
+            .onChange(of: isFocused) { _, focused in
+                if !focused {
+                    // 編集完了時にのみフォーマット
+                    text = formatCurrency(text)
+                }
+            }
+    }
+}
+```

--- a/ios_development/skills/swiftui-coding-guidelines/references/best-practices.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/best-practices.md
@@ -1,0 +1,520 @@
+# SwiftUI Best Practices
+
+## 1. 状態管理
+
+### Property Wrapperの使い分け（iOS 13-16）
+
+| ラッパー | 用途 | 所有権 |
+|---------|------|--------|
+| `@State` | 値型のローカル状態（Int, String, Bool, struct）。必ず`private`にする | 所有 |
+| `@StateObject` | 参照型の所有者。1度だけ初期化、再描画でも維持 | 所有 |
+| `@ObservedObject` | 外部から受け取る参照型。親から渡される場合 | 非所有 |
+| `@EnvironmentObject` | アプリ全体で共有する状態。依存性注入として使用 | 非所有 |
+| `@Binding` | 親ビューの状態への双方向参照 | 非所有 |
+
+```swift
+// ✅ 正しい使い分け
+struct ParentView: View {
+    @StateObject private var viewModel = MyViewModel() // 所有者
+    
+    var body: some View {
+        ChildView(viewModel: viewModel)
+    }
+}
+
+struct ChildView: View {
+    @ObservedObject var viewModel: MyViewModel // 外部から受け取る
+    
+    var body: some View {
+        GrandchildView(text: $viewModel.text) // Bindingで渡す
+    }
+}
+```
+
+### Single Source of Truth (SSOT)
+
+データは1箇所でのみ管理。複数ビューで共有時は`@Binding`や`@ObservedObject`使用。
+
+```swift
+// ❌ 状態の重複
+struct BadView: View {
+    @State private var items: [Item] = []
+    @State private var count: Int = 0 // itemsから導出可能
+}
+
+// ✅ 導出プロパティを使用
+struct GoodView: View {
+    @State private var items: [Item] = []
+    private var count: Int { items.count }
+}
+```
+
+## 2. パフォーマンス最適化
+
+### 不要な再レンダリング防止
+
+```swift
+// デバッグ: なぜ再レンダリングされたか確認
+var body: some View {
+    let _ = Self._printChanges()
+    // ...
+}
+```
+
+**ポイント**:
+- `@StateObject`は所有者で使用、`@ObservedObject`は注入時のみ
+- `body`内で重い計算を避ける → `onChange`等で事前計算
+- 小さなビューに分割してSwiftUIが必要な部分のみ更新
+
+### Lazyコンテナの活用
+
+```swift
+// ✅ オンデマンドレンダリング（30-40%のメモリ削減）
+ScrollView {
+    LazyVStack {
+        ForEach(items) { item in
+            ItemRow(item: item)
+        }
+    }
+}
+
+// ❌ 全アイテムを即座にレンダリング
+ScrollView {
+    VStack {
+        ForEach(items) { ... }
+    }
+}
+```
+
+### EquatableViewの活用
+
+```swift
+// 15%のレンダリング時間削減（高コストなビューに効果的）
+struct ExpensiveView: View, Equatable {
+    let data: ExpensiveData
+    
+    static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.data.id == rhs.data.id
+    }
+    
+    var body: some View {
+        // 複雑なレンダリング
+    }
+}
+```
+
+### GeometryReaderの使用を最小限に
+
+- レイアウト変更毎に再計算、パフォーマンス影響
+- 動的レイアウト計算が本当に必要な場合のみ使用
+- リスト/グリッド内での使用を避ける
+
+## 3. ビュー構成（View Composition）
+
+### Root Views vs Content Views
+
+```swift
+// Root View: ビジネスロジック、ナビゲーション管理
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+    
+    var body: some View {
+        ArticleListContent(
+            articles: viewModel.articles,
+            isLoading: viewModel.isLoading,
+            onRefresh: { await viewModel.refresh() }
+        )
+    }
+}
+
+// Content View: 純粋なUI表示、プリミティブ型のみ受け取る
+struct ArticleListContent: View {
+    let articles: [Article]
+    let isLoading: Bool
+    let onRefresh: () async -> Void
+    
+    var body: some View {
+        // UIのみ
+    }
+}
+```
+
+### ViewModifierの活用
+
+```swift
+// カスタムモディファイア定義
+struct CardStyle: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+            .shadow(radius: 4)
+    }
+}
+
+extension View {
+    func cardStyle() -> some View {
+        modifier(CardStyle())
+    }
+}
+
+// 使用
+Text("Hello").cardStyle()
+```
+
+### コンポーネントライブラリ構造
+
+```
+Design/
+├── Colors.swift      # カラーパレット
+├── Typography.swift  # フォントスタイル
+└── Spacing.swift     # 間隔定数
+
+Components/
+├── Buttons/
+├── Cards/
+└── TextFields/
+
+Modifiers/
+└── CardStyle.swift
+```
+
+## 4. ナビゲーション（iOS 16+）
+
+### NavigationStackの使用
+
+```swift
+// 型安全なルート定義
+enum Route: Hashable {
+    case detail(Article)
+    case settings
+    case profile(userId: String)
+}
+
+struct ContentView: View {
+    @State private var path = NavigationPath()
+    
+    var body: some View {
+        NavigationStack(path: $path) {
+            List(articles) { article in
+                NavigationLink(value: Route.detail(article)) {
+                    ArticleRow(article: article)
+                }
+            }
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .detail(let article):
+                    ArticleDetailView(article: article)
+                case .settings:
+                    SettingsView()
+                case .profile(let userId):
+                    ProfileView(userId: userId)
+                }
+            }
+        }
+    }
+    
+    // プログラマティックナビゲーション
+    func navigateToSettings() {
+        path.append(Route.settings)
+    }
+    
+    func popToRoot() {
+        path.removeLast(path.count)
+    }
+}
+```
+
+## 5. 非同期処理（Async/Await）
+
+### .taskモディファイアの使用（iOS 15+）
+
+```swift
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+    
+    var body: some View {
+        List(viewModel.articles) { article in
+            ArticleRow(article: article)
+        }
+        .task {
+            // async/await直接使用、ビュー消失時に自動キャンセル
+            await viewModel.fetchArticles()
+        }
+        .task(id: viewModel.selectedCategory) {
+            // idが変わると再実行
+            await viewModel.fetchArticles()
+        }
+    }
+}
+```
+
+### .task vs .onAppear
+
+| 特徴 | .task | .onAppear |
+|------|-------|-----------|
+| async/await | 直接使用可能 | Task{}で囲む必要 |
+| キャンセル | 自動 | 手動 |
+| 優先度設定 | 可能 | 不可 |
+| iOS | 15+ | 13+ |
+
+### @MainActorの使用
+
+```swift
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    
+    func fetchArticles() async {
+        isLoading = true
+        defer { isLoading = false }
+        
+        do {
+            articles = try await articleService.fetch()
+        } catch {
+            // エラーハンドリング
+        }
+    }
+}
+```
+
+## 6. Preview駆動開発
+
+### 複数状態のプレビュー
+
+```swift
+#Preview("Loading") {
+    ArticleListContent(articles: [], isLoading: true, onRefresh: {})
+}
+
+#Preview("Empty") {
+    ArticleListContent(articles: [], isLoading: false, onRefresh: {})
+}
+
+#Preview("With Data") {
+    ArticleListContent(articles: Article.samples, isLoading: false, onRefresh: {})
+}
+
+#Preview("Error") {
+    ArticleListContent(articles: [], isLoading: false, error: .networkError, onRefresh: {})
+}
+
+// iOS 17+ @Previewableマクロ
+#Preview {
+    @Previewable @State var isOn = false
+    Toggle("Switch", isOn: $isOn)
+}
+```
+
+### プレビューのベストプラクティス
+
+- 異なるデバイスサイズ、Dynamic Type設定でプレビュー
+- ダークモード、ライトモード両方
+- 空、ロード中、エラー、データありの各状態
+
+## 7. プロジェクト構造
+
+```
+Sources/
+├── App/                 # メインアプリファイル
+├── Features/            # 機能別
+│   ├── Home/
+│   │   ├── HomeView.swift
+│   │   └── HomeViewModel.swift
+│   └── Profile/
+├── Shared/              # 共通コンポーネント
+│   ├── Components/
+│   └── Modifiers/
+├── Models/              # データモデル
+├── Services/            # Network, Persistence
+└── Utilities/           # Extensions, Constants
+
+Resources/
+├── Assets/              # 画像、色
+├── Localization/        # ローカライズ
+└── Fonts/               # カスタムフォント
+```
+
+## 8. MVVM vs MV パターン
+
+SwiftUIではMVVMは必須ではない。Apple Developer Forumsでも議論されている。
+
+```swift
+// MVパターン（Store使用）
+@MainActor
+class ArticleStore: ObservableObject {
+    @Published private(set) var articles: [Article] = []
+    
+    func fetch() async { /* ... */ }
+}
+
+// Viewで直接使用
+struct ArticleListView: View {
+    @StateObject private var store = ArticleStore()
+    // ...
+}
+```
+
+**ポイント**:
+- ViewModelという名称は混乱を招く可能性
+- テスタビリティのために過度な抽象化を避ける
+- Storeパターンも有効な選択肢
+
+## 9. Layoutプロトコル（iOS 16+）
+
+GeometryReaderの代替として、カスタムレイアウトコンテナを作成可能。パフォーマンスに優れ、レイアウトサイクルのリスクが低い。
+
+### 基本構造
+
+```swift
+struct EqualWidthHStack: Layout {
+    var spacing: CGFloat = 8
+    
+    // 1. 必要なサイズを計算
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let maxWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
+        let totalWidth = maxWidth * CGFloat(subviews.count) + spacing * CGFloat(subviews.count - 1)
+        let maxHeight = subviews.map { $0.sizeThatFits(.unspecified).height }.max() ?? 0
+        
+        return CGSize(width: totalWidth, height: maxHeight)
+    }
+    
+    // 2. 子Viewを配置
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let maxWidth = subviews.map { $0.sizeThatFits(.unspecified).width }.max() ?? 0
+        var x = bounds.minX
+        
+        for subview in subviews {
+            subview.place(
+                at: CGPoint(x: x, y: bounds.minY),
+                proposal: ProposedViewSize(width: maxWidth, height: bounds.height)
+            )
+            x += maxWidth + spacing
+        }
+    }
+}
+
+// 使用
+EqualWidthHStack(spacing: 12) {
+    Button("Short") { }
+    Button("Medium Text") { }
+    Button("Very Long Button") { }
+}
+```
+
+### フローレイアウト（折り返し配置）
+
+```swift
+struct FlowLayout: Layout {
+    var spacing: CGFloat = 8
+    
+    func sizeThatFits(
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) -> CGSize {
+        let result = arrange(subviews: subviews, in: proposal.width ?? 0)
+        return result.size
+    }
+    
+    func placeSubviews(
+        in bounds: CGRect,
+        proposal: ProposedViewSize,
+        subviews: Subviews,
+        cache: inout ()
+    ) {
+        let result = arrange(subviews: subviews, in: bounds.width)
+        
+        for (index, position) in result.positions.enumerated() {
+            subviews[index].place(
+                at: CGPoint(x: bounds.minX + position.x, y: bounds.minY + position.y),
+                proposal: .unspecified
+            )
+        }
+    }
+    
+    private func arrange(subviews: Subviews, in width: CGFloat) -> (size: CGSize, positions: [CGPoint]) {
+        var positions: [CGPoint] = []
+        var currentX: CGFloat = 0
+        var currentY: CGFloat = 0
+        var lineHeight: CGFloat = 0
+        var maxWidth: CGFloat = 0
+        
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            
+            if currentX + size.width > width && currentX > 0 {
+                currentX = 0
+                currentY += lineHeight + spacing
+                lineHeight = 0
+            }
+            
+            positions.append(CGPoint(x: currentX, y: currentY))
+            lineHeight = max(lineHeight, size.height)
+            currentX += size.width + spacing
+            maxWidth = max(maxWidth, currentX - spacing)
+        }
+        
+        return (CGSize(width: maxWidth, height: currentY + lineHeight), positions)
+    }
+}
+
+// 使用（タグ表示など）
+FlowLayout(spacing: 8) {
+    ForEach(tags, id: \.self) { tag in
+        TagView(text: tag)
+    }
+}
+```
+
+### GeometryReaderとの比較
+
+| 特徴 | Layout | GeometryReader |
+|------|--------|----------------|
+| パフォーマンス | ◎ 優秀 | △ レイアウトサイクルのリスク |
+| 再利用性 | ◎ 高い | △ 低い |
+| 複雑さ | やや高い | 低い |
+| iOS | 16+ | 13+ |
+| 用途 | カスタムコンテナ | サイズ取得・相対配置 |
+
+### GeometryReaderを使う場合の注意
+
+```swift
+// ❌ 避ける: リスト内でGeometryReader
+List(items) { item in
+    GeometryReader { geo in
+        ItemRow(item: item, width: geo.size.width)
+    }
+}
+
+// ✅ 推奨: background/overlayで使用
+Text("Hello")
+    .background(
+        GeometryReader { geo in
+            Color.clear.onAppear {
+                size = geo.size
+            }
+        }
+    )
+
+// ✅ 推奨: 外側で1回だけ
+GeometryReader { geo in
+    ScrollView {
+        LazyVStack {
+            ForEach(items) { item in
+                ItemRow(item: item, width: geo.size.width)
+            }
+        }
+    }
+}

--- a/ios_development/skills/swiftui-coding-guidelines/references/patterns-forms.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/patterns-forms.md
@@ -1,0 +1,390 @@
+# SwiftUI フォーム・入力パターン
+
+## 3-1. 検索機能（デバウンス付き）
+
+### iOS 15+ searchableモディファイア
+
+```swift
+struct SearchableListView: View {
+    @StateObject private var viewModel = SearchViewModel()
+    @State private var searchText = ""
+
+    var body: some View {
+        NavigationStack {
+            List(viewModel.results) { item in
+                ItemRow(item: item)
+            }
+            .navigationTitle("検索")
+            .searchable(text: $searchText, prompt: "キーワードを入力")
+            .onChange(of: searchText) { _, newValue in
+                viewModel.searchTextChanged(newValue)
+            }
+        }
+    }
+}
+
+@MainActor
+class SearchViewModel: ObservableObject {
+    @Published var results: [Item] = []
+
+    private var searchTask: Task<Void, Never>?
+
+    func searchTextChanged(_ text: String) {
+        // 前の検索をキャンセル
+        searchTask?.cancel()
+
+        guard !text.isEmpty else {
+            results = []
+            return
+        }
+
+        // デバウンス: 300ms後に検索実行
+        searchTask = Task {
+            try? await Task.sleep(nanoseconds: 300_000_000)
+
+            guard !Task.isCancelled else { return }
+
+            do {
+                results = try await searchService.search(query: text)
+            } catch {
+                // エラーハンドリング
+            }
+        }
+    }
+}
+```
+
+---
+
+## 3-2. フォーム入力（バリデーション付き）
+
+```swift
+struct RegistrationForm: View {
+    @StateObject private var viewModel = RegistrationViewModel()
+
+    var body: some View {
+        Form {
+            Section("アカウント情報") {
+                TextField("メールアドレス", text: $viewModel.email)
+                    .keyboardType(.emailAddress)
+                    .textContentType(.emailAddress)
+                    .textInputAutocapitalization(.never)
+
+                if let error = viewModel.emailError {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+
+                SecureField("パスワード", text: $viewModel.password)
+                    .textContentType(.newPassword)
+
+                if let error = viewModel.passwordError {
+                    Text(error)
+                        .foregroundColor(.red)
+                        .font(.caption)
+                }
+            }
+
+            Section {
+                Button("登録") {
+                    Task {
+                        await viewModel.register()
+                    }
+                }
+                .disabled(!viewModel.isValid)
+            }
+        }
+    }
+}
+
+@MainActor
+class RegistrationViewModel: ObservableObject {
+    @Published var email = ""
+    @Published var password = ""
+
+    var emailError: String? {
+        guard !email.isEmpty else { return nil }
+        let emailRegex = /^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/
+        return email.uppercased().wholeMatch(of: emailRegex) == nil
+            ? "有効なメールアドレスを入力してください"
+            : nil
+    }
+
+    var passwordError: String? {
+        guard !password.isEmpty else { return nil }
+        return password.count < 8
+            ? "パスワードは8文字以上必要です"
+            : nil
+    }
+
+    var isValid: Bool {
+        !email.isEmpty &&
+        !password.isEmpty &&
+        emailError == nil &&
+        passwordError == nil
+    }
+
+    func register() async {
+        // 登録処理
+    }
+}
+```
+
+---
+
+## 3-3. 認証画面（ログインフォーム）
+
+### 完全な実装例
+
+FocusState、textContentType、キーボード設定を組み合わせた認証画面の推奨パターン。
+
+```swift
+struct LoginView: View {
+    enum Field: Hashable {
+        case email
+        case password
+    }
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var isLoading = false
+    @State private var errorMessage: String?
+
+    @FocusState private var focusedField: Field?
+
+    var body: some View {
+        Form {
+            Section {
+                // メールアドレス入力欄
+                TextField("メールアドレス", text: $email)
+                    .focused($focusedField, equals: .email)
+                    .textContentType(.username)           // パスワードマネージャー対応
+                    .keyboardType(.emailAddress)          // メール用キーボード
+                    .textInputAutocapitalization(.never)  // 自動大文字化を無効
+                    .autocorrectionDisabled()             // 自動修正を無効
+                    .submitLabel(.next)                   // Returnキーを「次へ」に
+                    .onSubmit {
+                        focusedField = .password          // パスワード欄にフォーカス移動
+                    }
+
+                // パスワード入力欄
+                SecureField("パスワード", text: $password)
+                    .focused($focusedField, equals: .password)
+                    .textContentType(.password)           // パスワードマネージャー対応
+                    .submitLabel(.go)                     // Returnキーを「Go」に
+                    .onSubmit {
+                        login()                           // ログイン実行
+                    }
+            } header: {
+                Text("アカウント情報")
+            } footer: {
+                if let errorMessage {
+                    Text(errorMessage)
+                        .foregroundColor(.red)
+                }
+            }
+
+            Section {
+                Button {
+                    login()
+                } label: {
+                    if isLoading {
+                        ProgressView()
+                            .frame(maxWidth: .infinity)
+                    } else {
+                        Text("ログイン")
+                            .frame(maxWidth: .infinity)
+                    }
+                }
+                .disabled(!isFormValid || isLoading)
+            }
+        }
+        .onAppear {
+            // 画面表示時に最初のフィールドにフォーカス
+            focusedField = .email
+        }
+    }
+
+    private var isFormValid: Bool {
+        !email.isEmpty && !password.isEmpty
+    }
+
+    private func login() {
+        // 未入力フィールドがあればフォーカス移動
+        if email.isEmpty {
+            focusedField = .email
+            return
+        }
+        if password.isEmpty {
+            focusedField = .password
+            return
+        }
+
+        // キーボードを閉じる
+        focusedField = nil
+
+        isLoading = true
+        errorMessage = nil
+
+        Task {
+            // ログイン処理...
+        }
+    }
+}
+```
+
+### 新規登録画面
+
+新規パスワード作成時は `.newPassword` を使用。
+
+```swift
+struct SignUpView: View {
+    enum Field: Hashable {
+        case email
+        case password
+        case confirmPassword
+    }
+
+    @State private var email = ""
+    @State private var password = ""
+    @State private var confirmPassword = ""
+
+    @FocusState private var focusedField: Field?
+
+    var body: some View {
+        Form {
+            TextField("メールアドレス", text: $email)
+                .focused($focusedField, equals: .email)
+                .textContentType(.username)
+                .keyboardType(.emailAddress)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .submitLabel(.next)
+                .onSubmit { focusedField = .password }
+
+            SecureField("パスワード", text: $password)
+                .focused($focusedField, equals: .password)
+                .textContentType(.newPassword)  // ✅ 新規パスワード
+                .submitLabel(.next)
+                .onSubmit { focusedField = .confirmPassword }
+
+            SecureField("パスワード（確認）", text: $confirmPassword)
+                .focused($focusedField, equals: .confirmPassword)
+                .textContentType(.newPassword)  // ✅ 新規パスワード
+                .submitLabel(.done)
+                .onSubmit { signUp() }
+        }
+    }
+
+    private func signUp() {
+        // 登録処理
+    }
+}
+```
+
+### ワンタイムパスワード（OTP）入力
+
+SMSやメールで送信されたコードの入力。
+
+```swift
+struct OTPInputView: View {
+    @State private var code = ""
+    @FocusState private var isFocused: Bool
+
+    var body: some View {
+        VStack(spacing: 24) {
+            Text("認証コードを入力")
+                .font(.headline)
+
+            TextField("000000", text: $code)
+                .focused($isFocused)
+                .textContentType(.oneTimeCode)    // ✅ OTP自動入力対応
+                .keyboardType(.numberPad)         // 数字キーボード
+                .multilineTextAlignment(.center)
+                .font(.title.monospaced())
+                .frame(maxWidth: 200)
+                .onChange(of: code) { _, newValue in
+                    // 6桁入力で自動送信
+                    if newValue.count == 6 {
+                        verifyCode()
+                    }
+                }
+
+            Text("SMSで送信されたコードを入力してください")
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .onAppear {
+            isFocused = true
+        }
+    }
+
+    private func verifyCode() {
+        // 検証処理
+    }
+}
+```
+
+### textContentType 一覧
+
+| 用途 | textContentType | 説明 |
+|------|-----------------|------|
+| ユーザー名/メール | `.username` | ログイン時のID入力 |
+| 既存パスワード | `.password` | ログイン時のパスワード |
+| 新規パスワード | `.newPassword` | 登録・変更時のパスワード |
+| ワンタイムコード | `.oneTimeCode` | SMS/メール認証コード |
+| メールアドレス | `.emailAddress` | メール専用入力 |
+| 電話番号 | `.telephoneNumber` | 電話番号入力 |
+| 名前 | `.name` | フルネーム |
+| 姓 | `.familyName` | 姓のみ |
+| 名 | `.givenName` | 名のみ |
+
+### FocusStateのベストプラクティス
+
+```swift
+// ✅ 推奨: enumでフォーカス状態を管理
+enum Field: Hashable {
+    case username
+    case password
+}
+@FocusState private var focusedField: Field?
+
+// フォーカス移動
+focusedField = .password
+
+// キーボードを閉じる
+focusedField = nil
+
+// ❌ 避けるべき: 複数のBool FocusState
+@FocusState private var isUsernameFocused: Bool
+@FocusState private var isPasswordFocused: Bool
+// → 状態管理が複雑になり、同時に複数がtrueになる可能性
+```
+
+### キーボードのReturnキー設定
+
+| submitLabel | 表示 | 用途 |
+|-------------|------|------|
+| `.next` | 次へ | 次のフィールドへ移動 |
+| `.done` | 完了 | 入力完了 |
+| `.go` | Go | アクション実行 |
+| `.send` | 送信 | メッセージ送信 |
+| `.search` | 検索 | 検索実行 |
+| `.continue` | 続ける | 次のステップへ |
+| `.join` | 参加 | 参加アクション |
+| `.return` | 改行 | デフォルト |
+
+### アクセシビリティ対応
+
+```swift
+TextField("メールアドレス", text: $email)
+    .textContentType(.username)
+    .accessibilityLabel("メールアドレス入力欄")
+    .accessibilityHint("ログインに使用するメールアドレスを入力してください")
+
+SecureField("パスワード", text: $password)
+    .textContentType(.password)
+    .accessibilityLabel("パスワード入力欄")
+    // パスワードの内容は読み上げられない（セキュリティ）
+```

--- a/ios_development/skills/swiftui-coding-guidelines/references/patterns-list.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/patterns-list.md
@@ -1,0 +1,246 @@
+# SwiftUI リスト・データ表示パターン
+
+## 1-1. 無限スクロール（Pagination）
+
+### 基本実装
+
+```swift
+@MainActor
+class ArticleListViewModel: ObservableObject {
+    @Published var articles: [Article] = []
+    @Published var isLoading = false
+    @Published var hasMorePages = true
+
+    private var currentPage = 1
+    private let pageSize = 20
+
+    func loadMoreIfNeeded(currentItem: Article?) async {
+        guard !isLoading, hasMorePages else { return }
+
+        // 最後から5番目に到達したら次を読み込み
+        guard let currentItem = currentItem,
+              let index = articles.firstIndex(where: { $0.id == currentItem.id }),
+              index >= articles.count - 5 else {
+            return
+        }
+
+        await loadMore()
+    }
+
+    func loadMore() async {
+        isLoading = true
+        defer { isLoading = false }
+
+        do {
+            let newArticles = try await articleService.fetch(
+                page: currentPage,
+                limit: pageSize
+            )
+            articles.append(contentsOf: newArticles)
+            currentPage += 1
+            hasMorePages = newArticles.count == pageSize
+        } catch {
+            // エラーハンドリング
+        }
+    }
+}
+
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+
+    var body: some View {
+        List {
+            ForEach(viewModel.articles) { article in
+                ArticleRow(article: article)
+                    .task {
+                        await viewModel.loadMoreIfNeeded(currentItem: article)
+                    }
+            }
+
+            if viewModel.isLoading {
+                ProgressView()
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .task {
+            await viewModel.loadMore()
+        }
+    }
+}
+```
+
+---
+
+## 1-2. プルトゥリフレッシュ
+
+```swift
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+
+    var body: some View {
+        List(viewModel.articles) { article in
+            ArticleRow(article: article)
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+}
+
+// ViewModel
+func refresh() async {
+    currentPage = 1
+    hasMorePages = true
+
+    do {
+        articles = try await articleService.fetch(page: 1, limit: pageSize)
+        currentPage = 2
+    } catch {
+        // エラーハンドリング
+    }
+}
+```
+
+---
+
+## 1-3. フィルタリング・ソート
+
+```swift
+struct FilterableListView: View {
+    @StateObject private var viewModel = ItemListViewModel()
+    @State private var selectedFilter: Filter = .all
+    @State private var sortOrder: SortOrder = .dateDescending
+
+    enum Filter: String, CaseIterable {
+        case all = "すべて"
+        case active = "アクティブ"
+        case completed = "完了"
+    }
+
+    enum SortOrder: String, CaseIterable {
+        case dateDescending = "新しい順"
+        case dateAscending = "古い順"
+        case nameAscending = "名前順"
+    }
+
+    var filteredItems: [Item] {
+        var items = viewModel.items
+
+        // フィルタ適用
+        switch selectedFilter {
+        case .active:
+            items = items.filter { !$0.isCompleted }
+        case .completed:
+            items = items.filter { $0.isCompleted }
+        case .all:
+            break
+        }
+
+        // ソート適用
+        switch sortOrder {
+        case .dateDescending:
+            items.sort { $0.date > $1.date }
+        case .dateAscending:
+            items.sort { $0.date < $1.date }
+        case .nameAscending:
+            items.sort { $0.name < $1.name }
+        }
+
+        return items
+    }
+
+    var body: some View {
+        List(filteredItems) { item in
+            ItemRow(item: item)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Picker("フィルタ", selection: $selectedFilter) {
+                        ForEach(Filter.allCases, id: \.self) { filter in
+                            Text(filter.rawValue).tag(filter)
+                        }
+                    }
+
+                    Picker("並び替え", selection: $sortOrder) {
+                        ForEach(SortOrder.allCases, id: \.self) { order in
+                            Text(order.rawValue).tag(order)
+                        }
+                    }
+                } label: {
+                    Image(systemName: "line.3.horizontal.decrease.circle")
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## 1-4. スワイプアクション
+
+```swift
+List {
+    ForEach(items) { item in
+        ItemRow(item: item)
+            .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                Button(role: .destructive) {
+                    deleteItem(item)
+                } label: {
+                    Label("削除", systemImage: "trash")
+                }
+
+                Button {
+                    archiveItem(item)
+                } label: {
+                    Label("アーカイブ", systemImage: "archivebox")
+                }
+                .tint(.orange)
+            }
+            .swipeActions(edge: .leading) {
+                Button {
+                    toggleFavorite(item)
+                } label: {
+                    Label(
+                        item.isFavorite ? "お気に入り解除" : "お気に入り",
+                        systemImage: item.isFavorite ? "star.slash" : "star"
+                    )
+                }
+                .tint(.yellow)
+            }
+    }
+}
+```
+
+---
+
+## 1-5. コンテキストメニュー
+
+```swift
+ArticleRow(article: article)
+    .contextMenu {
+        Button {
+            shareArticle(article)
+        } label: {
+            Label("共有", systemImage: "square.and.arrow.up")
+        }
+
+        Button {
+            toggleFavorite(article)
+        } label: {
+            Label(
+                article.isFavorite ? "お気に入り解除" : "お気に入り",
+                systemImage: article.isFavorite ? "star.slash" : "star"
+            )
+        }
+
+        Divider()
+
+        Button(role: .destructive) {
+            deleteArticle(article)
+        } label: {
+            Label("削除", systemImage: "trash")
+        }
+    }
+```

--- a/ios_development/skills/swiftui-coding-guidelines/references/patterns-navigation.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/patterns-navigation.md
@@ -1,0 +1,174 @@
+# SwiftUI ナビゲーション・画面遷移パターン
+
+## 2-1. タブビュー
+
+```swift
+struct MainTabView: View {
+    @State private var selectedTab = 0
+
+    var body: some View {
+        TabView(selection: $selectedTab) {
+            HomeView()
+                .tabItem {
+                    Label("ホーム", systemImage: "house")
+                }
+                .tag(0)
+
+            SearchView()
+                .tabItem {
+                    Label("検索", systemImage: "magnifyingglass")
+                }
+                .tag(1)
+
+            ProfileView()
+                .tabItem {
+                    Label("プロフィール", systemImage: "person")
+                }
+                .tag(2)
+        }
+    }
+
+    // プログラマティックにタブ切り替え
+    func switchToSearch() {
+        selectedTab = 1
+    }
+}
+```
+
+---
+
+## 2-2. ナビゲーション（NavigationStack）
+
+```swift
+enum Route: Hashable {
+    case articleDetail(Article)
+    case userProfile(userId: String)
+    case settings
+}
+
+struct ContentView: View {
+    @State private var path = NavigationPath()
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            ArticleListView(onSelectArticle: { article in
+                path.append(Route.articleDetail(article))
+            })
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .articleDetail(let article):
+                    ArticleDetailView(article: article)
+                case .userProfile(let userId):
+                    UserProfileView(userId: userId)
+                case .settings:
+                    SettingsView()
+                }
+            }
+        }
+    }
+
+    // ディープリンク対応
+    func handleDeepLink(url: URL) {
+        guard let route = parseDeepLink(url) else { return }
+        path.append(route)
+    }
+
+    func popToRoot() {
+        path.removeLast(path.count)
+    }
+}
+```
+
+---
+
+## 2-3. モーダル表示
+
+### Sheet
+
+```swift
+struct ContentView: View {
+    @State private var showSheet = false
+    @State private var selectedItem: Item?
+
+    var body: some View {
+        List(items) { item in
+            Button(item.name) {
+                selectedItem = item
+            }
+        }
+        .sheet(item: $selectedItem) { item in
+            ItemDetailView(item: item)
+        }
+
+        // または isPresented
+        Button("新規作成") {
+            showSheet = true
+        }
+        .sheet(isPresented: $showSheet) {
+            CreateItemView()
+        }
+    }
+}
+```
+
+### FullScreenCover
+
+```swift
+.fullScreenCover(isPresented: $showFullScreen) {
+    FullScreenView()
+}
+```
+
+### 閉じる処理
+
+```swift
+struct SheetView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            Content()
+                .toolbar {
+                    ToolbarItem(placement: .cancellationAction) {
+                        Button("キャンセル") {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+}
+```
+
+---
+
+## 2-4. アラート・ダイアログ
+
+```swift
+struct ContentView: View {
+    @State private var showAlert = false
+    @State private var showConfirmation = false
+
+    var body: some View {
+        VStack {
+            Button("アラート表示") {
+                showAlert = true
+            }
+            .alert("タイトル", isPresented: $showAlert) {
+                Button("OK") { }
+            } message: {
+                Text("メッセージ内容")
+            }
+
+            Button("確認ダイアログ") {
+                showConfirmation = true
+            }
+            .confirmationDialog("選択してください", isPresented: $showConfirmation) {
+                Button("編集") { }
+                Button("削除", role: .destructive) { }
+                Button("キャンセル", role: .cancel) { }
+            }
+        }
+    }
+}
+```

--- a/ios_development/skills/swiftui-coding-guidelines/references/patterns-views.md
+++ b/ios_development/skills/swiftui-coding-guidelines/references/patterns-views.md
@@ -1,0 +1,469 @@
+# SwiftUI View構築・レイアウトパターン
+
+## 4-1. AsyncImage（キャッシュ付き）
+
+### 基本使用
+
+```swift
+AsyncImage(url: imageURL) { phase in
+    switch phase {
+    case .empty:
+        ProgressView()
+    case .success(let image):
+        image
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+    case .failure:
+        Image(systemName: "photo")
+            .foregroundColor(.gray)
+    @unknown default:
+        EmptyView()
+    }
+}
+.frame(width: 100, height: 100)
+.clipShape(RoundedRectangle(cornerRadius: 8))
+```
+
+### キャッシュ付き実装
+
+```swift
+struct CachedAsyncImage: View {
+    let url: URL?
+
+    @State private var image: Image?
+
+    var body: some View {
+        Group {
+            if let image = image {
+                image
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+            } else {
+                ProgressView()
+                    .task {
+                        await loadImage()
+                    }
+            }
+        }
+    }
+
+    private func loadImage() async {
+        guard let url = url else { return }
+
+        // キャッシュチェック
+        if let cached = ImageCache.shared.get(for: url) {
+            image = cached
+            return
+        }
+
+        do {
+            let (data, _) = try await URLSession.shared.data(from: url)
+            if let uiImage = UIImage(data: data) {
+                let loadedImage = Image(uiImage: uiImage)
+                ImageCache.shared.set(loadedImage, for: url)
+                image = loadedImage
+            }
+        } catch {
+            // エラーハンドリング
+        }
+    }
+}
+
+actor ImageCache {
+    static let shared = ImageCache()
+    private var cache: [URL: Image] = [:]
+
+    func get(for url: URL) -> Image? {
+        cache[url]
+    }
+
+    func set(_ image: Image, for url: URL) {
+        cache[url] = image
+    }
+}
+```
+
+---
+
+## 4-2. 空状態・エラー状態
+
+```swift
+struct ContentStateView<Content: View, Empty: View, Loading: View, Error: View>: View {
+    let state: ContentState
+    let content: () -> Content
+    let empty: () -> Empty
+    let loading: () -> Loading
+    let error: (Swift.Error) -> Error
+
+    var body: some View {
+        switch state {
+        case .idle:
+            empty()
+        case .loading:
+            loading()
+        case .loaded:
+            content()
+        case .error(let err):
+            error(err)
+        }
+    }
+}
+
+enum ContentState {
+    case idle
+    case loading
+    case loaded
+    case error(Error)
+}
+
+// 使用例
+struct ArticleListView: View {
+    @StateObject private var viewModel = ArticleListViewModel()
+
+    var body: some View {
+        ContentStateView(state: viewModel.state) {
+            List(viewModel.articles) { article in
+                ArticleRow(article: article)
+            }
+        } empty: {
+            EmptyStateView(
+                icon: "doc.text",
+                title: "記事がありません",
+                message: "新しい記事を追加してください"
+            )
+        } loading: {
+            ProgressView("読み込み中...")
+        } error: { error in
+            ErrorStateView(
+                error: error,
+                onRetry: {
+                    Task { await viewModel.fetch() }
+                }
+            )
+        }
+    }
+}
+
+struct EmptyStateView: View {
+    let icon: String
+    let title: String
+    let message: String
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: icon)
+                .font(.system(size: 60))
+                .foregroundColor(.gray)
+
+            Text(title)
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(message)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+    }
+}
+
+struct ErrorStateView: View {
+    let error: Error
+    let onRetry: () -> Void
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "exclamationmark.triangle")
+                .font(.system(size: 60))
+                .foregroundColor(.orange)
+
+            Text("エラーが発生しました")
+                .font(.title2)
+                .fontWeight(.semibold)
+
+            Text(error.localizedDescription)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+
+            Button("再試行") {
+                onRetry()
+            }
+            .buttonStyle(.borderedProminent)
+        }
+        .padding()
+    }
+}
+```
+
+---
+
+## 4-3. アニメーション
+
+```swift
+struct AnimatedView: View {
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack {
+            Button("トグル") {
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+                    isExpanded.toggle()
+                }
+            }
+
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color.blue)
+                .frame(
+                    width: isExpanded ? 200 : 100,
+                    height: isExpanded ? 200 : 100
+                )
+        }
+    }
+}
+
+// Reduce Motion対応
+struct AccessibleAnimatedView: View {
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+    @State private var isVisible = false
+
+    var body: some View {
+        Text("Hello")
+            .opacity(isVisible ? 1 : 0)
+            .animation(reduceMotion ? nil : .easeInOut, value: isVisible)
+    }
+}
+```
+
+---
+
+## 4-4. View重なりパターン（ZStack / overlay / background）
+
+### 使い分けガイド
+
+| 方法 | サイズ決定 | 用途 |
+|------|-----------|------|
+| `ZStack` | 最大の子に合わせる | 複数の独立したViewを重ねる |
+| `.overlay` | ベースViewに合わせる | 前面に装飾・バッジを追加 |
+| `.background` | ベースViewに合わせる | 背景として配置 |
+
+### ZStack: 複数の独立したViewを重ねる
+
+```swift
+// 複数の独立した要素を重ねる
+ZStack(alignment: .topTrailing) {
+    Image("photo")
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+
+    // お気に入りボタン
+    Button(action: toggleFavorite) {
+        Image(systemName: "heart.fill")
+            .foregroundColor(.red)
+    }
+    .padding(8)
+}
+```
+
+### overlay: ベースViewの前面に装飾
+
+```swift
+// バッジ付きアイコン
+Image(systemName: "bell")
+    .font(.title)
+    .overlay(alignment: .topTrailing) {
+        // バッジはベースアイコンのサイズに影響しない
+        Text("3")
+            .font(.caption2)
+            .padding(4)
+            .background(Color.red)
+            .clipShape(Circle())
+            .offset(x: 8, y: -8)
+    }
+
+// ローディングオーバーレイ
+List(items) { item in
+    ItemRow(item: item)
+}
+.overlay {
+    if isLoading {
+        ProgressView()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color.black.opacity(0.3))
+    }
+}
+```
+
+### background: ベースViewの背景
+
+```swift
+// カード背景
+Text("Hello, World!")
+    .padding()
+    .background {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(Color.white)
+            .shadow(radius: 4)
+    }
+
+// グラデーション背景
+Text("Gradient")
+    .padding()
+    .background {
+        LinearGradient(
+            colors: [.blue, .purple],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+    }
+```
+
+### 選択の指針
+
+```swift
+// ✅ ZStack: 両方のサイズが重要、または複数要素を対等に扱う
+ZStack {
+    BackgroundView()
+    ContentView()
+    OverlayView()
+}
+
+// ✅ overlay: メインコンテンツに付加的な要素を追加
+MainContent()
+    .overlay(alignment: .bottomTrailing) {
+        FloatingActionButton()
+    }
+
+// ✅ background: メインコンテンツに背景を追加
+MainContent()
+    .background {
+        BackgroundEffect()
+    }
+```
+
+---
+
+## 4-5. ContentUnavailableView パターン（iOS 17+）
+
+### 基本的な使い方
+
+```swift
+// システム提供のスタイル
+ContentUnavailableView.search  // 検索結果なし
+ContentUnavailableView.search(text: query)  // 検索クエリ付き
+
+// カスタムメッセージ
+ContentUnavailableView(
+    "データがありません",
+    systemImage: "tray",
+    description: Text("新しいアイテムを追加してください")
+)
+```
+
+### overlayを使った責務分離パターン
+
+メインコンテンツと空/エラー状態を分離して可読性を向上。
+
+```swift
+// ✅ 推奨: overlayで分離
+struct ItemListView: View {
+    @State private var items: [Item] = []
+    @State private var searchText = ""
+    @State private var error: Error?
+
+    var filteredItems: [Item] {
+        if searchText.isEmpty {
+            return items
+        }
+        return items.filter { $0.name.contains(searchText) }
+    }
+
+    var body: some View {
+        NavigationStack {
+            List(filteredItems) { item in
+                ItemRow(item: item)
+            }
+            .searchable(text: $searchText)
+            // 空状態・エラー状態をoverlayで分離
+            .overlay {
+                if let error {
+                    ContentUnavailableView(
+                        "読み込みエラー",
+                        systemImage: "exclamationmark.triangle",
+                        description: Text(error.localizedDescription)
+                    )
+                } else if items.isEmpty {
+                    ContentUnavailableView(
+                        "アイテムがありません",
+                        systemImage: "tray",
+                        description: Text("右上の＋ボタンから追加できます")
+                    )
+                } else if filteredItems.isEmpty {
+                    ContentUnavailableView.search(text: searchText)
+                }
+            }
+        }
+    }
+}
+
+// ❌ 避けるべき: if-elseで分岐（可読性低下）
+var body: some View {
+    if let error {
+        ErrorView(error: error)
+    } else if items.isEmpty {
+        EmptyView()
+    } else if filteredItems.isEmpty {
+        SearchEmptyView()
+    } else {
+        List(filteredItems) { ... }  // メインロジックが深くネスト
+    }
+}
+```
+
+### アクションボタン付き
+
+```swift
+ContentUnavailableView {
+    Label("接続エラー", systemImage: "wifi.slash")
+} description: {
+    Text("インターネット接続を確認してください")
+} actions: {
+    Button("再試行") {
+        Task { await retry() }
+    }
+    .buttonStyle(.borderedProminent)
+}
+```
+
+### iOS 16以前との互換性
+
+```swift
+struct ContentUnavailableViewCompat<Label: View, Description: View, Actions: View>: View {
+    let label: Label
+    let description: Description
+    let actions: Actions
+
+    init(
+        @ViewBuilder label: () -> Label,
+        @ViewBuilder description: () -> Description = { EmptyView() },
+        @ViewBuilder actions: () -> Actions = { EmptyView() }
+    ) {
+        self.label = label()
+        self.description = description()
+        self.actions = actions()
+    }
+
+    var body: some View {
+        VStack(spacing: 16) {
+            label
+                .font(.title)
+                .foregroundColor(.secondary)
+            description
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+            actions
+        }
+        .padding()
+    }
+}
+```

--- a/ios_development/skills/swiftui-components/SKILL.md
+++ b/ios_development/skills/swiftui-components/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: swiftui-components
+description: SwiftUI UI component catalog. Use when implementing NavigationStack, Swift Charts, PhotosPicker, TipKit, ScrollView enhancements, animations, layouts, WebView, Liquid Glass and other UI components. Organized by feature category with OS version compatibility info. Reference for discovering available components and implementation patterns.
+---
+
+# SwiftUI UIコンポーネントカタログ
+
+iOS 16以降で利用可能なSwiftUIコンポーネントを機能別に整理したリファレンス。
+
+## ディレクトリ構成
+
+```
+swiftui-components/
+├── SKILL.md (このファイル)
+└── references/
+    ├── navigation.md    # ナビゲーション
+    ├── charts.md        # チャート・グラフ
+    ├── scroll.md        # スクロール
+    ├── media.md         # メディア・共有
+    ├── animation.md     # アニメーション
+    ├── layout.md        # レイアウト
+    ├── tips.md          # TipKit
+    ├── preview.md       # プレビュー
+    ├── container.md     # コンテナ値
+    ├── theming.md       # テーマ・デザイン
+    └── webview.md       # WebView
+```
+
+## リファレンスファイル
+
+### references/navigation.md
+ナビゲーション関連コンポーネント：
+- **NavigationStack** (iOS 16+): NavigationViewの後継、プログラマティックナビゲーション
+- **NavigationSplitView** (iOS 16+): 2列/3列レイアウト対応
+- **NavigationPath** (iOS 16+): 複数の型をサポートするナビゲーションパス
+- **TabView刷新** (iOS 26+): 新デザイン・アニメーション
+
+### references/charts.md
+チャート・グラフ関連コンポーネント：
+- **Swift Charts** (iOS 16+): LineMark, BarMark, AreaMark, PointMark等
+- **Chart3D** (iOS 26+): 3Dチャートのネイティブサポート
+
+### references/scroll.md
+スクロール関連コンポーネント：
+- **scrollPosition** (iOS 17+): スクロール位置の取得・設定
+- **scrollTargetBehavior** (iOS 17+): スナップスクロール
+- **containerRelativeFrame** (iOS 17+): 親コンテナに対する相対サイズ指定
+
+### references/media.md
+メディア・共有関連コンポーネント：
+- **PhotosPicker** (iOS 16+): 写真ライブラリアクセス不要の写真選択
+- **ShareLink** (iOS 16+): 標準シェア機能のSwiftUI対応
+- **Transferable** (iOS 16+): データ転送プロトコル
+
+### references/animation.md
+アニメーション関連コンポーネント：
+- **symbolEffect** (iOS 17+): SF Symbolsアニメーション
+- **contentTransition** (iOS 17+): テキスト・コンテンツ変更アニメーション
+- **phaseAnimator** (iOS 17+): 複数フェーズのアニメーション
+- **keyframeAnimator** (iOS 17+): キーフレームベースのアニメーション
+- **@Animatable** (iOS 26+): アニメーション対応マクロ
+
+### references/layout.md
+レイアウト関連コンポーネント：
+- **Grid** (iOS 16+): 柔軟なグリッドレイアウト
+- **ViewThatFits** (iOS 16+): スペースに応じた自動ビュー選択
+- **AnyLayout** (iOS 16+): 動的レイアウト切り替え
+- **Gauge** (iOS 16+): 進捗・レベル表示
+- **Table** (iOS 16+): 表形式のデータ表示（macOS/iPadOS）
+- **ToolbarSpacer** (iOS 26+): ツールバースペース制御
+- **labelIconToTitleSpacing** (iOS 26+): Labelスペース調整
+
+### references/tips.md
+TipKitフレームワーク：
+- **TipKit** (iOS 17+): 機能発見ヒント表示
+
+### references/preview.md
+プレビュー関連：
+- **#Preview** (iOS 17+): プレビューマクロの簡略化
+- **@Previewable** (iOS 18+ / Xcode 16+): プレビュー内で直接@State使用
+
+### references/container.md
+コンテナ値・トランザクション：
+- **ContainerValues** (iOS 18+): 子→親への値伝達
+- **Transaction** (iOS 18+): アニメーション制御
+
+### references/theming.md
+テーマ・デザイン：
+- **Liquid Glass** (iOS 26+): iOS 7以来最大のUI刷新
+- **.liquidGlass()** (iOS 26+): Liquid Glassエフェクト
+- **.depthLayer()** (iOS 26+): 深度レイヤー設定
+
+### references/webview.md
+WebView関連：
+- **WebView** (iOS 26+): SwiftUIネイティブWebView
+- **Scene Bridging** (iOS 26+): UIKit/AppKitとSwiftUIシーンの統合
+
+## バージョン対応表（概要）
+
+| コンポーネント | iOS | 備考 |
+|--------------|-----|------|
+| NavigationStack | 16+ | NavigationViewの後継 |
+| Swift Charts | 16+ | 宣言的チャート |
+| PhotosPicker | 16+ | 権限不要の写真選択 |
+| Grid | 16+ | 柔軟なグリッド |
+| TipKit | 17+ | 機能発見ヒント |
+| scrollPosition | 17+ | スクロール位置制御 |
+| symbolEffect | 17+ | SFシンボルアニメ |
+| #Preview | 17+ | 簡易プレビュー |
+| ContainerValues | 18+ | 子→親値伝達 |
+| @Previewable | 18+ | プレビュー内@State |
+| Liquid Glass | 26+ | 新デザイン言語 |
+| WebView | 26+ | ネイティブWebView |
+| @Animatable | 26+ | アニメーションマクロ |
+| Chart3D | 26+ | 3Dチャート |
+
+## 使用方法
+
+### 新しいUIを実装する際
+1. 実装したい機能に対応するリファレンスファイルを参照
+2. バージョン対応表でプロジェクトのデプロイメントターゲットとの互換性を確認
+3. コード例を参考に実装
+
+### 利用可能なコンポーネントを探す際
+1. バージョン対応表でデプロイメントターゲット以下のコンポーネントを確認
+2. 該当するリファレンスファイルで詳細を確認
+
+## 関連スキル
+
+- **swift-ios-migration**: 移行ガイド（@Observable、Swift 6等）
+- **swiftui-coding-guidelines**: コーディングガイドライン
+- **swiftui-ssot**: 状態管理の設計

--- a/ios_development/skills/swiftui-components/references/animation.md
+++ b/ios_development/skills/swiftui-components/references/animation.md
@@ -1,0 +1,394 @@
+# アニメーションコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| symbolEffect | 17+ | 17+ | 14+ | SF Symbolsアニメーション |
+| contentTransition | 17+ | 17+ | 14+ | コンテンツ変更アニメ |
+| phaseAnimator | 17+ | 17+ | 14+ | 複数フェーズアニメ |
+| keyframeAnimator | 17+ | 17+ | 14+ | キーフレームアニメ |
+| sensoryFeedback | 17+ | 17+ | - | 触覚フィードバック |
+| @Animatable | 26+ | 26+ | 26+ | アニメーション対応マクロ |
+
+---
+
+## symbolEffect (iOS 17+)
+
+SF Symbolsに対してアニメーション効果を適用。
+
+### バウンスエフェクト
+
+```swift
+@State private var notificationCount = 0
+
+Image(systemName: "bell")
+    .symbolEffect(.bounce, value: notificationCount)
+
+Button("通知") {
+    notificationCount += 1
+}
+```
+
+### パルスエフェクト（繰り返し）
+
+```swift
+Image(systemName: "heart.fill")
+    .symbolEffect(.pulse.wholeSymbol, options: .repeating)
+```
+
+### 可変カラー
+
+```swift
+Image(systemName: "wifi")
+    .symbolEffect(.variableColor.iterative, options: .repeating)
+```
+
+### 制御付きアニメーション
+
+```swift
+@State private var isAnimating = false
+
+Image(systemName: "arrow.down.circle")
+    .symbolEffect(.bounce, options: .repeat(3), value: isAnimating)
+
+Button("アニメーション開始") {
+    isAnimating.toggle()
+}
+```
+
+### 置換アニメーション
+
+```swift
+@State private var isPlaying = false
+
+Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+    .contentTransition(.symbolEffect(.replace))
+
+Button("切り替え") {
+    withAnimation {
+        isPlaying.toggle()
+    }
+}
+```
+
+---
+
+## contentTransition (iOS 17+)
+
+テキストやコンテンツの変更をアニメーション化。
+
+### 数値のアニメーション
+
+```swift
+struct CounterView: View {
+    @State private var count = 0
+
+    var body: some View {
+        Text("\(count)")
+            .font(.largeTitle)
+            .contentTransition(.numericText())
+
+        Button("増加") {
+            withAnimation {
+                count += 1
+            }
+        }
+    }
+}
+```
+
+### 補間アニメーション
+
+```swift
+Text(status)
+    .contentTransition(.interpolate) // 補間アニメーション
+```
+
+### シンボル置換
+
+```swift
+Image(systemName: isFavorite ? "star.fill" : "star")
+    .contentTransition(.symbolEffect(.replace))
+```
+
+---
+
+## phaseAnimator (iOS 17+)
+
+複数フェーズのアニメーションを定義。
+
+### 基本的な使用法
+
+```swift
+struct PulsingView: View {
+    var body: some View {
+        Circle()
+            .fill(.blue)
+            .phaseAnimator([false, true]) { content, phase in
+                content
+                    .scaleEffect(phase ? 1.2 : 1.0)
+                    .opacity(phase ? 0.5 : 1.0)
+            } animation: { phase in
+                .easeInOut(duration: 0.5)
+            }
+    }
+}
+```
+
+### カスタムフェーズ
+
+```swift
+enum AnimationPhase: CaseIterable {
+    case initial, scaled, rotated, final
+}
+
+Circle()
+    .phaseAnimator(AnimationPhase.allCases) { content, phase in
+        content
+            .scaleEffect(phase == .scaled ? 1.5 : 1.0)
+            .rotationEffect(.degrees(phase == .rotated ? 180 : 0))
+    } animation: { phase in
+        switch phase {
+        case .initial: .easeIn(duration: 0.3)
+        case .scaled: .spring(duration: 0.5)
+        case .rotated: .easeOut(duration: 0.4)
+        case .final: .linear(duration: 0.2)
+        }
+    }
+```
+
+### トリガー付き
+
+```swift
+@State private var trigger = false
+
+Circle()
+    .phaseAnimator([0, 1, 2], trigger: trigger) { content, phase in
+        content
+            .scaleEffect(1.0 + Double(phase) * 0.1)
+    }
+
+Button("Animate") {
+    trigger.toggle()
+}
+```
+
+---
+
+## keyframeAnimator (iOS 17+)
+
+キーフレームベースの詳細なアニメーション制御。
+
+### 基本的な使用法
+
+```swift
+struct BouncingView: View {
+    @State private var trigger = false
+
+    var body: some View {
+        Circle()
+            .keyframeAnimator(
+                initialValue: AnimationValues(),
+                trigger: trigger
+            ) { content, value in
+                content
+                    .scaleEffect(value.scale)
+                    .offset(y: value.verticalOffset)
+            } keyframes: { _ in
+                KeyframeTrack(\.scale) {
+                    SpringKeyframe(1.2, duration: 0.2)
+                    SpringKeyframe(1.0, duration: 0.2)
+                }
+                KeyframeTrack(\.verticalOffset) {
+                    LinearKeyframe(-50, duration: 0.15)
+                    SpringKeyframe(0, duration: 0.3)
+                }
+            }
+
+        Button("Bounce") {
+            trigger.toggle()
+        }
+    }
+}
+
+struct AnimationValues {
+    var scale = 1.0
+    var verticalOffset = 0.0
+}
+```
+
+### 複雑なアニメーション
+
+```swift
+struct ComplexAnimationValues {
+    var scale = 1.0
+    var rotation = 0.0
+    var opacity = 1.0
+    var xOffset = 0.0
+}
+
+Rectangle()
+    .keyframeAnimator(
+        initialValue: ComplexAnimationValues(),
+        trigger: trigger
+    ) { content, value in
+        content
+            .scaleEffect(value.scale)
+            .rotationEffect(.degrees(value.rotation))
+            .opacity(value.opacity)
+            .offset(x: value.xOffset)
+    } keyframes: { _ in
+        KeyframeTrack(\.scale) {
+            CubicKeyframe(1.5, duration: 0.3)
+            CubicKeyframe(1.0, duration: 0.3)
+        }
+        KeyframeTrack(\.rotation) {
+            LinearKeyframe(360, duration: 0.6)
+        }
+        KeyframeTrack(\.opacity) {
+            LinearKeyframe(0.5, duration: 0.3)
+            LinearKeyframe(1.0, duration: 0.3)
+        }
+    }
+```
+
+---
+
+## sensoryFeedback (iOS 17+)
+
+触覚フィードバックの簡易化。`UIFeedbackGenerator`の代替。
+
+### 基本的な使用法
+
+```swift
+struct InteractiveView: View {
+    @State private var isSelected = false
+
+    var body: some View {
+        Button("選択") {
+            isSelected.toggle()
+        }
+        .sensoryFeedback(.selection, trigger: isSelected)
+    }
+}
+```
+
+### 成功・エラーフィードバック
+
+```swift
+Button("送信") {
+    submit()
+}
+.sensoryFeedback(.success, trigger: submitSucceeded)
+.sensoryFeedback(.error, trigger: submitFailed)
+```
+
+### カスタム条件
+
+```swift
+.sensoryFeedback(trigger: errorOccurred) { oldValue, newValue in
+    newValue ? .error : nil
+}
+```
+
+### フィードバックタイプ
+
+```swift
+.sensoryFeedback(.impact)           // 衝撃
+.sensoryFeedback(.selection)        // 選択
+.sensoryFeedback(.success)          // 成功
+.sensoryFeedback(.warning)          // 警告
+.sensoryFeedback(.error)            // エラー
+.sensoryFeedback(.increase)         // 増加
+.sensoryFeedback(.decrease)         // 減少
+```
+
+---
+
+## @Animatable マクロ (iOS 26+)
+
+従来の `animatableData` ボイラープレートを削減するマクロ。
+
+### Before (iOS 25以前)
+
+```swift
+struct LoadingArc: Shape {
+    var center: CGPoint
+    var radius: CGFloat
+    var startAngle: Angle
+    var endAngle: Angle
+    var drawPathClockwise: Bool
+
+    var animatableData: AnimatablePair<
+        AnimatablePair<CGPoint.AnimatableData, CGFloat>,
+        AnimatablePair<Angle.AnimatableData, Angle.AnimatableData>
+    > {
+        get {
+            AnimatablePair(
+                AnimatablePair(center.animatableData, radius),
+                AnimatablePair(startAngle.animatableData, endAngle.animatableData)
+            )
+        }
+        set {
+            center.animatableData = newValue.first.first
+            radius = newValue.first.second
+            startAngle.animatableData = newValue.second.first
+            endAngle.animatableData = newValue.second.second
+        }
+    }
+
+    func path(in rect: CGRect) -> Path {
+        // パス生成ロジック
+    }
+}
+```
+
+### After (iOS 26+)
+
+```swift
+import SwiftUI
+
+@Animatable
+struct LoadingArc: Shape {
+    var center: CGPoint
+    var radius: CGFloat
+    var startAngle: Angle
+    var endAngle: Angle
+
+    @AnimatableIgnored
+    var drawPathClockwise: Bool
+
+    func path(in rect: CGRect) -> Path {
+        // パス生成ロジック
+        Path()
+    }
+}
+```
+
+### @AnimatableIgnored
+
+アニメーション対象から除外するプロパティに使用。
+
+```swift
+@Animatable
+struct CustomShape: Shape {
+    var animatedValue: CGFloat      // アニメーション対象
+
+    @AnimatableIgnored
+    var staticConfig: Configuration // アニメーション対象外
+
+    func path(in rect: CGRect) -> Path {
+        // ...
+    }
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [symbolEffect - Apple Developer](https://developer.apple.com/documentation/swiftui/view/symboleffect(_:options:isactive:))
+- [ContentTransition - Apple Developer](https://developer.apple.com/documentation/swiftui/contenttransition)
+- [phaseAnimator - Apple Developer](https://developer.apple.com/documentation/swiftui/view/phaseanimator(_:content:animation:))
+- [keyframeAnimator - Apple Developer](https://developer.apple.com/documentation/swiftui/view/keyframeanimator(initialvalue:repeating:content:keyframes:))

--- a/ios_development/skills/swiftui-components/references/charts.md
+++ b/ios_development/skills/swiftui-components/references/charts.md
@@ -1,0 +1,219 @@
+# チャート・グラフコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| Swift Charts | 16+ | 16+ | 13+ | 宣言的チャートフレームワーク |
+| LineMark | 16+ | 16+ | 13+ | 折れ線グラフ |
+| BarMark | 16+ | 16+ | 13+ | 棒グラフ |
+| AreaMark | 16+ | 16+ | 13+ | 面グラフ |
+| PointMark | 16+ | 16+ | 13+ | 散布図 |
+| RectangleMark | 16+ | 16+ | 13+ | 矩形マーク |
+| RuleMark | 16+ | 16+ | 13+ | 線（軸線・参照線） |
+| Chart3D | 26+ | 26+ | - | 3Dチャート |
+
+---
+
+## Swift Charts (iOS 16+)
+
+iOS 16で導入された宣言的なチャートフレームワーク。
+
+### 基本的な折れ線グラフ
+
+```swift
+import Charts
+
+struct SalesData: Identifiable {
+    let id = UUID()
+    let month: String
+    let sales: Int
+}
+
+struct SalesChart: View {
+    let data: [SalesData]
+
+    var body: some View {
+        Chart(data) { item in
+            LineMark(
+                x: .value("月", item.month),
+                y: .value("売上", item.sales)
+            )
+        }
+    }
+}
+```
+
+### 棒グラフ
+
+```swift
+Chart(data) { item in
+    BarMark(
+        x: .value("カテゴリ", item.category),
+        y: .value("値", item.value)
+    )
+    .foregroundStyle(by: .value("タイプ", item.type))
+}
+```
+
+### 面グラフ
+
+```swift
+Chart(data) { item in
+    AreaMark(
+        x: .value("日付", item.date),
+        y: .value("値", item.value)
+    )
+    .foregroundStyle(.blue.opacity(0.3))
+}
+```
+
+### 散布図
+
+```swift
+Chart(data) { item in
+    PointMark(
+        x: .value("X", item.x),
+        y: .value("Y", item.y)
+    )
+    .symbolSize(item.size)
+}
+```
+
+### カスタマイズ
+
+```swift
+Chart(data) { item in
+    LineMark(
+        x: .value("日付", item.date),
+        y: .value("値", item.value)
+    )
+    .interpolationMethod(.catmullRom) // 曲線補間
+    .symbol(Circle())
+    .foregroundStyle(.blue)
+}
+.chartXAxis {
+    AxisMarks(values: .stride(by: .month)) { value in
+        AxisValueLabel(format: .dateTime.month(.abbreviated))
+    }
+}
+.chartYAxis {
+    AxisMarks(position: .leading)
+}
+.chartLegend(position: .bottom)
+```
+
+### 複合チャート
+
+```swift
+Chart {
+    ForEach(salesData) { item in
+        BarMark(
+            x: .value("月", item.month),
+            y: .value("売上", item.sales)
+        )
+        .foregroundStyle(.blue.opacity(0.5))
+    }
+
+    ForEach(targetData) { item in
+        LineMark(
+            x: .value("月", item.month),
+            y: .value("目標", item.target)
+        )
+        .foregroundStyle(.red)
+        .lineStyle(StrokeStyle(lineWidth: 2, dash: [5, 3]))
+    }
+
+    RuleMark(y: .value("平均", averageValue))
+        .foregroundStyle(.green)
+        .annotation(position: .trailing) {
+            Text("平均")
+                .font(.caption)
+        }
+}
+```
+
+### インタラクティブなチャート
+
+```swift
+struct InteractiveChart: View {
+    @State private var selectedElement: SalesData?
+
+    var body: some View {
+        Chart(data) { item in
+            BarMark(
+                x: .value("月", item.month),
+                y: .value("売上", item.sales)
+            )
+            .opacity(selectedElement == nil || selectedElement?.id == item.id ? 1 : 0.3)
+        }
+        .chartOverlay { proxy in
+            GeometryReader { geometry in
+                Rectangle()
+                    .fill(.clear)
+                    .contentShape(Rectangle())
+                    .gesture(
+                        DragGesture(minimumDistance: 0)
+                            .onChanged { value in
+                                let location = value.location
+                                if let month: String = proxy.value(atX: location.x) {
+                                    selectedElement = data.first { $0.month == month }
+                                }
+                            }
+                            .onEnded { _ in
+                                selectedElement = nil
+                            }
+                    )
+            }
+        }
+    }
+}
+```
+
+---
+
+## Chart3D (iOS 26+)
+
+iOS 26で導入された3Dチャートのネイティブサポート。
+
+### 基本的な使用法
+
+```swift
+import Charts
+
+Chart3D {
+    // PointMark, RuleMark, RectangleMark, SurfacePlot
+}
+```
+
+### 3D散布図
+
+```swift
+Chart3D(data) { item in
+    PointMark(
+        x: .value("X", item.x),
+        y: .value("Y", item.y),
+        z: .value("Z", item.z)
+    )
+}
+```
+
+> **注意**: Chart3Dは現在iPadOSとmacOSでは利用できません。
+
+---
+
+## 移行チェックリスト
+
+### Chart導入
+
+1. [ ] `import Charts`を追加
+2. [ ] データモデルを`Identifiable`に準拠
+3. [ ] 適切なMark（LineMark, BarMark等）を選択
+4. [ ] 軸とレジェンドをカスタマイズ
+
+---
+
+## 関連ドキュメント
+
+- [Swift Charts - Apple Developer](https://developer.apple.com/documentation/charts)
+- [Creating a chart using Swift Charts - Apple Developer](https://developer.apple.com/documentation/charts/creating-a-chart-using-swift-charts)

--- a/ios_development/skills/swiftui-components/references/container.md
+++ b/ios_development/skills/swiftui-components/references/container.md
@@ -1,0 +1,238 @@
+# コンテナ値・トランザクション
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| ContainerValues | 18+ | 18+ | 15+ | 子→親への値伝達 |
+| @Entry | 18+ | 18+ | 15+ | ContainerValue定義マクロ |
+| Transaction | 18+ | 18+ | 15+ | アニメーション制御強化 |
+
+---
+
+## ContainerValues (iOS 18+)
+
+子Viewから親コンテナに構成情報を伝える新しい仕組み。Preference Keyより直感的で型安全。
+
+### 基本的な使い方
+
+```swift
+// 1. ContainerValueを定義
+extension ContainerValues {
+    @Entry var columnSpan: Int = 1
+}
+
+// 2. 子Viewで値を設定
+struct WideCard: View {
+    var body: some View {
+        CardContent()
+            .containerValue(\.columnSpan, 2)  // 2列分を占有
+    }
+}
+
+// 3. 親コンテナで値を読み取り
+struct CustomGrid: View {
+    var body: some View {
+        Grid {
+            ForEach(subviewOf: self) { subview in
+                let span = subview.containerValues.columnSpan
+                GridRow {
+                    subview
+                        .gridCellColumns(span)
+                }
+            }
+        }
+    }
+}
+```
+
+### カスタムコンテナでの活用
+
+```swift
+// カスタム値の定義
+extension ContainerValues {
+    @Entry var priority: Priority = .normal
+    @Entry var isHighlighted: Bool = false
+}
+
+enum Priority: Int, Comparable {
+    case low, normal, high
+    static func < (lhs: Priority, rhs: Priority) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}
+
+// 子Viewで設定
+Text("重要なメッセージ")
+    .containerValue(\.priority, .high)
+    .containerValue(\.isHighlighted, true)
+
+// 親コンテナで読み取り・ソート
+struct PriorityList: View {
+    @ViewBuilder var content: some View
+
+    var body: some View {
+        VStack {
+            ForEach(subviewOf: content) { subview in
+                let priority = subview.containerValues.priority
+                let highlighted = subview.containerValues.isHighlighted
+
+                subview
+                    .background(highlighted ? Color.yellow.opacity(0.3) : Color.clear)
+            }
+        }
+    }
+}
+```
+
+### Preference Key との比較
+
+| 特徴 | ContainerValues | PreferenceKey |
+|------|-----------------|---------------|
+| 方向 | 子 → 直接の親コンテナ | 子 → 祖先全体 |
+| 型安全 | @Entryマクロで簡潔 | 手動でプロトコル準拠 |
+| 用途 | レイアウト情報、構成 | 集約値（サイズ、アンカーなど） |
+| iOS | 18+ | 13+ |
+
+---
+
+## Transaction (iOS 18+)
+
+アニメーションのコンテキスト自体を操作。親から伝播するアニメーションの無効化や上書きが可能。
+
+### 基本的なTransaction
+
+```swift
+struct ContentView: View {
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack {
+            Button("Toggle") {
+                // withAnimationの代わりにTransaction
+                var transaction = Transaction(animation: .spring(response: 0.3))
+                transaction.disablesAnimations = false
+
+                withTransaction(transaction) {
+                    isExpanded.toggle()
+                }
+            }
+
+            Rectangle()
+                .frame(width: isExpanded ? 200 : 100)
+        }
+    }
+}
+```
+
+### アニメーションの無効化
+
+親から伝播してきたアニメーションを子で無効化。
+
+```swift
+struct ChildView: View {
+    let value: Double
+
+    var body: some View {
+        Text("\(value, specifier: "%.1f")")
+            .transaction { transaction in
+                // 親からのアニメーションを無効化
+                transaction.disablesAnimations = true
+            }
+    }
+}
+
+// 親View
+struct ParentView: View {
+    @State private var value = 0.0
+
+    var body: some View {
+        VStack {
+            // このアニメーションはChildViewには適用されない
+            Slider(value: $value)
+                .animation(.easeInOut, value: value)
+
+            ChildView(value: value)
+        }
+    }
+}
+```
+
+### アニメーションの上書き
+
+```swift
+struct ContentView: View {
+    @State private var isOn = false
+
+    var body: some View {
+        VStack {
+            Toggle("Toggle", isOn: $isOn)
+
+            Circle()
+                .frame(width: isOn ? 100 : 50)
+                .transaction { transaction in
+                    // 親のアニメーションを上書き
+                    transaction.animation = .bouncy(duration: 0.5)
+                }
+        }
+        .animation(.linear, value: isOn)  // このアニメーションは上書きされる
+    }
+}
+```
+
+### 条件付きアニメーション
+
+```swift
+struct SmartAnimationView: View {
+    @State private var count = 0
+    @Environment(\.accessibilityReduceMotion) var reduceMotion
+
+    var body: some View {
+        Text("\(count)")
+            .font(.largeTitle)
+            .transaction { transaction in
+                if reduceMotion {
+                    transaction.disablesAnimations = true
+                } else {
+                    transaction.animation = .spring(response: 0.3)
+                }
+            }
+
+        Button("Increment") {
+            count += 1
+        }
+    }
+}
+```
+
+### 特定のビューのみアニメーション
+
+```swift
+struct SelectiveAnimationView: View {
+    @State private var isExpanded = false
+
+    var body: some View {
+        VStack {
+            // このビューはアニメーションする
+            Rectangle()
+                .frame(height: isExpanded ? 200 : 100)
+                .animation(.spring, value: isExpanded)
+
+            // このビューはアニメーションしない
+            Text("Status: \(isExpanded ? "Expanded" : "Collapsed")")
+                .transaction { $0.disablesAnimations = true }
+
+            Button("Toggle") {
+                isExpanded.toggle()
+            }
+        }
+    }
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [ContainerValues - Apple Developer](https://developer.apple.com/documentation/swiftui/containervalues)
+- [Transaction - Apple Developer](https://developer.apple.com/documentation/swiftui/transaction)

--- a/ios_development/skills/swiftui-components/references/layout.md
+++ b/ios_development/skills/swiftui-components/references/layout.md
@@ -1,0 +1,370 @@
+# レイアウトコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| Grid | 16+ | 16+ | 13+ | 柔軟なグリッドレイアウト |
+| GridRow | 16+ | 16+ | 13+ | グリッド行 |
+| ViewThatFits | 16+ | 16+ | 13+ | 自動ビュー選択 |
+| AnyLayout | 16+ | 16+ | 13+ | 動的レイアウト切り替え |
+| Gauge | 16+ | 16+ | 13+ | 進捗・レベル表示 |
+| Table | 16+ | 16+ | 12+ | 表形式データ（主にmacOS/iPadOS） |
+| TextField(axis:) | 16+ | 16+ | 13+ | 複数行テキストフィールド |
+| ToolbarSpacer | 26+ | 26+ | 26+ | ツールバースペース制御 |
+| labelIconToTitleSpacing | 26+ | 26+ | 26+ | Labelスペース調整 |
+
+---
+
+## Grid (iOS 16+)
+
+より柔軟なグリッドレイアウト。LazyVGrid/LazyHGridと異なり、すべてのセルが一度にレンダリングされる。
+
+### 基本的な使用法
+
+```swift
+Grid {
+    GridRow {
+        Text("1")
+        Text("2")
+        Text("3")
+    }
+    GridRow {
+        Text("4")
+        Text("5")
+        Text("6")
+    }
+}
+```
+
+### 複数列にまたがるセル
+
+```swift
+Grid {
+    GridRow {
+        Text("1")
+        Text("2")
+        Text("3")
+    }
+    GridRow {
+        Text("4")
+        Text("5")
+            .gridCellColumns(2) // 2列分を占有
+    }
+    Divider()
+        .gridCellUnsizedAxes(.horizontal)
+    GridRow {
+        Text("7")
+        Text("8")
+        Text("9")
+    }
+}
+```
+
+### アライメント
+
+```swift
+Grid(alignment: .leading, horizontalSpacing: 10, verticalSpacing: 10) {
+    GridRow {
+        Text("Name:")
+            .gridColumnAlignment(.trailing)
+        Text("John Doe")
+    }
+    GridRow {
+        Text("Email:")
+        Text("john@example.com")
+    }
+}
+```
+
+---
+
+## ViewThatFits (iOS 16+)
+
+利用可能なスペースに応じてビューを自動選択。
+
+### 基本的な使用法
+
+```swift
+ViewThatFits {
+    // 優先度順に試行
+    HStack {
+        Image(systemName: "star")
+        Text("お気に入りに追加")
+    }
+
+    // スペースが足りない場合
+    HStack {
+        Image(systemName: "star")
+        Text("追加")
+    }
+
+    // さらにスペースが足りない場合
+    Image(systemName: "star")
+}
+```
+
+### 軸を指定
+
+```swift
+ViewThatFits(in: .horizontal) {
+    // 水平方向のスペースのみをチェック
+    WideView()
+    NarrowView()
+}
+```
+
+---
+
+## AnyLayout (iOS 16+)
+
+条件に応じてレイアウトを動的に切り替え。
+
+### 基本的な使用法
+
+```swift
+struct AdaptiveView: View {
+    @Environment(\.horizontalSizeClass) var sizeClass
+
+    var layout: AnyLayout {
+        sizeClass == .compact
+            ? AnyLayout(VStackLayout())
+            : AnyLayout(HStackLayout())
+    }
+
+    var body: some View {
+        layout {
+            Image(systemName: "photo")
+            Text("タイトル")
+            Text("説明文")
+        }
+    }
+}
+```
+
+### アニメーション付きレイアウト変更
+
+```swift
+struct AnimatedLayoutView: View {
+    @State private var isGrid = false
+
+    var layout: AnyLayout {
+        isGrid
+            ? AnyLayout(GridLayout())
+            : AnyLayout(VStackLayout(spacing: 10))
+    }
+
+    var body: some View {
+        layout {
+            ForEach(items) { item in
+                ItemView(item: item)
+            }
+        }
+        .animation(.spring(), value: isGrid)
+
+        Toggle("Grid View", isOn: $isGrid)
+    }
+}
+```
+
+---
+
+## Gauge (iOS 16+)
+
+進捗やレベルを視覚的に表示。
+
+### 基本的なゲージ
+
+```swift
+Gauge(value: 0.7) {
+    Text("進捗")
+}
+```
+
+### 範囲とラベル付き
+
+```swift
+Gauge(value: 75, in: 0...100) {
+    Text("バッテリー")
+} currentValueLabel: {
+    Text("75%")
+} minimumValueLabel: {
+    Text("0")
+} maximumValueLabel: {
+    Text("100")
+}
+```
+
+### スタイル
+
+```swift
+// 線形
+Gauge(value: 0.5) {
+    Text("レベル")
+}
+.gaugeStyle(.linearCapacity)
+
+// 円形アクセサリ
+Gauge(value: 0.5) {
+    Text("レベル")
+}
+.gaugeStyle(.accessoryCircular)
+
+// その他のスタイル
+// .accessoryLinear
+// .accessoryCircularCapacity
+```
+
+### カスタムゲージ
+
+```swift
+Gauge(value: progress) {
+    Image(systemName: "heart.fill")
+} currentValueLabel: {
+    Text("\(Int(progress * 100))%")
+}
+.tint(Gradient(colors: [.green, .yellow, .red]))
+```
+
+---
+
+## Table (iOS 16+)
+
+表形式のデータ表示。主にmacOSとiPadOS向け。
+
+### 基本的な使用法
+
+```swift
+struct Person: Identifiable {
+    let id = UUID()
+    var name: String
+    var age: Int
+    var email: String
+}
+
+struct PeopleTable: View {
+    @State private var people: [Person] = [...]
+    @State private var selection: Set<Person.ID> = []
+    @State private var sortOrder = [KeyPathComparator(\Person.name)]
+
+    var body: some View {
+        Table(people, selection: $selection, sortOrder: $sortOrder) {
+            TableColumn("名前", value: \.name)
+            TableColumn("年齢") { person in
+                Text("\(person.age)")
+            }
+            TableColumn("メール", value: \.email)
+        }
+        .onChange(of: sortOrder) { newOrder in
+            people.sort(using: newOrder)
+        }
+    }
+}
+```
+
+---
+
+## TextField改善 (iOS 16+)
+
+### 軸方向の拡張
+
+```swift
+TextField("メッセージ", text: $message, axis: .vertical)
+    .lineLimit(3...6) // 3〜6行で自動拡張
+```
+
+### フォーカス制御の強化
+
+```swift
+enum Field: Hashable {
+    case username, password
+}
+
+struct LoginForm: View {
+    @State private var username = ""
+    @State private var password = ""
+    @FocusState private var focusedField: Field?
+
+    var body: some View {
+        Form {
+            TextField("ユーザー名", text: $username)
+                .focused($focusedField, equals: .username)
+                .submitLabel(.next)
+                .onSubmit {
+                    focusedField = .password
+                }
+
+            SecureField("パスワード", text: $password)
+                .focused($focusedField, equals: .password)
+                .submitLabel(.done)
+        }
+    }
+}
+```
+
+### defaultFocus (iOS 17+)
+
+```swift
+struct FormView: View {
+    @State private var email = ""
+    @State private var password = ""
+    @FocusState private var focusedField: Field?
+
+    var body: some View {
+        Form {
+            TextField("メール", text: $email)
+                .focused($focusedField, equals: .email)
+            SecureField("パスワード", text: $password)
+                .focused($focusedField, equals: .password)
+        }
+        .defaultFocus($focusedField, .email) // 初期フォーカス
+    }
+}
+```
+
+---
+
+## ToolbarSpacer (iOS 26+)
+
+ツールバーアイテム間のスペース制御。
+
+```swift
+struct ContentView: View {
+    var body: some View {
+        NavigationStack {
+            Content()
+                .toolbar {
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button("Action 1") { }
+                        ToolbarSpacer()
+                        Button("Action 2") { }
+                    }
+                }
+        }
+    }
+}
+```
+
+---
+
+## labelIconToTitleSpacing (iOS 26+)
+
+Labelのアイコンとテキスト間のスペース調整。
+
+```swift
+Label("Hello", systemImage: "globe")
+    .labelIconToTitleSpacing(8)
+
+Label("Settings", systemImage: "gear")
+    .labelIconToTitleSpacing(12)
+```
+
+---
+
+## 関連ドキュメント
+
+- [Grid - Apple Developer](https://developer.apple.com/documentation/swiftui/grid)
+- [ViewThatFits - Apple Developer](https://developer.apple.com/documentation/swiftui/viewthatfits)
+- [AnyLayout - Apple Developer](https://developer.apple.com/documentation/swiftui/anylayout)
+- [Gauge - Apple Developer](https://developer.apple.com/documentation/swiftui/gauge)
+- [Table - Apple Developer](https://developer.apple.com/documentation/swiftui/table)

--- a/ios_development/skills/swiftui-components/references/media.md
+++ b/ios_development/skills/swiftui-components/references/media.md
@@ -1,0 +1,205 @@
+# メディア・共有コンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| PhotosPicker | 16+ | 16+ | 13+ | 権限不要の写真選択 |
+| ShareLink | 16+ | 16+ | 13+ | 標準シェア機能 |
+| Transferable | 16+ | 16+ | 13+ | データ転送プロトコル |
+
+---
+
+## PhotosPicker (iOS 16+)
+
+写真ライブラリへのアクセス権限なしで写真を選択可能。
+
+### 基本的な使用法
+
+```swift
+import PhotosUI
+
+struct PhotoSelectorView: View {
+    @State private var selectedItem: PhotosPickerItem?
+    @State private var selectedImage: Image?
+
+    var body: some View {
+        VStack {
+            if let image = selectedImage {
+                image
+                    .resizable()
+                    .scaledToFit()
+            }
+
+            PhotosPicker(
+                selection: $selectedItem,
+                matching: .images
+            ) {
+                Label("写真を選択", systemImage: "photo")
+            }
+        }
+        .onChange(of: selectedItem) { newItem in
+            Task {
+                if let data = try? await newItem?.loadTransferable(type: Data.self),
+                   let uiImage = UIImage(data: data) {
+                    selectedImage = Image(uiImage: uiImage)
+                }
+            }
+        }
+    }
+}
+```
+
+### 複数選択
+
+```swift
+@State private var selectedItems: [PhotosPickerItem] = []
+@State private var selectedImages: [Image] = []
+
+PhotosPicker(
+    selection: $selectedItems,
+    maxSelectionCount: 5,
+    matching: .images
+) {
+    Text("最大5枚選択")
+}
+.onChange(of: selectedItems) { newItems in
+    Task {
+        selectedImages = []
+        for item in newItems {
+            if let data = try? await item.loadTransferable(type: Data.self),
+               let uiImage = UIImage(data: data) {
+                selectedImages.append(Image(uiImage: uiImage))
+            }
+        }
+    }
+}
+```
+
+### フィルタリング
+
+```swift
+// 画像のみ（スクリーンショット除外）
+PhotosPicker(
+    selection: $selectedItems,
+    matching: .any(of: [.images, .not(.screenshots)])
+) { ... }
+
+// 動画のみ
+PhotosPicker(
+    selection: $selectedItems,
+    matching: .videos
+) { ... }
+
+// ライブフォト
+PhotosPicker(
+    selection: $selectedItems,
+    matching: .livePhotos
+) { ... }
+
+// 画像と動画
+PhotosPicker(
+    selection: $selectedItems,
+    matching: .any(of: [.images, .videos])
+) { ... }
+```
+
+---
+
+## ShareLink (iOS 16+)
+
+標準のシェア機能をSwiftUIで簡単に実装。
+
+### 基本的な使用法
+
+```swift
+// URL共有
+ShareLink(item: URL(string: "https://example.com")!)
+
+// カスタムラベル
+ShareLink(item: article.url) {
+    Label("共有", systemImage: "square.and.arrow.up")
+}
+
+// プレビュー付き
+ShareLink(
+    item: photo,
+    subject: Text("写真を共有"),
+    message: Text("この写真を見てください"),
+    preview: SharePreview(
+        photo.title,
+        image: photo.image
+    )
+)
+```
+
+### Transferableプロトコル
+
+カスタム型をシェア可能にする。
+
+```swift
+struct Article: Transferable {
+    var title: String
+    var body: String
+    var url: URL
+
+    static var transferRepresentation: some TransferRepresentation {
+        ProxyRepresentation(exporting: \.url)
+    }
+}
+
+// 使用
+ShareLink(item: article, preview: SharePreview(article.title))
+```
+
+### 複数のTransferRepresentation
+
+```swift
+struct Document: Transferable {
+    var title: String
+    var content: String
+    var pdfData: Data
+
+    static var transferRepresentation: some TransferRepresentation {
+        // PDF形式
+        DataRepresentation(exportedContentType: .pdf) { document in
+            document.pdfData
+        }
+
+        // プレーンテキスト形式
+        CodableRepresentation(contentType: .plainText)
+
+        // URL形式（フォールバック）
+        ProxyRepresentation(exporting: \.shareURL)
+    }
+
+    var shareURL: URL {
+        URL(string: "https://example.com/doc/\(title)")!
+    }
+}
+```
+
+---
+
+## 移行チェックリスト
+
+### PhotosPicker導入
+
+1. [ ] `import PhotosUI`を追加
+2. [ ] `PHPhotoLibrary`の許可リクエストが不要に
+3. [ ] `UIImagePickerController`を置換
+4. [ ] 非同期で画像データをロード
+
+### ShareLink導入
+
+1. [ ] 共有するデータ型を`Transferable`に準拠
+2. [ ] 適切なプレビューを提供
+3. [ ] `UIActivityViewController`を置換
+
+---
+
+## 関連ドキュメント
+
+- [PhotosPicker - Apple Developer](https://developer.apple.com/documentation/photosui/photospicker)
+- [ShareLink - Apple Developer](https://developer.apple.com/documentation/swiftui/sharelink)
+- [Transferable - Apple Developer](https://developer.apple.com/documentation/coretransferable/transferable)

--- a/ios_development/skills/swiftui-components/references/navigation.md
+++ b/ios_development/skills/swiftui-components/references/navigation.md
@@ -1,0 +1,232 @@
+# ナビゲーションコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| NavigationStack | 16+ | 16+ | 13+ | NavigationViewの後継 |
+| NavigationSplitView | 16+ | 16+ | 13+ | 2列/3列レイアウト |
+| NavigationPath | 16+ | 16+ | 13+ | 複数型のナビゲーションパス |
+| navigationDestination | 16+ | 16+ | 13+ | 宣言的な遷移先定義 |
+| TabView (iOS 26刷新) | 26+ | 26+ | - | 新デザイン・アニメーション |
+
+---
+
+## NavigationStack
+
+iOS 16で導入された`NavigationView`の後継。プログラマティックなナビゲーション制御が可能。
+
+### 基本的な使用法
+
+```swift
+// iOS 15以前: NavigationView（非推奨）
+NavigationView {
+    List(items) { item in
+        NavigationLink(destination: DetailView(item: item)) {
+            Text(item.name)
+        }
+    }
+}
+
+// iOS 16+: NavigationStack
+NavigationStack {
+    List(items) { item in
+        NavigationLink(value: item) {
+            Text(item.name)
+        }
+    }
+    .navigationDestination(for: Item.self) { item in
+        DetailView(item: item)
+    }
+}
+```
+
+### プログラマティックナビゲーション
+
+```swift
+struct ContentView: View {
+    @State private var path: [Item] = []
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            List(items) { item in
+                NavigationLink(value: item) {
+                    Text(item.name)
+                }
+            }
+            .navigationDestination(for: Item.self) { item in
+                DetailView(item: item)
+            }
+        }
+    }
+
+    // プログラムでナビゲーション
+    func navigateTo(_ item: Item) {
+        path.append(item)
+    }
+
+    // ルートに戻る
+    func popToRoot() {
+        path.removeAll()
+    }
+}
+```
+
+### NavigationPath（複数の型をサポート）
+
+```swift
+struct ContentView: View {
+    @State private var path = NavigationPath()
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            VStack {
+                Button("Show User") {
+                    path.append(User(name: "John"))
+                }
+                Button("Show Article") {
+                    path.append(Article(title: "News"))
+                }
+            }
+            .navigationDestination(for: User.self) { user in
+                UserDetailView(user: user)
+            }
+            .navigationDestination(for: Article.self) { article in
+                ArticleDetailView(article: article)
+            }
+        }
+    }
+}
+```
+
+---
+
+## NavigationSplitView
+
+2列または3列のレイアウトを提供。iPadやMacでのマスター・ディテール表示に最適。
+
+### 2列レイアウト
+
+```swift
+NavigationSplitView {
+    // サイドバー
+    List(categories, selection: $selectedCategory) { category in
+        Text(category.name)
+    }
+} detail: {
+    // 詳細ビュー
+    if let category = selectedCategory {
+        CategoryDetailView(category: category)
+    } else {
+        Text("カテゴリを選択してください")
+    }
+}
+```
+
+### 3列レイアウト
+
+```swift
+NavigationSplitView {
+    // サイドバー
+    CategoryList(selection: $selectedCategory)
+} content: {
+    // コンテンツ列
+    if let category = selectedCategory {
+        ItemList(category: category, selection: $selectedItem)
+    }
+} detail: {
+    // 詳細列
+    if let item = selectedItem {
+        ItemDetailView(item: item)
+    }
+}
+```
+
+### カラム幅のカスタマイズ
+
+```swift
+NavigationSplitView(columnVisibility: $columnVisibility) {
+    Sidebar()
+} content: {
+    Content()
+} detail: {
+    Detail()
+}
+.navigationSplitViewColumnWidth(min: 180, ideal: 200, max: 250)
+```
+
+---
+
+## 後方互換性
+
+iOS 15以前をサポートする場合：
+
+```swift
+var body: some View {
+    if #available(iOS 16.0, *) {
+        NavigationStack {
+            content
+        }
+    } else {
+        NavigationView {
+            content
+        }
+        .navigationViewStyle(.stack)
+    }
+}
+```
+
+---
+
+## TabView刷新 (iOS 26+)
+
+iOS 26ではiPhoneのTabViewのUI/UXが刷新。
+
+### 特徴
+
+- 新しいビジュアルデザイン（Liquid Glassとの統合）
+- スムーズなアニメーション
+- よりモダンなタブ切り替え体験
+
+### 基本的な使用法
+
+```swift
+TabView {
+    HomeView()
+        .tabItem {
+            Label("ホーム", systemImage: "house")
+        }
+
+    SearchView()
+        .tabItem {
+            Label("検索", systemImage: "magnifyingglass")
+        }
+
+    ProfileView()
+        .tabItem {
+            Label("プロフィール", systemImage: "person")
+        }
+}
+```
+
+> **注意**: iOS 26では標準のTabViewが自動的に新デザインに更新されます。特別な対応は不要ですが、カスタマイズしている場合は確認が必要です。
+
+---
+
+## 移行チェックリスト
+
+### NavigationViewからの移行
+
+1. [ ] `NavigationView`を`NavigationStack`または`NavigationSplitView`に置換
+2. [ ] `NavigationLink(destination:)`を`NavigationLink(value:)`に変更
+3. [ ] `.navigationDestination(for:)`を追加
+4. [ ] プログラマティックナビゲーションには`@State`でパスを管理
+5. [ ] `.navigationViewStyle(.stack)`を削除（NavigationStackはデフォルトでスタック）
+
+---
+
+## 関連ドキュメント
+
+- [NavigationStack - Apple Developer](https://developer.apple.com/documentation/swiftui/navigationstack)
+- [NavigationSplitView - Apple Developer](https://developer.apple.com/documentation/swiftui/navigationsplitview)
+- [NavigationPath - Apple Developer](https://developer.apple.com/documentation/swiftui/navigationpath)

--- a/ios_development/skills/swiftui-components/references/preview.md
+++ b/ios_development/skills/swiftui-components/references/preview.md
@@ -1,0 +1,247 @@
+# プレビューコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | Xcode | 備考 |
+|--------------|-----|--------|-------|-------|------|
+| #Preview | 17+ | 17+ | 14+ | 15+ | 簡略化されたプレビューマクロ |
+| @Previewable | 18+ | 18+ | 15+ | 16+ | プレビュー内で@State使用可能 |
+
+---
+
+## #Preview マクロ (iOS 17+)
+
+従来の`PreviewProvider`プロトコルを置き換える簡略化されたプレビュー構文。
+
+### 基本的な使用法
+
+```swift
+// iOS 16以前: PreviewProvider
+struct ArticleView_Previews: PreviewProvider {
+    static var previews: some View {
+        ArticleView(article: .sample)
+    }
+}
+
+// iOS 17+: #Previewマクロ
+#Preview {
+    ArticleView(article: .sample)
+}
+```
+
+### 名前付きプレビュー
+
+```swift
+#Preview("通常状態") {
+    ContentView(state: .normal)
+}
+
+#Preview("エラー状態") {
+    ContentView(state: .error)
+}
+
+#Preview("ローディング状態") {
+    ContentView(state: .loading)
+}
+```
+
+### ダークモード
+
+```swift
+#Preview("ダークモード") {
+    ArticleView(article: .sample)
+        .preferredColorScheme(.dark)
+}
+```
+
+### デバイス回転
+
+```swift
+#Preview(traits: .landscapeLeft) {
+    ArticleView(article: .sample)
+}
+
+#Preview(traits: .portrait) {
+    ArticleView(article: .sample)
+}
+```
+
+### 固定サイズ
+
+```swift
+#Preview(traits: .fixedLayout(width: 300, height: 200)) {
+    CardView(card: .sample)
+}
+```
+
+### 複数のトレイト
+
+```swift
+#Preview(traits: .landscapeLeft, .sizeThatFitsLayout) {
+    MyView()
+}
+```
+
+---
+
+## @Previewable (iOS 18+ / Xcode 16+)
+
+プレビュー内で直接`@State`を使用可能に。ラッパーViewが不要。
+
+### 基本的な使用法
+
+```swift
+// iOS 17以前: ラッパーViewが必要だった
+struct TogglePreviewWrapper: View {
+    @State private var isOn = false
+
+    var body: some View {
+        MyToggle(isOn: $isOn)
+    }
+}
+
+#Preview {
+    TogglePreviewWrapper()
+}
+
+// iOS 18 / Xcode 16: @Previewableで直接定義
+#Preview {
+    @Previewable @State var isOn = false
+    MyToggle(isOn: $isOn)
+}
+```
+
+### 複数の状態を持つプレビュー
+
+```swift
+#Preview("Form Preview") {
+    @Previewable @State var name = ""
+    @Previewable @State var email = ""
+    @Previewable @State var isSubscribed = true
+
+    Form {
+        TextField("Name", text: $name)
+        TextField("Email", text: $email)
+        Toggle("Subscribe", isOn: $isSubscribed)
+    }
+}
+```
+
+### インタラクティブなプレビュー
+
+```swift
+#Preview("Counter") {
+    @Previewable @State var count = 0
+
+    VStack(spacing: 20) {
+        Text("Count: \(count)")
+            .font(.largeTitle)
+
+        HStack {
+            Button("-") { count -= 1 }
+            Button("+") { count += 1 }
+        }
+        .buttonStyle(.borderedProminent)
+    }
+}
+```
+
+### 環境値との組み合わせ
+
+```swift
+#Preview("Dark Mode") {
+    @Previewable @State var text = ""
+
+    TextField("Input", text: $text)
+        .preferredColorScheme(.dark)
+}
+
+#Preview("Large Text") {
+    @Previewable @State var isOn = false
+
+    Toggle("Option", isOn: $isOn)
+        .environment(\.sizeCategory, .accessibilityExtraLarge)
+}
+```
+
+### スライダー付きプレビュー
+
+```swift
+#Preview("Adjustable") {
+    @Previewable @State var progress: Double = 0.5
+
+    VStack {
+        ProgressView(value: progress)
+        Slider(value: $progress)
+    }
+    .padding()
+}
+```
+
+---
+
+## プレビューのベストプラクティス
+
+### サンプルデータの用意
+
+```swift
+extension Article {
+    static var sample: Article {
+        Article(
+            id: UUID(),
+            title: "サンプル記事",
+            content: "これはプレビュー用のサンプルコンテンツです。"
+        )
+    }
+}
+
+#Preview {
+    ArticleView(article: .sample)
+}
+```
+
+### 複数状態のプレビュー
+
+```swift
+#Preview("Empty") {
+    ListView(items: [])
+}
+
+#Preview("Few Items") {
+    ListView(items: Array(repeating: .sample, count: 3))
+}
+
+#Preview("Many Items") {
+    ListView(items: Array(repeating: .sample, count: 50))
+}
+```
+
+### 環境設定のバリエーション
+
+```swift
+#Preview("Default") {
+    MyView()
+}
+
+#Preview("Dark Mode") {
+    MyView()
+        .preferredColorScheme(.dark)
+}
+
+#Preview("RTL") {
+    MyView()
+        .environment(\.layoutDirection, .rightToLeft)
+}
+
+#Preview("Large Dynamic Type") {
+    MyView()
+        .environment(\.sizeCategory, .accessibilityLarge)
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [Preview - Apple Developer](https://developer.apple.com/documentation/swiftui/preview())
+- [Previewable - Apple Developer](https://developer.apple.com/documentation/swiftui/previewable)

--- a/ios_development/skills/swiftui-components/references/scroll.md
+++ b/ios_development/skills/swiftui-components/references/scroll.md
@@ -1,0 +1,241 @@
+# スクロールコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| scrollPosition | 17+ | 17+ | 14+ | スクロール位置の取得・設定 |
+| scrollTargetBehavior | 17+ | 17+ | 14+ | スナップスクロール |
+| scrollTargetLayout | 17+ | 17+ | 14+ | スクロールターゲットレイアウト |
+| containerRelativeFrame | 17+ | 17+ | 14+ | 親コンテナ相対サイズ |
+| scrollIndicators | 16+ | 16+ | 13+ | スクロールインジケータ制御 |
+| scrollClipDisabled | 17+ | 17+ | 14+ | クリッピング無効化 |
+| safeAreaPadding | 17+ | 17+ | 14+ | 安全領域余白 |
+
+---
+
+## scrollPosition (iOS 17+)
+
+スクロール位置の取得と設定を可能にする。
+
+### 基本的な使用法
+
+```swift
+struct ArticleList: View {
+    @State private var scrollPosition: Int?
+    let articles: [Article]
+
+    var body: some View {
+        ScrollView {
+            LazyVStack {
+                ForEach(articles) { article in
+                    ArticleRow(article: article)
+                        .id(article.id)
+                }
+            }
+            .scrollTargetLayout()
+        }
+        .scrollPosition(id: $scrollPosition)
+
+        // 特定の位置にスクロール
+        Button("先頭へ") {
+            withAnimation {
+                scrollPosition = articles.first?.id
+            }
+        }
+    }
+}
+```
+
+### String IDでの使用
+
+```swift
+struct ScrollableList: View {
+    @State private var scrollPosition: String?
+    let items = (1...100).map { "Item \($0)" }
+
+    var body: some View {
+        VStack {
+            // 現在位置の表示
+            Text("Current: \(scrollPosition ?? "none")")
+
+            ScrollView {
+                LazyVStack {
+                    ForEach(items, id: \.self) { item in
+                        Text(item)
+                            .frame(height: 50)
+                    }
+                }
+                .scrollTargetLayout()
+            }
+            .scrollPosition(id: $scrollPosition)
+
+            // プログラムでスクロール
+            Button("Go to Item 50") {
+                withAnimation {
+                    scrollPosition = "Item 50"
+                }
+            }
+        }
+    }
+}
+```
+
+---
+
+## scrollTargetBehavior (iOS 17+)
+
+スクロールのスナップ動作を制御。
+
+### ビュー単位のスナップ
+
+```swift
+ScrollView(.horizontal) {
+    LazyHStack(spacing: 16) {
+        ForEach(cards) { card in
+            CardView(card: card)
+                .containerRelativeFrame(.horizontal)
+        }
+    }
+    .scrollTargetLayout()
+}
+.scrollTargetBehavior(.viewAligned) // ビュー単位でスナップ
+```
+
+### ページング
+
+```swift
+ScrollView(.horizontal) {
+    LazyHStack(spacing: 0) {
+        ForEach(pages) { page in
+            PageView(page: page)
+                .containerRelativeFrame(.horizontal)
+        }
+    }
+    .scrollTargetLayout()
+}
+.scrollTargetBehavior(.paging) // ページング動作
+```
+
+---
+
+## containerRelativeFrame (iOS 17+)
+
+親コンテナに対する相対的なサイズ指定。
+
+### 基本的な使用法
+
+```swift
+ScrollView(.horizontal) {
+    LazyHStack {
+        ForEach(items) { item in
+            ItemView(item: item)
+                .containerRelativeFrame(.horizontal, count: 3, spacing: 8)
+                // 画面幅を3分割したサイズ
+        }
+    }
+}
+```
+
+### カード表示例
+
+```swift
+ScrollView(.horizontal) {
+    LazyHStack(spacing: 16) {
+        ForEach(cards) { card in
+            CardView(card: card)
+                .containerRelativeFrame(.horizontal) { width, _ in
+                    width * 0.85  // 画面幅の85%
+                }
+        }
+    }
+    .scrollTargetLayout()
+}
+.scrollTargetBehavior(.viewAligned)
+.contentMargins(.horizontal, 16, for: .scrollContent)
+```
+
+---
+
+## scrollIndicators (iOS 16+)
+
+スクロールインジケータの表示制御。
+
+```swift
+ScrollView {
+    content
+}
+.scrollIndicators(.hidden) // スクロールインジケータを非表示
+
+.scrollIndicators(.visible, axes: .vertical) // 垂直のみ表示
+
+.scrollIndicators(.automatic) // 自動（デフォルト）
+```
+
+---
+
+## scrollClipDisabled (iOS 17+)
+
+スクロールビューのクリッピングを無効化。シャドウやオーバーフロー要素を表示可能に。
+
+```swift
+ScrollView(.horizontal) {
+    LazyHStack {
+        ForEach(cards) { card in
+            CardView(card: card)
+                .shadow(radius: 10) // シャドウがクリップされない
+        }
+    }
+    .padding(.vertical, 20)
+}
+.scrollClipDisabled()
+```
+
+---
+
+## safeAreaPadding (iOS 17+)
+
+安全領域に余白を追加。フローティングUIの配置に便利。
+
+```swift
+ScrollView {
+    content
+}
+.safeAreaPadding(.bottom, 80) // 下部にフローティングボタン用のスペース
+
+// 全方向
+.safeAreaPadding(20)
+
+// 特定の辺
+.safeAreaPadding(.horizontal, 16)
+```
+
+---
+
+## 後方互換性
+
+iOS 16以前をサポートする場合：
+
+```swift
+var body: some View {
+    if #available(iOS 17.0, *) {
+        content
+            .scrollPosition(id: $position)
+    } else {
+        ScrollViewReader { proxy in
+            content
+                .onChange(of: targetId) { id in
+                    proxy.scrollTo(id)
+                }
+        }
+    }
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [ScrollPosition - Apple Developer](https://developer.apple.com/documentation/swiftui/scrollposition)
+- [scrollTargetBehavior - Apple Developer](https://developer.apple.com/documentation/swiftui/view/scrolltargetbehavior(_:))
+- [containerRelativeFrame - Apple Developer](https://developer.apple.com/documentation/swiftui/view/containerrelativeframe(_:count:span:spacing:alignment:))

--- a/ios_development/skills/swiftui-components/references/theming.md
+++ b/ios_development/skills/swiftui-components/references/theming.md
@@ -1,0 +1,126 @@
+# テーマ・デザインコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| Liquid Glass | 26+ | 26+ | 26+ | iOS 7以来最大のUI刷新 |
+| .liquidGlass() | 26+ | 26+ | 26+ | Liquid Glassエフェクト |
+| .depthLayer() | 26+ | 26+ | 26+ | 深度レイヤー設定 |
+| .adaptiveTint() | 26+ | 26+ | 26+ | 適応型ティント |
+
+---
+
+## Liquid Glass (iOS 26+)
+
+iOS 7以来最大のUI刷新。visionOSにインスパイアされた半透明・ガラス風デザイン。
+
+### 概要
+
+- 光、コンテンツ、入力に反応する動的なUI要素
+- 標準UIKit/SwiftUIコンポーネントは自動的に新デザインに適用
+- カスタムUIは調整が必要な場合あり
+
+### 基本的な使用法
+
+```swift
+// Liquid Glass エフェクトの適用
+View()
+    .liquidGlass(.prominent)
+    .depthLayer(.background)
+    .adaptiveTint(.system)
+```
+
+### スタイルオプション
+
+```swift
+// 目立つスタイル
+.liquidGlass(.prominent)
+
+// 控えめなスタイル
+.liquidGlass(.subtle)
+
+// カスタムティント
+.liquidGlass(.prominent)
+    .tint(.blue)
+```
+
+### 深度レイヤー
+
+```swift
+// 背景レイヤー
+.depthLayer(.background)
+
+// 前面レイヤー
+.depthLayer(.foreground)
+
+// オーバーレイレイヤー
+.depthLayer(.overlay)
+```
+
+---
+
+## 移行オプション
+
+### 猶予期間
+
+- Xcode 26では1年間の猶予期間あり
+- Liquid Glassを無効化して従来UIを維持可能
+- 段階的な移行を推奨
+
+### 無効化方法
+
+```swift
+// Info.plistで設定
+// UIDisableLiquidGlass = YES
+```
+
+---
+
+## デザインガイドライン
+
+### 推奨事項
+
+- 全面画像背景の活用を推奨
+- コンテンツの読みやすさを確保
+- 既存のブラー効果との競合に注意
+
+### 注意点
+
+- カスタムビューの透明度やブラー効果を見直す必要がある可能性
+- 既存のカスタムUIがLiquid Glassと調和するか確認
+- ダークモード・ライトモード両方でテスト
+
+### 自動適用されるコンポーネント
+
+以下の標準コンポーネントは自動的にLiquid Glassスタイルが適用されます：
+
+- NavigationBar
+- TabBar
+- ToolBar
+- Alert
+- ActionSheet
+- Sheets
+
+---
+
+## 後方互換性
+
+```swift
+var body: some View {
+    if #available(iOS 26.0, *) {
+        content
+            .liquidGlass(.prominent)
+    } else {
+        content
+            .background(.ultraThinMaterial)
+    }
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [What's new in SwiftUI - WWDC25](https://developer.apple.com/videos/play/wwdc2025/)
+- [Human Interface Guidelines - Materials](https://developer.apple.com/design/human-interface-guidelines/materials)

--- a/ios_development/skills/swiftui-components/references/tips.md
+++ b/ios_development/skills/swiftui-components/references/tips.md
@@ -1,0 +1,285 @@
+# TipKit
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| TipKit | 17+ | 17+ | 14+ | 機能発見ヒント表示 |
+| TipView | 17+ | 17+ | 14+ | インラインTip表示 |
+| popoverTip | 17+ | 17+ | 14+ | ポップオーバーTip表示 |
+| Tip Rules | 17+ | 17+ | 14+ | 表示条件制御 |
+
+---
+
+## 概要
+
+TipKitは、アプリの機能発見を促進するヒント表示フレームワーク。ユーザーに機能を教えるための統一されたUIを提供。
+
+---
+
+## 基本的なTip定義
+
+```swift
+import TipKit
+
+struct FavoriteTip: Tip {
+    var title: Text {
+        Text("お気に入りに追加")
+    }
+
+    var message: Text? {
+        Text("星をタップして記事をお気に入りに保存できます")
+    }
+
+    var image: Image? {
+        Image(systemName: "star")
+    }
+}
+```
+
+---
+
+## Tipの表示
+
+### インラインTip（TipView）
+
+```swift
+struct ArticleView: View {
+    let favoriteTip = FavoriteTip()
+
+    var body: some View {
+        VStack {
+            TipView(favoriteTip)
+
+            // コンテンツ
+            ArticleContent()
+        }
+    }
+}
+```
+
+### ポップオーバーTip
+
+```swift
+struct ArticleView: View {
+    let favoriteTip = FavoriteTip()
+
+    var body: some View {
+        Button(action: addToFavorites) {
+            Image(systemName: "star")
+        }
+        .popoverTip(favoriteTip)
+    }
+}
+```
+
+---
+
+## TipKitの設定
+
+アプリ起動時に設定が必要。
+
+```swift
+@main
+struct MyApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+                .task {
+                    try? Tips.configure([
+                        .displayFrequency(.immediate),
+                        .datastoreLocation(.applicationDefault)
+                    ])
+                }
+        }
+    }
+}
+```
+
+### 表示頻度オプション
+
+```swift
+// 即時表示
+.displayFrequency(.immediate)
+
+// 1時間ごと
+.displayFrequency(.hourly)
+
+// 1日ごと
+.displayFrequency(.daily)
+
+// 1週間ごと
+.displayFrequency(.weekly)
+
+// 1ヶ月ごと
+.displayFrequency(.monthly)
+```
+
+---
+
+## Tipのルールと条件
+
+### イベントベースのルール
+
+ユーザーのアクション回数に基づいて表示。
+
+```swift
+struct AdvancedTip: Tip {
+    // イベント定義
+    static let articleViewedEvent = Event(id: "articleViewed")
+
+    var rules: [Rule] {
+        // 3回以上記事を見た後に表示
+        #Rule(Self.articleViewedEvent) { $0.donations.count >= 3 }
+    }
+
+    var title: Text {
+        Text("もっと便利に")
+    }
+}
+
+// イベントの発火
+Button("記事を見る") {
+    AdvancedTip.articleViewedEvent.donate()
+}
+```
+
+### パラメータベースのルール
+
+アプリの状態に基づいて表示。
+
+```swift
+struct LoginRequiredTip: Tip {
+    @Parameter
+    static var isLoggedIn: Bool = false
+
+    var rules: [Rule] {
+        #Rule(Self.$isLoggedIn) { $0 == true }
+    }
+
+    var title: Text {
+        Text("プレミアム機能")
+    }
+}
+
+// パラメータの更新
+func onLogin() {
+    LoginRequiredTip.isLoggedIn = true
+}
+```
+
+### 複合ルール
+
+```swift
+struct ComplexTip: Tip {
+    static let usageEvent = Event(id: "usage")
+
+    @Parameter
+    static var isPremiumUser: Bool = false
+
+    var rules: [Rule] {
+        #Rule(Self.usageEvent) { $0.donations.count >= 5 }
+        #Rule(Self.$isPremiumUser) { $0 == true }
+    }
+
+    var title: Text {
+        Text("上級者向け機能")
+    }
+}
+```
+
+---
+
+## Tipの無効化
+
+### 手動で無効化
+
+```swift
+let favoriteTip = FavoriteTip()
+
+// ユーザーがアクションを実行した時
+func addToFavorites() {
+    // 処理
+    favoriteTip.invalidate(reason: .actionPerformed)
+}
+```
+
+### 無効化理由
+
+```swift
+// ユーザーがアクションを実行
+.actionPerformed
+
+// ユーザーがTipを閉じた
+.tipClosed
+
+// 最大表示回数に達した
+.maxDisplayCountExceeded
+```
+
+### データストアのリセット（開発用）
+
+```swift
+// 全てのTipをリセット
+try? Tips.resetDatastore()
+```
+
+---
+
+## カスタマイズ
+
+### TipViewのスタイル
+
+```swift
+TipView(favoriteTip, arrowEdge: .top)
+
+TipView(favoriteTip)
+    .tipBackground(Color.blue.opacity(0.1))
+```
+
+### アクション付きTip
+
+```swift
+struct ActionTip: Tip {
+    var title: Text {
+        Text("新機能")
+    }
+
+    var message: Text? {
+        Text("この機能を試してみませんか？")
+    }
+
+    var actions: [Action] {
+        Action(id: "try", title: "試してみる")
+        Action(id: "later", title: "後で")
+    }
+}
+
+// アクションの処理
+TipView(actionTip) { action in
+    if action.id == "try" {
+        // 機能を実行
+    }
+    actionTip.invalidate(reason: .actionPerformed)
+}
+```
+
+---
+
+## 移行チェックリスト
+
+### TipKit導入
+
+1. [ ] `import TipKit`を追加
+2. [ ] `Tips.configure()`をアプリ起動時に呼び出し
+3. [ ] Tip構造体を定義
+4. [ ] `TipView`または`.popoverTip()`で表示
+5. [ ] 適切なタイミングで`invalidate()`を呼び出し
+
+---
+
+## 関連ドキュメント
+
+- [TipKit - Apple Developer](https://developer.apple.com/documentation/tipkit)
+- [Tip - Apple Developer](https://developer.apple.com/documentation/tipkit/tip)
+- [TipView - Apple Developer](https://developer.apple.com/documentation/tipkit/tipview)

--- a/ios_development/skills/swiftui-components/references/webview.md
+++ b/ios_development/skills/swiftui-components/references/webview.md
@@ -1,0 +1,127 @@
+# WebViewコンポーネント
+
+## バージョン対応表
+
+| コンポーネント | iOS | iPadOS | macOS | 備考 |
+|--------------|-----|--------|-------|------|
+| WebView | 26+ | 26+ | 26+ | SwiftUIネイティブWebView |
+
+---
+
+## WebView (iOS 26+)
+
+SwiftUIネイティブのWebView。従来のWKWebViewラッパーが不要に。
+
+### 基本的な使用法
+
+```swift
+import SwiftUI
+
+struct WebContent: View {
+    var body: some View {
+        WebView(url: URL(string: "https://example.com")!)
+    }
+}
+```
+
+### ナビゲーション制御
+
+```swift
+WebView(url: url)
+    .webViewAllowsBackForwardNavigation(true)
+```
+
+### リーダーモード
+
+```swift
+WebView(url: url)
+    .webViewReaderMode(enabled: true)
+```
+
+### カスタマイズ例
+
+```swift
+struct BrowserView: View {
+    @State private var url = URL(string: "https://apple.com")!
+    @State private var isLoading = false
+
+    var body: some View {
+        VStack {
+            if isLoading {
+                ProgressView()
+            }
+
+            WebView(url: url)
+                .webViewAllowsBackForwardNavigation(true)
+                .onWebViewStartLoading {
+                    isLoading = true
+                }
+                .onWebViewFinishLoading {
+                    isLoading = false
+                }
+        }
+    }
+}
+```
+
+---
+
+## Scene Bridging (iOS 26+)
+
+UIKit/AppKitアプリにSwiftUIシーンを統合。完全な書き換え不要で段階的移行が可能。
+
+### ユースケース
+
+- 既存UIKitアプリへの新機能追加
+- 段階的なSwiftUI移行
+- 複数ウィンドウ対応
+
+### 概念
+
+```swift
+// 既存のUIKitアプリにSwiftUIシーンを追加
+// SceneDelegateやAppDelegateからSwiftUIシーンを起動可能
+```
+
+---
+
+## 従来のWKWebViewラッパー（iOS 25以前）
+
+iOS 26未満をサポートする必要がある場合：
+
+```swift
+import SwiftUI
+import WebKit
+
+struct LegacyWebView: UIViewRepresentable {
+    let url: URL
+
+    func makeUIView(context: Context) -> WKWebView {
+        WKWebView()
+    }
+
+    func updateUIView(_ webView: WKWebView, context: Context) {
+        let request = URLRequest(url: url)
+        webView.load(request)
+    }
+}
+```
+
+### 後方互換性
+
+```swift
+var body: some View {
+    if #available(iOS 26.0, *) {
+        WebView(url: url)
+    } else {
+        LegacyWebView(url: url)
+    }
+}
+```
+
+---
+
+## 関連ドキュメント
+
+- [WebView - Apple Developer](https://developer.apple.com/documentation/swiftui/webview)
+- [WKWebView - Apple Developer](https://developer.apple.com/documentation/webkit/wkwebview)

--- a/ios_development/skills/swiftui-ssot/SKILL.md
+++ b/ios_development/skills/swiftui-ssot/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: swiftui-ssot
+description: Single Source of Truth (SSOT) guidelines for SwiftUI state management. Use when designing state architecture, choosing between @State/@Binding/@StateObject/@ObservedObject/@EnvironmentObject, fixing state synchronization issues, refactoring duplicated state, or reviewing state management in PRs. Covers SSOT principles, property wrapper selection, state lifting, and common violations.
+---
+
+# SwiftUI SSOT (Single Source of Truth)
+
+SwiftUIにおける状態管理とSSOT原則の包括的ガイド。
+
+## ディレクトリ構成
+
+```
+swiftui-ssot/
+├── SKILL.md (このファイル)
+└── references/
+    └── ssot.md
+```
+
+## リファレンスファイル
+
+### references/ssot.md
+Single Source of Truth（SSOT）の包括的ガイド：
+- **SSOTの3つの柱**: 唯一の情報源、導出状態、単方向データフロー
+- **Property Wrapper選択フローチャート**: @State/@Binding/@StateObject/@ObservedObject/@EnvironmentObject
+- **パターン別ガイド**:
+  - 状態重複の解消
+  - 導出状態（Computed Property）
+  - State Lifting（状態の持ち上げ）
+  - 兄弟View間通信
+  - EnvironmentObjectの適切な使用
+- **違反検出方法**: コードスメル、検索パターン
+- **iOS 17+ @ObservableでのSSO実装**
+- **レビューチェックリスト**
+
+## 使用方法
+
+### 状態設計時
+1. `references/ssot.md`のProperty Wrapper選択フローチャートを参照
+2. データの所有者を明確化
+3. 導出可能な状態は持たない
+
+### 状態関連の問題発生時
+1. `references/ssot.md`の違反パターンを確認
+2. 該当するパターンの解決策を適用
+
+### PRレビュー時
+1. `references/ssot.md`のレビューチェックリストを使用
+
+## SSOT 3つの柱
+
+1. **唯一の情報源**: 各データは1箇所でのみ管理
+2. **導出状態**: 他の状態から計算可能なものは持たない
+3. **単方向データフロー**: 親→子へデータを渡し、子→親へはアクション
+
+## Property Wrapper 選択ガイド
+
+| 状況 | 推奨 |
+|------|------|
+| View内のローカル状態 | `@State` |
+| 親から受け取る値（読み書き） | `@Binding` |
+| Viewが所有するObservableObject | `@StateObject` |
+| 外部から注入されるObservableObject | `@ObservedObject` |
+| アプリ全体で共有 | `@EnvironmentObject` |
+| iOS 17+ | `@Observable` + `@Bindable` |
+
+## 関連スキル
+
+- **swiftui-coding-guidelines**: 基本的なベストプラクティス
+- **swift-ios-migration**: iOS 17 @Observable移行

--- a/ios_development/skills/swiftui-ssot/references/ssot.md
+++ b/ios_development/skills/swiftui-ssot/references/ssot.md
@@ -1,0 +1,406 @@
+# SwiftUI Single Source of Truth (SSOT) ガイド
+
+## SSOTとは
+
+Single Source of Truth（単一の信頼できる情報源）は、各データが唯一の場所でのみ管理されるべきという原則。SwiftUIでは状態の重複を避け、データの一貫性を保つために不可欠。
+
+**SSOTの3つの柱**
+1. **唯一の所有者**: 各状態は1つのビュー/オブジェクトのみが所有
+2. **参照で共有**: 複数ビューで必要な場合は`@Binding`や`@ObservedObject`で参照
+3. **導出は計算**: 他の状態から計算できる値は`@State`で持たない
+
+---
+
+## Property Wrapperの選択フローチャート
+
+```
+状態を保存する必要がある？
+├─ ビューローカル（他のビューは不要）？
+│  └─ @State（必ずprivate）
+├─ 親が所有し、子が書き込み必要？
+│  └─ @Binding
+├─ 複雑な共有状態（参照型）？
+│  ├─ このビューで作成？
+│  │  └─ @StateObject
+│  └─ 親から受け取る？
+│     └─ @ObservedObject
+└─ 深い階層で共有？
+   └─ @EnvironmentObject
+```
+
+### 所有権の原則
+
+| ラッパー | 所有権 | 用途 |
+|---------|--------|------|
+| `@State` | 所有 | 値型のローカル状態 |
+| `@StateObject` | 所有 | 参照型の作成・所有 |
+| `@Binding` | 非所有 | 親の状態への参照 |
+| `@ObservedObject` | 非所有 | 参照型を受け取る |
+| `@EnvironmentObject` | 非所有 | 深い階層での共有 |
+
+---
+
+## パターン別ガイド
+
+### パターン1: 状態の重複（❌ 最も多いSSO違反）
+
+```swift
+// ❌ アンチパターン: 状態の重複
+struct ParentView: View {
+    @State private var username = ""
+    
+    var body: some View {
+        ChildView(initialUsername: username)
+    }
+}
+
+struct ChildView: View {
+    @State private var username: String  // 重複！
+    
+    init(initialUsername: String) {
+        _username = State(initialValue: initialUsername)
+    }
+    
+    var body: some View {
+        TextField("Username", text: $username)
+    }
+}
+// 問題: 子の変更が親に反映されない
+
+// ✅ 解決策: Bindingで参照
+struct ParentView: View {
+    @State private var username = ""  // 唯一の情報源
+    
+    var body: some View {
+        ChildView(username: $username)  // Bindingで渡す
+    }
+}
+
+struct ChildView: View {
+    @Binding var username: String  // 親の状態への参照
+    
+    var body: some View {
+        TextField("Username", text: $username)
+    }
+}
+```
+
+### パターン2: 導出可能な状態の保持
+
+```swift
+// ❌ アンチパターン: 計算可能な値を保持
+struct CartView: View {
+    @State private var items: [CartItem] = []
+    @State private var totalCount = 0      // items.countで計算可能
+    @State private var totalPrice = 0.0    // 合計で計算可能
+    @State private var isEmpty = true      // items.isEmptyで計算可能
+    
+    var body: some View {
+        // ...
+    }
+    .onChange(of: items) { _, newItems in
+        // 手動同期が必要（バグの温床）
+        totalCount = newItems.count
+        totalPrice = newItems.reduce(0) { $0 + $1.price }
+        isEmpty = newItems.isEmpty
+    }
+}
+
+// ✅ 解決策: 計算プロパティを使用
+struct CartView: View {
+    @State private var items: [CartItem] = []  // 唯一の状態
+    
+    // 導出値は計算プロパティ
+    private var totalCount: Int { items.count }
+    private var totalPrice: Double { items.reduce(0) { $0 + $1.price } }
+    private var isEmpty: Bool { items.isEmpty }
+    
+    var body: some View {
+        // 常に一貫性が保たれる
+    }
+}
+```
+
+### パターン3: 不適切な状態所有（State Lifting）
+
+```swift
+// ❌ アンチパターン: 子が共有状態を所有
+struct ParentView: View {
+    var body: some View {
+        VStack {
+            CounterView()
+            // 子のcounterにアクセスできない！
+            Button("リセット") {
+                // どうやってリセットする？
+            }
+        }
+    }
+}
+
+struct CounterView: View {
+    @State private var counter = 0  // 親がアクセス不可
+    
+    var body: some View {
+        Button("\(counter)") { counter += 1 }
+    }
+}
+
+// ✅ 解決策: 状態を共通の親に引き上げ（State Lifting）
+struct ParentView: View {
+    @State private var counter = 0  // 親が所有
+    
+    var body: some View {
+        VStack {
+            CounterView(counter: $counter)
+            Button("リセット") {
+                counter = 0  // 親がコントロール可能
+            }
+        }
+    }
+}
+
+struct CounterView: View {
+    @Binding var counter: Int
+    
+    var body: some View {
+        Button("\(counter)") { counter += 1 }
+    }
+}
+```
+
+### パターン4: 兄弟ビュー間の通信
+
+```swift
+// ❌ アンチパターン: 各ビューが独自に状態を持つ
+struct MasterDetailView: View {
+    var body: some View {
+        HStack {
+            ItemListView()   // 独自の@State selectedItem
+            ItemDetailView() // どうやって選択を知る？
+        }
+    }
+}
+
+// ✅ 解決策: 共通の親で状態管理
+struct MasterDetailView: View {
+    @State private var selectedItem: Item?  // 共通の親で管理
+    
+    var body: some View {
+        HStack {
+            ItemListView(selectedItem: $selectedItem)
+            ItemDetailView(item: selectedItem)  // 読み取り専用
+        }
+    }
+}
+
+struct ItemListView: View {
+    @Binding var selectedItem: Item?  // 書き込み可能
+    let items: [Item]
+    
+    var body: some View {
+        List(items) { item in
+            Button(item.name) {
+                selectedItem = item
+            }
+        }
+    }
+}
+
+struct ItemDetailView: View {
+    let item: Item?  // 読み取り専用（変更不要）
+    
+    var body: some View {
+        if let item = item {
+            Text(item.description)
+        }
+    }
+}
+```
+
+### パターン5: 深い階層での共有（EnvironmentObject）
+
+```swift
+// ❌ アンチパターン: プロップドリリング
+struct RootView: View {
+    @StateObject private var userSettings = UserSettings()
+    
+    var body: some View {
+        Level1View(settings: userSettings)  // 渡す
+    }
+}
+
+struct Level1View: View {
+    @ObservedObject var settings: UserSettings
+    var body: some View {
+        Level2View(settings: settings)  // また渡す
+    }
+}
+
+struct Level2View: View {
+    @ObservedObject var settings: UserSettings
+    var body: some View {
+        Level3View(settings: settings)  // また渡す...
+    }
+}
+// 問題: 中間ビューが不要な依存を持つ
+
+// ✅ 解決策: EnvironmentObjectで注入
+struct RootView: View {
+    @StateObject private var userSettings = UserSettings()
+    
+    var body: some View {
+        Level1View()
+            .environmentObject(userSettings)  // 1回だけ注入
+    }
+}
+
+struct Level1View: View {
+    var body: some View {
+        Level2View()  // settingsを渡す必要なし
+    }
+}
+
+struct Level3View: View {
+    @EnvironmentObject var settings: UserSettings  // 必要な場所で取得
+    
+    var body: some View {
+        Toggle("Dark Mode", isOn: $settings.isDarkMode)
+    }
+}
+```
+
+---
+
+## SSOT違反の検出方法
+
+### コードスメル（警告サイン）
+
+**1. イニシャライザでの@State設定**
+```swift
+// ❌ 警告: _プロパティ構文
+init(value: String) {
+    _localValue = State(initialValue: value)
+}
+```
+
+**2. onChange での状態同期**
+```swift
+// ❌ 警告: 手動同期
+.onChange(of: sourceValue) { _, newValue in
+    targetValue = newValue  // 同期コード
+}
+```
+
+**3. 似た名前の@Stateが複数ビューに存在**
+```swift
+// ❌ 警告: 同じ名前の状態
+struct ViewA: View { @State private var username = "" }
+struct ViewB: View { @State private var username = "" }  // 重複？
+```
+
+**4. .constant() の使用**
+```swift
+// ❌ 警告: Bindingのワークアラウンド
+Toggle("Option", isOn: .constant(true))  // 本来は@Binding
+```
+
+### 検索パターン
+
+レビュー時に以下を検索:
+- `_.*= State(initialValue:` - イニシャライザでの@State設定
+- `.onChange.*=` - 状態同期の可能性
+- `@State private var` - 重複の可能性を確認
+
+---
+
+## iOS 17+ @Observable での SSOT
+
+```swift
+// iOS 17+: より簡潔なSSO実装
+@Observable
+class AppState {
+    var user: User?
+    var settings: Settings = Settings()
+    
+    // 導出プロパティもそのまま使用可能
+    var isLoggedIn: Bool { user != nil }
+}
+
+struct RootView: View {
+    @State private var appState = AppState()  // @Stateで所有
+    
+    var body: some View {
+        ContentView(appState: appState)
+            .environment(appState)  // 深い階層用
+    }
+}
+
+struct ContentView: View {
+    var appState: AppState  // ラッパー不要
+    
+    var body: some View {
+        // appState.userが変更された時のみ再描画
+        if appState.isLoggedIn {
+            MainView()
+        } else {
+            LoginView()
+        }
+    }
+}
+
+struct SettingsView: View {
+    @Environment(AppState.self) var appState
+    
+    var body: some View {
+        @Bindable var appState = appState  // 書き込み用
+        Toggle("Notifications", isOn: $appState.settings.notificationsEnabled)
+    }
+}
+```
+
+---
+
+## レビューチェックリスト
+
+### 🔴 必須（Critical）
+
+- [ ] @Stateが複数ビューで重複していないか
+- [ ] イニシャライザで@Stateを外部値から設定していないか
+- [ ] onChangeで状態同期をしていないか
+- [ ] 子が所有すべきでない共有状態を@Stateで持っていないか
+- [ ] @Bindingが必要な場所で値渡しになっていないか
+
+### 🟡 推奨（Important）
+
+- [ ] 計算可能な値を@Stateで保持していないか
+- [ ] @StateObjectが作成ビューで使われているか
+- [ ] @ObservedObjectが受け取りビューで使われているか
+- [ ] 深い階層でプロップドリリングになっていないか
+
+### 🟢 提案（Optional）
+
+- [ ] 状態が適切なレベルで所有されているか
+- [ ] UI状態とビジネスロジック状態が分離されているか
+- [ ] 状態の粒度は適切か（更新範囲の最小化）
+
+---
+
+## 修正例テンプレート
+
+```markdown
+## SSOT違反: [場所]
+
+**問題**: [何が問題か]
+
+**現在のコード**:
+```swift
+// 問題のあるコード
+```
+
+**修正後**:
+```swift
+// 修正されたコード
+```
+
+**理由**: [なぜこれがSSOT違反で、修正により何が改善されるか]
+```


### PR DESCRIPTION
## 概要

iOS/SwiftUI開発用のClaude Codeスキルディレクトリを追加しました。

## 追加内容

以下の6つのスキルを追加：

- **swift-ios-migration**: Swift/iOSマイグレーションガイド
  - iOS 17 @Observable移行
  - Swift 6/6.2並行処理対応
  - iPadOS 26ウィンドウシステム対応

- **swiftui-accessibility**: アクセシビリティ実装ガイド
  - VoiceOver対応
  - Dynamic Type対応
  - コントラスト・モーション対応

- **swiftui-code-review-checklist**: コードレビューチェックリスト
  - 優先度別チェック項目
  - 状態管理・パフォーマンス・セキュリティ

- **swiftui-coding-guidelines**: コーディングガイドライン
  - ベストプラクティス
  - 実装パターン（リスト、ナビゲーション、フォーム、ビュー）
  - アンチパターン集

- **swiftui-components**: UIコンポーネントカタログ
  - NavigationStack、Swift Charts、PhotosPicker等
  - iOS 16以降の新機能
  - バージョン対応表付き

- **swiftui-ssot**: 状態管理（SSOT）ガイド
  - Single Source of Truth原則
  - Property Wrapper選択ガイド
  - 違反パターンと解決策

## ファイル構成

```
ios_development/
├── README.md
└── skills/
    ├── swift-ios-migration/
    ├── swiftui-accessibility/
    ├── swiftui-code-review-checklist/
    ├── swiftui-coding-guidelines/
    ├── swiftui-components/
    └── swiftui-ssot/
```

## 変更統計

- 31ファイル追加
- 8,189行追加

## 参考

元のスキルは `/Users/okubo/XcodeProjects/docomo-dmenu-news-ios/.claude/skills` からコピーしました。