### PR TITLE
feat(android-test-runner): Agent Skills オープンスタンダード対応

### DIFF
--- a/android_development/.claude/skills/android-test-runner/SKILL.md
+++ b/android_development/.claude/skills/android-test-runner/SKILL.md
@@ -296,7 +296,27 @@ fun setup() {
 - ✅ 実行可能な修正提案を提供
 - ✅ デバッグ時間を30%以上削減
 
+## 互換性
+
+### Agent Skills (Open Standard)
+
+このスキルは [Agent Skills](https://agentskills.io) オープンスタンダードに準拠しています。
+
+**対応ツール**:
+- Claude Code ✅
+- GitHub Copilot ✅
+- VS Code ✅
+- Cursor (Nightly) ✅
+- OpenAI Codex ✅
+
+`.claude/skills/` ディレクトリに配置することで、上記すべてのツールで使用可能です。
+
 ## バージョン
+
+### v1.1 - Agent Skills対応 (2025-12-23)
+- ✅ Agent Skills オープンスタンダード準拠を確認
+- ✅ 互換性セクション追加
+- ✅ 複数コーディングエージェントで使用可能
 
 ### v1.0 - 汎用版リリース (2025-11-20)
 - ✅ Pattern 1-19 を実装


### PR DESCRIPTION
## Summary

- android-test-runner を Agent Skills オープンスタンダードに対応
- 互換性セクションを追加し、対応ツールを明記
- バージョン v1.1 としてリリース

## 背景

2025年12月18日、AnthropicがAgent Skillsをオープンスタンダードとして公開しました。
これにより、同じSKILL.mdファイルを複数のコーディングエージェントで使用可能になりました。

### 対応ツール

| ツール | 対応状況 | .claude/skills互換 |
|--------|----------|-------------------|
| Claude Code | ✅ | ネイティブ |
| GitHub Copilot | ✅ | 公式サポート |
| VS Code | ✅ | Insiders対応済み |
| Cursor | ✅ | Nightlyのみ |
| OpenAI Codex | ✅ | 対応済み |

## 変更内容

- `SKILL.md` に互換性セクションを追加
- Agent Skills仕様への準拠を確認
- バージョン履歴を更新

## ARS/Xtone共同開発へのインパクト

- 両チームで異なるツールを使用しても同じSkillsを共有可能
- 型化共有（合宿目標）の基盤として活用可能

## 参考リンク

- [Agent Skills 仕様](https://agentskills.io)
- [Publickey記事](https://www.publickey1.jp/blog/25/anthropicaiagent_skillsvs_codecursor.html)
- [GitHub Copilot Agent Skills](https://docs.github.com/en/copilot/concepts/agents/about-agent-skills)

Refs: #11

## Test plan

- [x] SKILL.md のYAMLフロントマターが公式要件を満たすことを確認
- [x] name: 小文字・数字・ハイフンのみ、64文字以内
- [x] description: 1024文字以内、いつ使うかを明記

🤖 Generated with [Claude Code](https://claude.com/claude-code)