### PR TITLE
feat(flutter): add Figma to Flutter design and implementation skills

### DIFF
--- a/flutter_development/.claude-plugin/marketplace.json
+++ b/flutter_development/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "name": "flutter-development",
-    "description": "Flutter開発向けのツール群。Widget実装の設計判断から実装までをサポート",
-    "version": "0.1.0",
+    "description": "Flutter開発向けのツール群。Figmaデザイン分析からWidget実装、ネイティブ連携までをサポート",
+    "version": "0.2.0",
     "owner": {
         "name": "HINO, Yasushi",
         "email": "y.hino@xtone.co.jp"
@@ -16,6 +16,26 @@
                 "name": "HINO, Yasushi"
             },
             "tags": ["flutter", "widget", "architecture", "state-management", "riverpod", "autoroute", "mvvm", "interview"]
+        },
+        {
+            "name": "figma-to-flutter",
+            "source": "./skills/figma-to-flutter",
+            "description": "FigmaデザインをFlutter向け設計仕様書に変換します。Figma MCPツールを使用してレイアウト、スペーシング、タイポグラフィを抽出し、Row/Column/Stackへのマッピング、EdgeInsetsへの変換、TextStyleの生成を行います。Atomic Designに基づくコンポーネント分類も実施します。",
+            "version": "1.0.0",
+            "author": {
+                "name": "HINO, Yasushi"
+            },
+            "tags": ["flutter", "figma", "design", "atomic-design", "layout", "typography", "specification"]
+        },
+        {
+            "name": "flutter-implementation",
+            "source": "./skills/flutter-implementation",
+            "description": "設計仕様書からFlutterコードを生成します。StatelessWidget/StatefulWidget/ConsumerWidgetの適切な選択、Riverpod状態管理の統合、Widget testの生成、ネイティブプラットフォーム連携（iOS/Android）のガイドを提供します。",
+            "version": "1.0.0",
+            "author": {
+                "name": "HINO, Yasushi"
+            },
+            "tags": ["flutter", "implementation", "riverpod", "testing", "native-integration", "ios", "android"]
         }
     ]
 }

--- a/flutter_development/skills/figma-to-flutter/SKILL.md
+++ b/flutter_development/skills/figma-to-flutter/SKILL.md
@@ -1,0 +1,572 @@
+---
+name: figma-to-flutter
+description: Extract and analyze Figma designs to create Flutter-specific design specifications. Use this skill when you need to analyze Figma nodes, extract design properties (layout, spacing, typography), classify components using Atomic Design principles, and generate design specification documents optimized for Flutter implementation.
+---
+
+# Figma to Flutter Design Analyzer
+
+## Overview
+
+Systematically analyze Figma designs and extract structured design specifications optimized for Flutter implementation. This skill focuses on understanding design intent, extracting accurate properties, and creating comprehensive design specification documents that serve as blueprints for Flutter widgets.
+
+**Use this skill when:**
+- Analyzing Figma designs for Flutter implementation
+- Extracting design tokens and component specifications for Flutter
+- Classifying components according to Atomic Design principles
+- Creating design specification documents for Flutter developers
+- Converting Figma Auto Layout to Flutter Row/Column/Stack
+
+## Core Workflow
+
+### Step 1: Extract Figma Design Information
+
+When given a Figma URL or node ID, use Figma MCP tools to extract design data:
+
+1. **Parse the Figma URL to extract node ID:**
+   ```
+   URL: https://figma.com/design/fileKey/fileName?node-id=1-2
+   Node ID: 1:2 (replace - with :)
+   ```
+
+2. **Extract node design context:**
+   ```
+   mcp__figma-dev__get_design_context(
+     nodeId: "1:2",
+     dirForAssetWrites: "/absolute/path/to/project/assets",
+     clientLanguages: "dart",
+     clientFrameworks: "flutter"
+   )
+   ```
+
+3. **Get component metadata for structure overview:**
+   ```
+   mcp__figma-dev__get_metadata(
+     nodeId: "1:2",
+     clientLanguages: "dart",
+     clientFrameworks: "flutter"
+   )
+   ```
+
+4. **Check for Figma variables (design tokens):**
+   ```
+   mcp__figma-dev__get_variable_defs(
+     nodeId: "1:2",
+     clientLanguages: "dart",
+     clientFrameworks: "flutter"
+   )
+   ```
+
+5. **Verify Code Connect mappings:**
+   ```
+   mcp__figma-dev__get_code_connect_map(
+     nodeId: "1:2",
+     clientLanguages: "dart",
+     clientFrameworks: "flutter"
+   )
+   ```
+
+### Step 2: Handle Component Instances and Variants
+
+**Important:** When the node is a component instance:
+
+1. **Identify if it's an instance:**
+   - Check metadata for "component instance" type
+   - Note the main component ID
+
+2. **Get the main component:**
+   - Use `get_design_context` on the main component node
+   - Extract the base structure and properties
+
+3. **Extract instance-specific properties:**
+   - Get the instance's specific size, device, and variant settings
+   - Note any overrides (text, images, colors, etc.)
+
+4. **Handle variants:**
+   - If the main component uses variants, identify the variant mode
+   - Extract the correct variant values for the instance
+   - Document variant properties for Flutter constructor parameters
+
+### Step 3: Classify the Component
+
+Use Atomic Design principles to classify the component:
+
+1. **Read the classification guide:**
+   ```
+   Read references/flutter-atomic-design.md
+   ```
+
+2. **Apply the decision tree:**
+   - **Atom**: Indivisible, single purpose (button, text field, icon, text)
+   - **Molecule**: 2-5 atoms, simple combination (search bar, form field)
+   - **Organism**: Complex, multiple molecules/atoms (app bar, card, form)
+
+3. **Determine the Flutter widget category:**
+   - Document: `atomicCategory: Atom | Molecule | Organism`
+   - Map to Flutter directory: `atoms/`, `molecules/`, `organisms/`
+
+### Step 4: Analyze Layout and Map to Flutter
+
+Extract layout information and map to Flutter widgets:
+
+1. **Read layout mapping guide:**
+   ```
+   Read references/flutter-layout-mapping.md
+   ```
+
+2. **Map Figma Auto Layout to Flutter:**
+
+   | Figma Auto Layout | Flutter Widget |
+   |-------------------|----------------|
+   | Horizontal direction | `Row` |
+   | Vertical direction | `Column` |
+   | Spacing between items | `SizedBox` or `MainAxisAlignment.spaceEvenly` |
+   | Wrap | `Wrap` |
+   | Overlapping elements | `Stack` + `Positioned` |
+
+3. **Map Figma sizing to Flutter:**
+
+   | Figma Setting | Flutter Equivalent |
+   |---------------|-------------------|
+   | Hug contents | Default (no constraint) |
+   | Fill container | `Expanded` or `Flexible` |
+   | Fixed width/height | `SizedBox(width: X, height: Y)` |
+   | Min/Max constraints | `ConstrainedBox` |
+
+4. **Map alignment:**
+
+   | Figma Alignment | Flutter |
+   |-----------------|---------|
+   | Left/Top | `CrossAxisAlignment.start` / `MainAxisAlignment.start` |
+   | Center | `CrossAxisAlignment.center` / `MainAxisAlignment.center` |
+   | Right/Bottom | `CrossAxisAlignment.end` / `MainAxisAlignment.end` |
+   | Space Between | `MainAxisAlignment.spaceBetween` |
+
+5. **Document in specification:**
+   ```markdown
+   ## Layout
+   - Widget: Column
+   - MainAxisAlignment: start
+   - CrossAxisAlignment: center
+   - Children spacing: 16.0
+
+   ## Sizing
+   - Width: Expanded (fill parent)
+   - Height: Hug contents (intrinsic)
+   ```
+
+### Step 5: Extract Spacing and Padding
+
+Extract spacing values for Flutter:
+
+1. **Read spacing guide:**
+   ```
+   Read references/flutter-spacing-guide.md
+   ```
+
+2. **Extract padding values:**
+   - Map Figma padding to `EdgeInsets`
+   - Use `EdgeInsets.all()`, `EdgeInsets.symmetric()`, or `EdgeInsets.only()`
+
+3. **Extract gap/spacing values:**
+   - Convert gaps to `SizedBox(width: X)` or `SizedBox(height: Y)`
+   - Consider using `gap` package for cleaner code
+
+4. **Extract border radius:**
+   - Map to `BorderRadius.circular()` or `BorderRadius.only()`
+
+5. **Document in specification:**
+   ```markdown
+   ## Spacing
+   - Padding: EdgeInsets.symmetric(horizontal: 24.0, vertical: 16.0)
+   - Children spacing: 12.0 (use SizedBox)
+   - Border Radius: BorderRadius.circular(12.0)
+   ```
+
+### Step 6: Extract Typography
+
+Extract text styling for Flutter:
+
+1. **Read typography guide:**
+   ```
+   Read references/flutter-typography-guide.md
+   ```
+
+2. **Map to TextStyle:**
+   ```dart
+   TextStyle(
+     fontFamily: 'Roboto',
+     fontSize: 16.0,
+     fontWeight: FontWeight.w600,
+     height: 1.5, // line height ratio
+     letterSpacing: 0.5,
+     color: Color(0xFF1A1A1A),
+   )
+   ```
+
+3. **Consider ThemeData integration:**
+   - Map to `Theme.of(context).textTheme.bodyLarge`
+   - Check if custom TextTheme is needed
+
+4. **Document in specification:**
+   ```markdown
+   ## Typography
+   - Style: TextStyle
+     - fontFamily: 'Roboto'
+     - fontSize: 16.0
+     - fontWeight: FontWeight.w600
+     - height: 1.5
+     - color: Color(0xFF1A1A1A)
+   - Theme mapping: bodyLarge (if applicable)
+   ```
+
+### Step 7: Extract Colors and Visual Properties
+
+Extract colors and visual styling for Flutter:
+
+1. **Extract color values:**
+   - Convert hex colors to `Color(0xFFRRGGBB)` format
+   - Note opacity values
+
+2. **Map to ColorScheme:**
+   - Check if colors match Material Design ColorScheme
+   - Document custom colors
+
+3. **Extract visual properties:**
+   - Box shadow → `BoxShadow`
+   - Border → `Border` or `BorderSide`
+   - Gradient → `LinearGradient` or `RadialGradient`
+
+4. **Document in specification:**
+   ```markdown
+   ## Colors
+   - Background: Color(0xFF2196F3)
+   - Text: Color(0xFFFFFFFF)
+   - Border: Color(0xFF1976D2)
+
+   ## Visual Properties
+   - Shadow: BoxShadow(
+       color: Color(0x1A000000),
+       blurRadius: 8.0,
+       offset: Offset(0, 4),
+     )
+   - Border: Border.all(color: Color(0xFF1976D2), width: 1.0)
+   - Border Radius: BorderRadius.circular(8.0)
+   ```
+
+### Step 8: Determine Widget Type and State Management
+
+Based on the design, determine the appropriate Flutter widget approach:
+
+1. **Widget type decision:**
+   - **StatelessWidget**: No internal state changes
+   - **StatefulWidget**: Has internal state (animations, form inputs)
+   - **HooksConsumerWidget**: Needs Riverpod + hooks
+   - **ConsumerWidget**: Needs Riverpod only
+
+2. **Identify required callbacks:**
+   - `onTap`, `onPressed`, `onChanged`, etc.
+   - Document callback signatures
+
+3. **Identify constructor parameters:**
+   - Required parameters
+   - Optional parameters with defaults
+   - Variant-based parameters
+
+4. **Document in specification:**
+   ```markdown
+   ## Widget Architecture
+   - Type: StatelessWidget
+   - Riverpod: Not required
+
+   ## Constructor Parameters
+   - required String label
+   - VoidCallback? onPressed
+   - ButtonVariant variant = ButtonVariant.primary
+   - ButtonSize size = ButtonSize.medium
+   ```
+
+### Step 9: Handle Responsive Design
+
+When multiple Figma nodes represent different device sizes:
+
+1. **Extract all node IDs** from provided URLs
+   - Mobile node
+   - Tablet node
+   - Desktop node (if applicable for Flutter Web)
+
+2. **Analyze each node:**
+   - Layout changes
+   - Spacing changes
+   - Typography changes
+   - Hidden/shown elements
+
+3. **Document responsive variations:**
+   ```markdown
+   ## Responsive Behavior
+   - Mobile (< 600): Column layout, smaller padding
+   - Tablet (>= 600): Row layout, larger spacing
+   - Use LayoutBuilder or MediaQuery for breakpoints
+   ```
+
+### Step 10: Identify Native Platform Requirements
+
+Check if the design requires native platform features:
+
+1. **Identify platform-specific elements:**
+   - Camera access
+   - Biometric authentication
+   - Push notifications
+   - Platform-specific UI (Cupertino for iOS)
+
+2. **Document native requirements:**
+   ```markdown
+   ## Native Integration
+   - iOS: Requires camera access (AVFoundation)
+   - Android: Requires camera permission (Camera2 API)
+   - MethodChannel: app.example/camera
+
+   ## Related Skills
+   - For iOS implementation: Use ios-development/swiftui-components
+   - For Android implementation: Use android-development skills
+   ```
+
+### Step 11: Generate Design Specification Document
+
+Create a comprehensive design specification:
+
+```markdown
+---
+widgetName: PrimaryButton
+atomicCategory: Atom
+figmaNodeId: "123:456"
+figmaUrl: "https://figma.com/design/..."
+---
+
+# PrimaryButton Widget Specification
+
+## Overview
+A primary action button widget for the application.
+
+## Atomic Design Classification
+- Category: Atom
+- Reason: Single, indivisible interactive element
+- Directory: lib/presentation/widgets/atoms/
+
+## Widget Architecture
+- Type: StatelessWidget
+- Riverpod: Not required
+
+## Constructor Parameters
+```dart
+const PrimaryButton({
+  super.key,
+  required this.label,
+  this.onPressed,
+  this.variant = ButtonVariant.primary,
+  this.size = ButtonSize.medium,
+  this.isLoading = false,
+});
+```
+
+## Layout
+- Widget: Container → InkWell → Row
+- MainAxisAlignment: center
+- CrossAxisAlignment: center
+- MainAxisSize: min
+
+## Sizing
+- Height: 48.0 (medium), 40.0 (small), 56.0 (large)
+- Width: Hug contents (intrinsic)
+- Min Width: 120.0
+
+## Spacing
+- Padding: EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0)
+- Icon-Label gap: 8.0
+
+## Typography
+- Style: TextStyle
+  - fontSize: 16.0
+  - fontWeight: FontWeight.w600
+  - color: Colors.white
+
+## Colors
+- Primary:
+  - Background: Color(0xFF2196F3)
+  - Text: Color(0xFFFFFFFF)
+- Secondary:
+  - Background: Color(0xFFFFFFFF)
+  - Text: Color(0xFF2196F3)
+  - Border: Color(0xFF2196F3)
+
+## Visual Properties
+- Border Radius: BorderRadius.circular(8.0)
+- Shadow (elevated): BoxShadow(
+    color: Color(0x1A000000),
+    blurRadius: 4.0,
+    offset: Offset(0, 2),
+  )
+
+## States
+- Default: As specified above
+- Pressed: Slightly darker background (0.9 opacity)
+- Disabled: 0.5 opacity, no interaction
+- Loading: Show CircularProgressIndicator, disable tap
+
+## Variants
+```dart
+enum ButtonVariant { primary, secondary, tertiary }
+enum ButtonSize { small, medium, large }
+```
+
+## Accessibility
+- Semantics label for screen readers
+- Sufficient touch target (minimum 48x48)
+- Color contrast meets WCAG AA
+
+## Assets
+- Icons: Use Icons.* or custom SVG
+
+## Native Integration
+- None required
+
+## Implementation Notes
+- Use InkWell for tap ripple effect
+- Wrap with Semantics for accessibility
+- Consider using Material Design 3 FilledButton as base
+```
+
+## Special Workflows
+
+### Breaking Down a Full Screen
+
+When given a full screen Figma node:
+
+1. **Get screen metadata** to understand structure
+2. **Identify major sections:**
+   - AppBar
+   - Body content
+   - Bottom navigation
+   - FAB (Floating Action Button)
+
+3. **For each section:**
+   - Classify as Organism
+   - Identify child Molecules and Atoms
+   - Extract design properties
+   - Create individual specifications
+
+4. **Create widget tree:**
+   ```
+   Screen (Scaffold)
+   ├─ AppBar (Organism)
+   │  ├─ BackButton (Atom)
+   │  ├─ Title (Atom)
+   │  └─ ActionButtons (Molecule)
+   ├─ Body (Organism)
+   │  ├─ HeaderSection (Molecule)
+   │  └─ ContentList (Organism)
+   │     └─ ListItem (Molecule) × N
+   └─ BottomNavigation (Organism)
+      └─ NavItem (Atom) × 4
+   ```
+
+5. **Generate specifications from bottom-up:**
+   - Create Atom specifications first
+   - Build Molecule specifications
+   - Assemble Organism specifications
+
+### Comparing Design with Implementation
+
+When asked to compare an existing widget with Figma:
+
+1. **Read the existing widget code**
+2. **Extract Figma design properties** using MCP tools
+3. **Compare systematically:**
+   - Layout (Row/Column vs Figma Auto Layout)
+   - Spacing values
+   - Typography
+   - Colors
+4. **Generate a diff report**
+
+## Best Practices
+
+1. **Always read guides before starting:**
+   - Layout mapping guide for Flutter widget selection
+   - Spacing guide for EdgeInsets extraction
+   - Typography guide for TextStyle creation
+   - Atomic Design guide for classification
+
+2. **Prioritize pixel-perfect accuracy:**
+   - Use exact spacing values from Figma
+   - Match typography precisely
+   - Verify colors match design tokens
+
+3. **Consider Flutter conventions:**
+   - Use const constructors where possible
+   - Follow Flutter naming conventions (camelCase)
+   - Use Material Design widgets as base when appropriate
+
+4. **Document thoroughly:**
+   - Include all variants and states
+   - Document responsive behavior
+   - Note accessibility considerations
+   - Include constructor parameters
+
+5. **Consider the flutter-widget-assistant:**
+   - For complex architecture decisions, recommend using flutter-widget-assistant skill
+   - This skill focuses on design extraction, not architecture decisions
+
+## Resources
+
+This skill includes comprehensive guides:
+
+### references/
+
+- **flutter-layout-mapping.md**: Mapping Figma Auto Layout to Flutter widgets
+- **flutter-spacing-guide.md**: Converting Figma spacing to EdgeInsets
+- **flutter-typography-guide.md**: Creating TextStyle from Figma
+- **flutter-atomic-design.md**: Atomic Design classification for Flutter
+
+**Usage:** Always read relevant guides before starting analysis.
+
+## Common Pitfalls
+
+1. **Not handling component instances properly:**
+   - Always get the main component when working with instances
+   - Extract instance-specific properties separately
+
+2. **Ignoring variants:**
+   - Check for variant properties in Figma
+   - Document all variant options as enums
+
+3. **Wrong layout widget selection:**
+   - Read the layout guide
+   - Don't use Stack when Row/Column would work
+
+4. **Forgetting responsive behavior:**
+   - Check for responsive variants in Figma
+   - Document breakpoint changes
+
+5. **Missing state considerations:**
+   - Document all interactive states
+   - Consider loading, error, empty states
+
+6. **Not considering native requirements:**
+   - Identify platform-specific features early
+   - Document MethodChannel requirements
+
+## Output Format
+
+The final output should be a Markdown document with:
+
+1. **Front matter** with metadata
+2. **Overview** section
+3. **Widget architecture** decisions
+4. **Constructor parameters**
+5. **Layout and spacing** specifications
+6. **Typography and colors** specifications
+7. **States and variants** documentation
+8. **Responsive behavior** notes
+9. **Native integration** requirements (if any)
+10. **Accessibility** considerations
+
+This specification document will be used by the `flutter-implementation` skill to generate actual Flutter code.

--- a/flutter_development/skills/figma-to-flutter/references/flutter-atomic-design.md
+++ b/flutter_development/skills/figma-to-flutter/references/flutter-atomic-design.md
@@ -1,0 +1,521 @@
+# Flutter Atomic Design Classification Guide
+
+This guide provides criteria for classifying Flutter widgets according to Atomic Design principles.
+
+## Atomic Design Overview
+
+Atomic Design is a methodology for creating design systems with five distinct levels:
+
+1. **Atoms** - Basic building blocks
+2. **Molecules** - Simple combinations of atoms
+3. **Organisms** - Complex combinations of molecules and atoms
+4. **Templates** - Page-level layouts (Scaffolds in Flutter)
+5. **Pages** - Specific instances of templates with real content
+
+For Flutter widget libraries, focus primarily on Atoms, Molecules, and Organisms.
+
+## Classification Criteria
+
+### Atoms
+
+**Definition:** The smallest, indivisible UI widgets that cannot be broken down further without losing meaning.
+
+**Characteristics:**
+- Single responsibility
+- Highly reusable
+- Self-contained
+- Cannot be broken down further
+- Typically StatelessWidget
+
+**Flutter Examples:**
+- `ElevatedButton`, `TextButton`, `IconButton`
+- `TextField`, `TextFormField`
+- `Text`, `Icon`
+- `Image`, `CircleAvatar`
+- `Checkbox`, `Radio`, `Switch`
+- `Badge`, `Chip`
+- `CircularProgressIndicator`, `LinearProgressIndicator`
+- `Divider`
+
+**Custom Atom Example:**
+```dart
+class AppButton extends StatelessWidget {
+  const AppButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.variant = ButtonVariant.primary,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final ButtonVariant variant;
+
+  @override
+  Widget build(BuildContext context) {
+    return ElevatedButton(
+      onPressed: onPressed,
+      style: _getButtonStyle(variant),
+      child: Text(label),
+    );
+  }
+}
+```
+
+**Directory:** `lib/presentation/widgets/atoms/`
+
+### Molecules
+
+**Definition:** Simple combinations of atoms that work together as a unit.
+
+**Characteristics:**
+- Composed of 2-5 atoms
+- Has a single, clear purpose
+- Still relatively simple
+- Reusable across contexts
+- May have simple internal logic
+
+**Flutter Examples:**
+- Search bar (TextField + IconButton)
+- Form field (Text label + TextField + Text error)
+- List tile with icon (Icon + Text + Icon)
+- Input with label
+- Rating display (Row of Icon atoms)
+- Social share button group
+- Breadcrumb navigation
+
+**Custom Molecule Example:**
+```dart
+class SearchBar extends StatelessWidget {
+  const SearchBar({
+    super.key,
+    required this.controller,
+    this.onSearch,
+    this.hint = 'Search...',
+  });
+
+  final TextEditingController controller;
+  final VoidCallback? onSearch;
+  final String hint;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: TextField(
+            controller: controller,
+            decoration: InputDecoration(
+              hintText: hint,
+              prefixIcon: Icon(Icons.search),
+            ),
+          ),
+        ),
+        SizedBox(width: 8),
+        IconButton(
+          icon: Icon(Icons.search),
+          onPressed: onSearch,
+        ),
+      ],
+    );
+  }
+}
+```
+
+**Directory:** `lib/presentation/widgets/molecules/`
+
+### Organisms
+
+**Definition:** Complex UI widgets composed of molecules and atoms, forming distinct sections of an interface.
+
+**Characteristics:**
+- Composed of multiple molecules and/or atoms
+- Complex structure
+- May have significant internal logic and state
+- Represents a distinct section of the UI
+- Often context-specific
+
+**Flutter Examples:**
+- AppBar (with logo, title, actions)
+- Navigation drawer
+- Product card
+- Comment section
+- Form (multiple form fields + submit button)
+- Modal/Dialog content
+- Bottom sheet content
+- User profile card
+- Settings section
+
+**Custom Organism Example:**
+```dart
+class ProductCard extends StatelessWidget {
+  const ProductCard({
+    super.key,
+    required this.product,
+    this.onAddToCart,
+    this.onFavorite,
+  });
+
+  final Product product;
+  final VoidCallback? onAddToCart;
+  final VoidCallback? onFavorite;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Image (Atom)
+          AspectRatio(
+            aspectRatio: 16 / 9,
+            child: Image.network(product.imageUrl, fit: BoxFit.cover),
+          ),
+          Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                // Title (Atom)
+                Text(
+                  product.name,
+                  style: Theme.of(context).textTheme.titleMedium,
+                ),
+                SizedBox(height: 8),
+                // Price badge (Atom)
+                PriceBadge(price: product.price),
+                SizedBox(height: 16),
+                // Action buttons (Molecule)
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    AppButton(
+                      label: 'Add to Cart',
+                      onPressed: onAddToCart,
+                    ),
+                    IconButton(
+                      icon: Icon(Icons.favorite_border),
+                      onPressed: onFavorite,
+                    ),
+                  ],
+                ),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+**Directory:** `lib/presentation/widgets/organisms/`
+
+### Templates (Scaffolds)
+
+**Definition:** Page-level layouts that define content structure without actual content.
+
+**Characteristics:**
+- Arranges organisms into page layouts
+- Uses placeholder/slot pattern
+- Defines overall structure
+- Reusable across multiple pages
+
+**Flutter Example:**
+```dart
+class MainScaffold extends StatelessWidget {
+  const MainScaffold({
+    super.key,
+    required this.body,
+    this.appBar,
+    this.bottomNavigationBar,
+    this.floatingActionButton,
+  });
+
+  final Widget body;
+  final PreferredSizeWidget? appBar;
+  final Widget? bottomNavigationBar;
+  final Widget? floatingActionButton;
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: appBar,
+      body: SafeArea(child: body),
+      bottomNavigationBar: bottomNavigationBar,
+      floatingActionButton: floatingActionButton,
+    );
+  }
+}
+```
+
+**Directory:** `lib/presentation/templates/`
+
+### Pages (Screens)
+
+**Definition:** Specific instances of templates with real content and state management.
+
+**Characteristics:**
+- Uses actual data
+- Represents a specific screen in the application
+- May include page-specific logic (data fetching, etc.)
+- Often uses Riverpod for state management
+
+**Flutter Example:**
+```dart
+@RoutePage()
+class ProductListScreen extends ConsumerWidget {
+  const ProductListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final products = ref.watch(productsProvider);
+
+    return MainScaffold(
+      appBar: AppBar(title: Text('Products')),
+      body: products.when(
+        data: (items) => GridView.builder(
+          gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+            crossAxisCount: 2,
+          ),
+          itemCount: items.length,
+          itemBuilder: (context, index) => ProductCard(
+            product: items[index],
+            onAddToCart: () => ref.read(cartProvider.notifier).add(items[index]),
+          ),
+        ),
+        loading: () => Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+      ),
+    );
+  }
+}
+```
+
+**Directory:** `lib/presentation/screens/[feature]/`
+
+## Classification Decision Tree
+
+### Is it an Atom?
+
+1. ✅ Can it be broken down further?
+   - **NO** → It's an Atom
+   - **YES** → Continue
+
+2. ✅ Does it have a single, indivisible purpose?
+   - **YES** → It's an Atom
+   - **NO** → Continue
+
+### Is it a Molecule?
+
+3. ✅ Is it composed of 2-5 atoms?
+   - **YES** → Likely a Molecule
+   - **NO** → Continue
+
+4. ✅ Does it serve a single, simple purpose?
+   - **YES** → It's a Molecule
+   - **NO** → Continue
+
+### Is it an Organism?
+
+5. ✅ Is it composed of multiple molecules and/or atoms?
+   - **YES** → It's an Organism
+
+6. ✅ Does it represent a distinct section of the interface?
+   - **YES** → It's an Organism
+
+## Flutter Directory Structure
+
+```
+lib/
+  presentation/
+    widgets/
+      atoms/
+        app_button.dart
+        app_text_field.dart
+        app_icon.dart
+        price_badge.dart
+      molecules/
+        search_bar.dart
+        form_field.dart
+        rating_display.dart
+      organisms/
+        product_card.dart
+        app_header.dart
+        navigation_drawer.dart
+        comment_section.dart
+    templates/
+      main_scaffold.dart
+      auth_scaffold.dart
+    screens/
+      home/
+        home_screen.dart
+        home_view_model.dart
+      product/
+        product_list_screen.dart
+        product_detail_screen.dart
+```
+
+## Widget Composition Patterns
+
+### Atoms → Molecules
+```dart
+// Atoms: Icon, Text
+// Molecule: IconLabel
+class IconLabel extends StatelessWidget {
+  const IconLabel({
+    super.key,
+    required this.icon,
+    required this.label,
+    this.spacing = 8,
+  });
+
+  final IconData icon;
+  final String label;
+  final double spacing;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Icon(icon),
+        SizedBox(width: spacing),
+        Text(label),
+      ],
+    );
+  }
+}
+```
+
+### Molecules → Organisms
+```dart
+// Molecules: IconLabel, AppButton
+// Organism: ActionCard
+class ActionCard extends StatelessWidget {
+  const ActionCard({
+    super.key,
+    required this.icon,
+    required this.title,
+    required this.description,
+    this.onAction,
+  });
+
+  final IconData icon;
+  final String title;
+  final String description;
+  final VoidCallback? onAction;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            IconLabel(icon: icon, label: title),
+            SizedBox(height: 8),
+            Text(description),
+            SizedBox(height: 16),
+            AppButton(
+              label: 'Learn More',
+              onPressed: onAction,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Common Flutter Patterns by Category
+
+### Forms
+
+- **Atoms**: TextField, Checkbox, Radio, Switch
+- **Molecules**: FormField (Label + TextField + Error)
+- **Organisms**: LoginForm (Multiple FormFields + Button)
+
+### Navigation
+
+- **Atoms**: Icon, Text
+- **Molecules**: NavItem (Icon + Text)
+- **Organisms**: BottomNavigationBar, NavigationDrawer
+
+### Cards
+
+- **Atoms**: Image, Text, Icon, Button
+- **Molecules**: CardHeader, CardFooter
+- **Organisms**: ProductCard, UserCard, ArticleCard
+
+### Lists
+
+- **Atoms**: Text, Icon, Avatar
+- **Molecules**: ListTile (Avatar + Text + Action)
+- **Organisms**: UserList (Header + Multiple ListTiles + Pagination)
+
+## Naming Conventions
+
+### Atoms
+```
+AppButton
+AppTextField
+AppIcon
+AppImage
+PriceBadge
+StatusChip
+```
+
+### Molecules
+```
+SearchBar
+FormField
+IconLabel
+RatingDisplay
+SocialShareButtons
+```
+
+### Organisms
+```
+ProductCard
+UserProfileCard
+CommentSection
+NavigationHeader
+SettingsSection
+```
+
+## Tips
+
+1. **Start small**: Begin with Atoms, then build up
+2. **Be consistent**: Once you classify a pattern, stick with it
+3. **Keep atoms pure**: No business logic in atoms
+4. **Molecules are simple**: If it's getting complex, it's probably an Organism
+5. **Organisms can use atoms directly**: Skip molecules if simpler
+6. **Use const constructors**: For static widgets
+7. **Consider reusability**: Atoms and Molecules should be highly reusable
+8. **Document decisions**: If classification is ambiguous, document why
+
+## Edge Cases
+
+### When a widget feels too simple for Molecule
+
+If a "Molecule" only combines 2 atoms without adding meaningful functionality:
+- Consider if it should be an Atom
+- Or accept it as a simple Molecule for consistency
+
+### When a widget feels too complex for Organism
+
+If an "Organism" is extremely complex:
+- Consider breaking it down into smaller Organisms
+- Or accept it as a complex Organism if it represents a single, cohesive UI section
+
+### Reusing across categories
+
+It's normal for:
+- Organisms to use Molecules
+- Molecules to use Atoms
+- Organisms to use Atoms directly (skip Molecules if simpler)
+
+**Don't force categorization** - the goal is organization and reusability.

--- a/flutter_development/skills/figma-to-flutter/references/flutter-layout-mapping.md
+++ b/flutter_development/skills/figma-to-flutter/references/flutter-layout-mapping.md
@@ -1,0 +1,376 @@
+# Flutter Layout Mapping Guide
+
+This guide provides criteria for mapping Figma designs to appropriate Flutter layout widgets.
+
+## Layout Widget Decision Tree
+
+### 1. Row (Most Common for Horizontal)
+
+Use `Row` when:
+- Elements are arranged horizontally
+- Elements have consistent spacing
+- You need alignment control on both axes
+
+**Figma Indicators:**
+- Auto Layout with horizontal direction
+- "Hug contents" or "Fill container" on children
+- Consistent spacing between items
+
+**Flutter Example:**
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+  crossAxisAlignment: CrossAxisAlignment.center,
+  children: [
+    Text('Label'),
+    Icon(Icons.arrow_forward),
+  ],
+)
+```
+
+### 2. Column (Most Common for Vertical)
+
+Use `Column` when:
+- Elements are arranged vertically
+- Elements have consistent spacing
+- You need alignment control on both axes
+
+**Figma Indicators:**
+- Auto Layout with vertical direction
+- Sequential top-to-bottom arrangement
+- Consistent vertical spacing
+
+**Flutter Example:**
+```dart
+Column(
+  mainAxisAlignment: MainAxisAlignment.start,
+  crossAxisAlignment: CrossAxisAlignment.stretch,
+  children: [
+    Text('Title'),
+    SizedBox(height: 16),
+    Text('Description'),
+  ],
+)
+```
+
+### 3. Stack (For Overlapping Elements)
+
+Use `Stack` when:
+- Elements overlap each other
+- Elements have absolute positioning
+- You need z-index layering
+
+**Figma Indicators:**
+- Overlapping layers
+- Elements positioned relative to frame edges
+- Background images with overlaid content
+
+**Flutter Example:**
+```dart
+Stack(
+  children: [
+    Image.asset('background.png'),
+    Positioned(
+      top: 16,
+      right: 16,
+      child: IconButton(...),
+    ),
+  ],
+)
+```
+
+### 4. Wrap (For Flowing Content)
+
+Use `Wrap` when:
+- Elements should wrap to next line
+- Dynamic number of items
+- Tags, chips, or badges
+
+**Figma Indicators:**
+- Multiple rows of similar items
+- Items that wrap based on container width
+- Tag or chip groups
+
+**Flutter Example:**
+```dart
+Wrap(
+  spacing: 8.0,
+  runSpacing: 8.0,
+  children: tags.map((tag) => Chip(label: Text(tag))).toList(),
+)
+```
+
+### 5. ListView (For Scrollable Lists)
+
+Use `ListView` when:
+- Content exceeds visible area
+- Scrolling is needed
+- List of similar items
+
+**Figma Indicators:**
+- Scrollable content area indicated
+- Repeated list items
+- Content extends beyond frame
+
+**Flutter Example:**
+```dart
+ListView.builder(
+  itemCount: items.length,
+  itemBuilder: (context, index) => ListTile(
+    title: Text(items[index].title),
+  ),
+)
+```
+
+### 6. GridView (For Grid Layouts)
+
+Use `GridView` when:
+- Two-dimensional grid layout
+- Consistent item sizes
+- Gallery or product grids
+
+**Figma Indicators:**
+- Grid structure visible
+- Consistent row and column alignment
+- Multiple columns of items
+
+**Flutter Example:**
+```dart
+GridView.count(
+  crossAxisCount: 2,
+  mainAxisSpacing: 16,
+  crossAxisSpacing: 16,
+  children: products.map((p) => ProductCard(p)).toList(),
+)
+```
+
+## Figma Auto Layout → Flutter Mapping
+
+### Direction Mapping
+
+| Figma Direction | Flutter Widget |
+|-----------------|----------------|
+| Horizontal | `Row` |
+| Vertical | `Column` |
+| Wrap (horizontal) | `Wrap(direction: Axis.horizontal)` |
+| Wrap (vertical) | `Wrap(direction: Axis.vertical)` |
+
+### Alignment Mapping
+
+| Figma Alignment | Flutter MainAxisAlignment |
+|-----------------|---------------------------|
+| Top / Left | `MainAxisAlignment.start` |
+| Center | `MainAxisAlignment.center` |
+| Bottom / Right | `MainAxisAlignment.end` |
+| Space between | `MainAxisAlignment.spaceBetween` |
+| Space around | `MainAxisAlignment.spaceAround` |
+| Space evenly | `MainAxisAlignment.spaceEvenly` |
+
+| Figma Cross-Axis | Flutter CrossAxisAlignment |
+|------------------|----------------------------|
+| Top / Left | `CrossAxisAlignment.start` |
+| Center | `CrossAxisAlignment.center` |
+| Bottom / Right | `CrossAxisAlignment.end` |
+| Stretch | `CrossAxisAlignment.stretch` |
+| Baseline | `CrossAxisAlignment.baseline` |
+
+### Sizing Mapping
+
+| Figma Sizing | Flutter Equivalent |
+|--------------|-------------------|
+| Hug contents | Default (no constraint) |
+| Fill container | `Expanded` (in Row/Column) |
+| Fixed | `SizedBox(width: X, height: Y)` |
+| Fill container (flexible) | `Flexible` |
+
+### Gap/Spacing Handling
+
+**Option 1: SizedBox (Recommended for simple cases)**
+```dart
+Column(
+  children: [
+    Text('First'),
+    SizedBox(height: 16),
+    Text('Second'),
+  ],
+)
+```
+
+**Option 2: gap package (Cleaner for many items)**
+```dart
+// Using gap package
+Column(
+  children: [
+    Text('First'),
+    Gap(16),
+    Text('Second'),
+  ],
+)
+```
+
+**Option 3: MainAxisAlignment (For distribution)**
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+  children: [Widget1(), Widget2(), Widget3()],
+)
+```
+
+## Common Layout Patterns
+
+### Card Component
+```dart
+Container(
+  padding: EdgeInsets.all(16),
+  decoration: BoxDecoration(
+    color: Colors.white,
+    borderRadius: BorderRadius.circular(12),
+    boxShadow: [
+      BoxShadow(
+        color: Colors.black.withOpacity(0.1),
+        blurRadius: 8,
+        offset: Offset(0, 4),
+      ),
+    ],
+  ),
+  child: Column(
+    crossAxisAlignment: CrossAxisAlignment.start,
+    children: [
+      Text('Title', style: TextStyle(fontWeight: FontWeight.bold)),
+      SizedBox(height: 8),
+      Text('Description'),
+    ],
+  ),
+)
+```
+
+### Header with Logo and Actions
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+  children: [
+    Image.asset('logo.png', height: 32),
+    Row(
+      children: [
+        IconButton(icon: Icon(Icons.search), onPressed: () {}),
+        IconButton(icon: Icon(Icons.menu), onPressed: () {}),
+      ],
+    ),
+  ],
+)
+```
+
+### Form Field
+```dart
+Column(
+  crossAxisAlignment: CrossAxisAlignment.start,
+  children: [
+    Text('Email', style: TextStyle(fontWeight: FontWeight.w500)),
+    SizedBox(height: 8),
+    TextField(
+      decoration: InputDecoration(
+        hintText: 'Enter your email',
+        border: OutlineInputBorder(),
+      ),
+    ),
+  ],
+)
+```
+
+### Overlay Modal
+```dart
+Stack(
+  children: [
+    // Background
+    GestureDetector(
+      onTap: onClose,
+      child: Container(color: Colors.black54),
+    ),
+    // Modal content
+    Center(
+      child: Container(
+        margin: EdgeInsets.all(32),
+        padding: EdgeInsets.all(24),
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(16),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Text('Modal Title'),
+            SizedBox(height: 16),
+            Text('Modal content goes here'),
+          ],
+        ),
+      ),
+    ),
+  ],
+)
+```
+
+## Constraints and Sizing
+
+### Container Constraints
+
+| Figma Setting | Flutter Widget/Property |
+|---------------|------------------------|
+| Fixed width | `SizedBox(width: X)` or `Container(width: X)` |
+| Fixed height | `SizedBox(height: Y)` or `Container(height: Y)` |
+| Min width | `ConstrainedBox(constraints: BoxConstraints(minWidth: X))` |
+| Max width | `ConstrainedBox(constraints: BoxConstraints(maxWidth: X))` |
+| Aspect ratio | `AspectRatio(aspectRatio: W/H)` |
+
+### Flexible Sizing in Row/Column
+
+```dart
+Row(
+  children: [
+    // Fixed width
+    SizedBox(width: 100, child: Text('Fixed')),
+    // Fill remaining space
+    Expanded(child: Text('Expanded')),
+    // Flexible with flex factor
+    Flexible(flex: 2, child: Text('Flex 2')),
+  ],
+)
+```
+
+## Tips
+
+- **Start with Row/Column**: Most layouts can be achieved with Row and Column
+- **Use Stack sparingly**: Only for overlapping elements, not for general positioning
+- **Prefer Expanded over Flexible**: Unless you need specific flex behavior
+- **Use SizedBox for spacing**: It's lightweight and explicit
+- **Consider ScrollView**: Wrap Column/Row in SingleChildScrollView if content might overflow
+- **Test on different screen sizes**: Use LayoutBuilder for responsive layouts
+
+## Responsive Layout
+
+```dart
+LayoutBuilder(
+  builder: (context, constraints) {
+    if (constraints.maxWidth < 600) {
+      // Mobile layout
+      return Column(children: [...]);
+    } else {
+      // Tablet/Desktop layout
+      return Row(children: [...]);
+    }
+  },
+)
+```
+
+## Common Mistakes
+
+1. **Using Stack when Row/Column would work**
+   - Stack is for overlapping, not for sequential layout
+
+2. **Forgetting MainAxisSize.min**
+   - Column/Row take full available space by default
+
+3. **Not using Expanded in Row/Column**
+   - Children won't fill available space without it
+
+4. **Nested ScrollViews without proper configuration**
+   - Use shrinkWrap: true and physics: NeverScrollableScrollPhysics()

--- a/flutter_development/skills/figma-to-flutter/references/flutter-spacing-guide.md
+++ b/flutter_development/skills/figma-to-flutter/references/flutter-spacing-guide.md
@@ -1,0 +1,284 @@
+# Flutter Spacing Guide
+
+This guide provides methods for extracting spacing values from Figma and converting them to Flutter EdgeInsets and spacing widgets.
+
+## EdgeInsets Mapping
+
+### Basic Patterns
+
+| Figma Padding | Flutter EdgeInsets |
+|---------------|-------------------|
+| All sides equal | `EdgeInsets.all(16)` |
+| Horizontal + Vertical | `EdgeInsets.symmetric(horizontal: 24, vertical: 16)` |
+| Individual sides | `EdgeInsets.only(left: 16, top: 8, right: 16, bottom: 24)` |
+| Left/Right only | `EdgeInsets.symmetric(horizontal: 16)` |
+| Top/Bottom only | `EdgeInsets.symmetric(vertical: 16)` |
+
+### Figma to EdgeInsets Conversion
+
+**Figma shows:**
+```
+Padding: 16, 24, 16, 24 (top, right, bottom, left)
+```
+
+**Flutter conversion:**
+```dart
+// If top == bottom AND left == right
+EdgeInsets.symmetric(horizontal: 24, vertical: 16)
+
+// If all different
+EdgeInsets.fromLTRB(24, 16, 24, 16) // left, top, right, bottom
+```
+
+### Common EdgeInsets Patterns
+
+```dart
+// Zero padding
+EdgeInsets.zero
+
+// All sides equal
+EdgeInsets.all(16)
+
+// Symmetric
+EdgeInsets.symmetric(horizontal: 24, vertical: 16)
+
+// Only specific sides
+EdgeInsets.only(top: 16, bottom: 24)
+
+// LTRB (Left, Top, Right, Bottom)
+EdgeInsets.fromLTRB(16, 8, 16, 24)
+```
+
+## Gap/Spacing Between Elements
+
+### Using SizedBox
+
+**For vertical spacing in Column:**
+```dart
+Column(
+  children: [
+    Text('First'),
+    SizedBox(height: 16),
+    Text('Second'),
+    SizedBox(height: 8),
+    Text('Third'),
+  ],
+)
+```
+
+**For horizontal spacing in Row:**
+```dart
+Row(
+  children: [
+    Icon(Icons.star),
+    SizedBox(width: 8),
+    Text('Label'),
+  ],
+)
+```
+
+### Using the gap Package
+
+```dart
+// pubspec.yaml: gap: ^3.0.1
+
+Column(
+  children: [
+    Text('First'),
+    Gap(16),
+    Text('Second'),
+    Gap(8),
+    Text('Third'),
+  ],
+)
+```
+
+### Using MainAxisAlignment for Distribution
+
+```dart
+Row(
+  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+  children: [Widget1(), Widget2(), Widget3()],
+)
+
+// Results in equal space between widgets, widgets at edges
+```
+
+| MainAxisAlignment | Behavior |
+|-------------------|----------|
+| `spaceBetween` | Equal space between, first/last at edges |
+| `spaceAround` | Equal space around each widget |
+| `spaceEvenly` | Equal space everywhere including edges |
+
+## Border Radius
+
+### Figma to Flutter Mapping
+
+| Figma Border Radius | Flutter BorderRadius |
+|--------------------|---------------------|
+| All corners equal | `BorderRadius.circular(12)` |
+| Top corners only | `BorderRadius.vertical(top: Radius.circular(12))` |
+| Bottom corners only | `BorderRadius.vertical(bottom: Radius.circular(12))` |
+| Left corners only | `BorderRadius.horizontal(left: Radius.circular(12))` |
+| Individual corners | `BorderRadius.only(topLeft: Radius.circular(12), ...)` |
+
+### Common Patterns
+
+```dart
+// All corners equal
+BorderRadius.circular(12)
+
+// Pill shape (half of height)
+BorderRadius.circular(24) // for 48px height button
+
+// Top corners only (for bottom sheets)
+BorderRadius.vertical(top: Radius.circular(24))
+
+// Individual corners
+BorderRadius.only(
+  topLeft: Radius.circular(12),
+  topRight: Radius.circular(12),
+  bottomLeft: Radius.circular(0),
+  bottomRight: Radius.circular(0),
+)
+```
+
+## Margin vs Padding
+
+In Flutter, "margin" is typically achieved with:
+
+### 1. Container margin property
+```dart
+Container(
+  margin: EdgeInsets.all(16),
+  child: Content(),
+)
+```
+
+### 2. Padding widget (around the element)
+```dart
+Padding(
+  padding: EdgeInsets.all(16),
+  child: Content(),
+)
+```
+
+### 3. SizedBox for specific spacing
+```dart
+Column(
+  children: [
+    SizedBox(height: 16), // Top margin
+    Content(),
+    SizedBox(height: 16), // Bottom margin
+  ],
+)
+```
+
+## Spacing Scale Recommendation
+
+Consider using a consistent spacing scale:
+
+```dart
+abstract class AppSpacing {
+  static const double xs = 4;
+  static const double sm = 8;
+  static const double md = 16;
+  static const double lg = 24;
+  static const double xl = 32;
+  static const double xxl = 48;
+}
+
+// Usage
+EdgeInsets.all(AppSpacing.md)
+SizedBox(height: AppSpacing.lg)
+```
+
+## Figma Auto Layout Spacing
+
+### Item Spacing (Gap)
+
+Figma's "Item spacing" in Auto Layout translates to:
+
+**Option 1: SizedBox between items**
+```dart
+Column(
+  children: [
+    Item1(),
+    SizedBox(height: 16), // Item spacing
+    Item2(),
+    SizedBox(height: 16),
+    Item3(),
+  ],
+)
+```
+
+**Option 2: Use List.separated**
+```dart
+ListView.separated(
+  itemCount: items.length,
+  separatorBuilder: (_, __) => SizedBox(height: 16),
+  itemBuilder: (context, index) => ItemWidget(items[index]),
+)
+```
+
+### Padding
+
+Figma's "Padding" in Auto Layout translates to Container/Padding:
+
+```dart
+Container(
+  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+  child: Column(children: [...]),
+)
+```
+
+## Responsive Spacing
+
+For responsive spacing, consider screen size:
+
+```dart
+EdgeInsets responsivePadding(BuildContext context) {
+  final width = MediaQuery.of(context).size.width;
+  if (width < 600) {
+    return EdgeInsets.all(16); // Mobile
+  } else if (width < 1200) {
+    return EdgeInsets.all(24); // Tablet
+  } else {
+    return EdgeInsets.all(32); // Desktop
+  }
+}
+```
+
+## Common Spacing Values
+
+| Use Case | Typical Value |
+|----------|---------------|
+| Tight spacing (icons, badges) | 4-8 |
+| Normal spacing (list items) | 12-16 |
+| Section spacing | 24-32 |
+| Page padding (mobile) | 16-20 |
+| Page padding (tablet) | 24-32 |
+| Card padding | 16-24 |
+| Button padding (horizontal) | 16-24 |
+| Button padding (vertical) | 8-16 |
+
+## Tips
+
+1. **Use const for static EdgeInsets:**
+   ```dart
+   static const padding = EdgeInsets.all(16);
+   ```
+
+2. **Prefer EdgeInsets.symmetric when applicable:**
+   It's more readable than LTRB
+
+3. **Create spacing constants:**
+   Define a spacing scale for consistency
+
+4. **Consider SafeArea:**
+   For screen-level padding, use SafeArea widget
+
+5. **Use MediaQuery.padding for system UI:**
+   ```dart
+   final systemPadding = MediaQuery.of(context).padding;
+   ```

--- a/flutter_development/skills/figma-to-flutter/references/flutter-typography-guide.md
+++ b/flutter_development/skills/figma-to-flutter/references/flutter-typography-guide.md
@@ -1,0 +1,378 @@
+# Flutter Typography Guide
+
+This guide provides methods for extracting typography from Figma and converting to Flutter TextStyle.
+
+## TextStyle Mapping
+
+### Basic Figma to Flutter Conversion
+
+| Figma Property | Flutter TextStyle Property |
+|----------------|---------------------------|
+| Font family | `fontFamily` |
+| Font size | `fontSize` |
+| Font weight | `fontWeight` |
+| Line height (%) | `height` (ratio) |
+| Letter spacing | `letterSpacing` |
+| Color | `color` |
+| Text decoration | `decoration` |
+| Text case | (handled separately) |
+
+### Complete TextStyle Example
+
+**Figma shows:**
+```
+Font: Roboto
+Size: 16px
+Weight: Semi Bold (600)
+Line height: 150%
+Letter spacing: 0.5px
+Color: #1A1A1A
+```
+
+**Flutter conversion:**
+```dart
+TextStyle(
+  fontFamily: 'Roboto',
+  fontSize: 16,
+  fontWeight: FontWeight.w600,
+  height: 1.5, // 150% / 100
+  letterSpacing: 0.5,
+  color: Color(0xFF1A1A1A),
+)
+```
+
+## Font Weight Mapping
+
+| Figma Weight | Flutter FontWeight |
+|--------------|-------------------|
+| Thin (100) | `FontWeight.w100` |
+| Extra Light (200) | `FontWeight.w200` |
+| Light (300) | `FontWeight.w300` |
+| Regular (400) | `FontWeight.w400` or `FontWeight.normal` |
+| Medium (500) | `FontWeight.w500` |
+| Semi Bold (600) | `FontWeight.w600` |
+| Bold (700) | `FontWeight.w700` or `FontWeight.bold` |
+| Extra Bold (800) | `FontWeight.w800` |
+| Black (900) | `FontWeight.w900` |
+
+## Line Height Conversion
+
+Figma shows line height as:
+- **Percentage**: 150% → `height: 1.5`
+- **Pixels**: 24px (for 16px font) → `height: 1.5` (24/16)
+- **Auto**: Use default (omit height property)
+
+```dart
+// Figma: Line height 150%
+TextStyle(
+  fontSize: 16,
+  height: 1.5, // Always a ratio, not pixels
+)
+
+// Figma: Line height 24px with 16px font
+TextStyle(
+  fontSize: 16,
+  height: 24 / 16, // = 1.5
+)
+```
+
+## Color Conversion
+
+### Hex to Color
+
+```dart
+// Figma: #2196F3
+Color(0xFF2196F3) // Add 0xFF prefix for full opacity
+
+// Figma: #2196F3 with 80% opacity
+Color(0xFF2196F3).withOpacity(0.8)
+// or
+Color(0xCC2196F3) // CC = 80% of FF (204/255)
+
+// Figma: rgba(33, 150, 243, 0.8)
+Color.fromRGBO(33, 150, 243, 0.8)
+```
+
+### Opacity Hex Values
+
+| Opacity | Hex Value |
+|---------|-----------|
+| 100% | FF |
+| 90% | E6 |
+| 80% | CC |
+| 70% | B3 |
+| 60% | 99 |
+| 50% | 80 |
+| 40% | 66 |
+| 30% | 4D |
+| 20% | 33 |
+| 10% | 1A |
+| 0% | 00 |
+
+## Text Decoration
+
+| Figma Decoration | Flutter Decoration |
+|------------------|-------------------|
+| Underline | `decoration: TextDecoration.underline` |
+| Strikethrough | `decoration: TextDecoration.lineThrough` |
+| None | `decoration: TextDecoration.none` |
+
+```dart
+TextStyle(
+  decoration: TextDecoration.underline,
+  decorationColor: Colors.red,
+  decorationStyle: TextDecorationStyle.dashed,
+  decorationThickness: 2,
+)
+```
+
+## Text Transform
+
+Flutter doesn't have a TextStyle property for text transform. Handle it in the Text widget:
+
+```dart
+// Uppercase
+Text(text.toUpperCase())
+
+// Lowercase
+Text(text.toLowerCase())
+
+// Capitalize (first letter of each word)
+Text(text.split(' ').map((word) =>
+  word.isNotEmpty ? '${word[0].toUpperCase()}${word.substring(1)}' : ''
+).join(' '))
+```
+
+## Material Design TextTheme Integration
+
+Map Figma typography to Material TextTheme:
+
+| Figma Text Style | Material TextTheme |
+|------------------|-------------------|
+| Display Large | `displayLarge` (57sp) |
+| Display Medium | `displayMedium` (45sp) |
+| Display Small | `displaySmall` (36sp) |
+| Headline Large | `headlineLarge` (32sp) |
+| Headline Medium | `headlineMedium` (28sp) |
+| Headline Small | `headlineSmall` (24sp) |
+| Title Large | `titleLarge` (22sp) |
+| Title Medium | `titleMedium` (16sp) |
+| Title Small | `titleSmall` (14sp) |
+| Body Large | `bodyLarge` (16sp) |
+| Body Medium | `bodyMedium` (14sp) |
+| Body Small | `bodySmall` (12sp) |
+| Label Large | `labelLarge` (14sp) |
+| Label Medium | `labelMedium` (12sp) |
+| Label Small | `labelSmall` (11sp) |
+
+**Usage:**
+```dart
+Text(
+  'Hello',
+  style: Theme.of(context).textTheme.headlineMedium,
+)
+```
+
+## Custom Font Setup
+
+### 1. Add font files to pubspec.yaml
+
+```yaml
+flutter:
+  fonts:
+    - family: Roboto
+      fonts:
+        - asset: fonts/Roboto-Regular.ttf
+        - asset: fonts/Roboto-Medium.ttf
+          weight: 500
+        - asset: fonts/Roboto-Bold.ttf
+          weight: 700
+    - family: CustomFont
+      fonts:
+        - asset: fonts/CustomFont-Regular.ttf
+        - asset: fonts/CustomFont-Bold.ttf
+          weight: 700
+```
+
+### 2. Use in TextStyle
+
+```dart
+TextStyle(
+  fontFamily: 'CustomFont',
+  fontSize: 16,
+  fontWeight: FontWeight.w700,
+)
+```
+
+### 3. Using Google Fonts package
+
+```dart
+// pubspec.yaml: google_fonts: ^6.1.0
+
+import 'package:google_fonts/google_fonts.dart';
+
+Text(
+  'Hello',
+  style: GoogleFonts.roboto(
+    fontSize: 16,
+    fontWeight: FontWeight.w600,
+  ),
+)
+
+// Or in theme
+ThemeData(
+  textTheme: GoogleFonts.robotoTextTheme(),
+)
+```
+
+## Typography System Definition
+
+Create a centralized typography system:
+
+```dart
+abstract class AppTypography {
+  // Headings
+  static const TextStyle h1 = TextStyle(
+    fontFamily: 'Roboto',
+    fontSize: 32,
+    fontWeight: FontWeight.w700,
+    height: 1.25,
+    letterSpacing: -0.5,
+  );
+
+  static const TextStyle h2 = TextStyle(
+    fontFamily: 'Roboto',
+    fontSize: 24,
+    fontWeight: FontWeight.w600,
+    height: 1.33,
+  );
+
+  // Body
+  static const TextStyle bodyLarge = TextStyle(
+    fontFamily: 'Roboto',
+    fontSize: 16,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+  );
+
+  static const TextStyle bodyMedium = TextStyle(
+    fontFamily: 'Roboto',
+    fontSize: 14,
+    fontWeight: FontWeight.w400,
+    height: 1.5,
+  );
+
+  // Labels
+  static const TextStyle labelLarge = TextStyle(
+    fontFamily: 'Roboto',
+    fontSize: 14,
+    fontWeight: FontWeight.w500,
+    height: 1.43,
+    letterSpacing: 0.1,
+  );
+}
+```
+
+## Common Typography Patterns
+
+### Button Text
+```dart
+TextStyle(
+  fontSize: 14,
+  fontWeight: FontWeight.w600,
+  letterSpacing: 0.5,
+)
+```
+
+### Input Placeholder
+```dart
+TextStyle(
+  fontSize: 16,
+  fontWeight: FontWeight.w400,
+  color: Colors.grey,
+)
+```
+
+### Caption/Helper Text
+```dart
+TextStyle(
+  fontSize: 12,
+  fontWeight: FontWeight.w400,
+  color: Colors.grey[600],
+  height: 1.33,
+)
+```
+
+### Error Text
+```dart
+TextStyle(
+  fontSize: 12,
+  fontWeight: FontWeight.w400,
+  color: Colors.red,
+)
+```
+
+## Rich Text
+
+For mixed styling within a single text block:
+
+```dart
+RichText(
+  text: TextSpan(
+    style: TextStyle(color: Colors.black),
+    children: [
+      TextSpan(text: 'Normal text '),
+      TextSpan(
+        text: 'bold text',
+        style: TextStyle(fontWeight: FontWeight.bold),
+      ),
+      TextSpan(text: ' and '),
+      TextSpan(
+        text: 'colored text',
+        style: TextStyle(color: Colors.blue),
+      ),
+    ],
+  ),
+)
+```
+
+## Text Overflow
+
+| Figma Behavior | Flutter TextOverflow |
+|----------------|---------------------|
+| Truncate with ... | `overflow: TextOverflow.ellipsis` |
+| Clip | `overflow: TextOverflow.clip` |
+| Fade | `overflow: TextOverflow.fade` |
+| Visible (overflow) | `overflow: TextOverflow.visible` |
+
+```dart
+Text(
+  'Long text that might overflow',
+  overflow: TextOverflow.ellipsis,
+  maxLines: 2,
+)
+```
+
+## Tips
+
+1. **Use const for static TextStyles:**
+   ```dart
+   static const TextStyle bodyText = TextStyle(...);
+   ```
+
+2. **Inherit and modify:**
+   ```dart
+   Theme.of(context).textTheme.bodyLarge?.copyWith(
+     color: Colors.red,
+   )
+   ```
+
+3. **Line height is a ratio:**
+   Always divide Figma's pixel value by font size
+
+4. **Use Theme for consistency:**
+   Define TextTheme in ThemeData for app-wide consistency
+
+5. **Consider accessibility:**
+   - Respect user's text scaling: `MediaQuery.textScaleFactorOf(context)`
+   - Minimum 12sp for body text

--- a/flutter_development/skills/flutter-implementation/SKILL.md
+++ b/flutter_development/skills/flutter-implementation/SKILL.md
@@ -1,0 +1,868 @@
+---
+name: flutter-implementation
+description: Generate production-ready Flutter widgets from design specifications. Use this skill when you have a design specification document and need to create Flutter/Dart widgets with proper state management, Riverpod integration, widget tests, and native platform integration when required.
+---
+
+# Flutter Implementation Skill
+
+## Overview
+
+Generate production-ready Flutter widgets from design specifications created by the `figma-to-flutter` skill. This skill focuses on creating well-structured, testable, and maintainable Flutter code that follows best practices.
+
+**Use this skill when:**
+- You have a design specification document from `figma-to-flutter`
+- Need to implement Flutter widgets with proper architecture
+- Require Riverpod state management integration
+- Need widget tests for the implementation
+- Require native platform integration (iOS/Android)
+
+## Prerequisites
+
+Before using this skill, ensure you have:
+1. A design specification document (from `figma-to-flutter` or manually created)
+2. Understanding of the project's existing architecture
+3. Knowledge of the project's design system/theme (if exists)
+
+## Core Workflow
+
+### Step 1: Analyze the Design Specification
+
+Read and understand the design specification:
+
+1. **Extract widget information:**
+   - Widget name
+   - Atomic category (Atom/Molecule/Organism)
+   - Widget type (StatelessWidget/StatefulWidget/ConsumerWidget)
+
+2. **Identify dependencies:**
+   - Required packages
+   - Theme dependencies
+   - State management needs
+   - Native platform requirements
+
+3. **Understand the widget structure:**
+   - Constructor parameters
+   - Layout hierarchy
+   - Child widgets
+
+### Step 2: Set Up File Structure
+
+Create files based on atomic category:
+
+```
+lib/presentation/widgets/
+├── atoms/
+│   └── [widget_name]/
+│       ├── [widget_name].dart
+│       └── [widget_name]_test.dart
+├── molecules/
+│   └── [widget_name]/
+│       ├── [widget_name].dart
+│       └── [widget_name]_test.dart
+└── organisms/
+    └── [widget_name]/
+        ├── [widget_name].dart
+        └── [widget_name]_test.dart
+```
+
+For screens:
+```
+lib/presentation/screens/
+└── [feature]/
+    ├── [screen_name]_screen.dart
+    ├── [screen_name]_view_model.dart
+    └── [screen_name]_ui_state.dart
+```
+
+### Step 3: Generate Widget Code
+
+#### For StatelessWidget (No State)
+
+```dart
+import 'package:flutter/material.dart';
+
+/// {@template widget_name}
+/// A brief description of what this widget does.
+/// {@endtemplate}
+class WidgetName extends StatelessWidget {
+  /// {@macro widget_name}
+  const WidgetName({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.variant = WidgetVariant.primary,
+  });
+
+  /// The text displayed on the widget.
+  final String label;
+
+  /// Called when the widget is pressed.
+  final VoidCallback? onPressed;
+
+  /// The visual variant of the widget.
+  final WidgetVariant variant;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      // Implementation based on design spec
+    );
+  }
+}
+
+/// Variants for [WidgetName].
+enum WidgetVariant {
+  /// Primary variant with filled background.
+  primary,
+
+  /// Secondary variant with outlined style.
+  secondary,
+
+  /// Tertiary variant with text-only style.
+  tertiary,
+}
+```
+
+#### For StatefulWidget (With Local State)
+
+```dart
+import 'package:flutter/material.dart';
+
+/// {@template widget_name}
+/// A brief description of what this widget does.
+/// {@endtemplate}
+class WidgetName extends StatefulWidget {
+  /// {@macro widget_name}
+  const WidgetName({
+    super.key,
+    required this.initialValue,
+    this.onChanged,
+  });
+
+  /// The initial value for the widget.
+  final String initialValue;
+
+  /// Called when the value changes.
+  final ValueChanged<String>? onChanged;
+
+  @override
+  State<WidgetName> createState() => _WidgetNameState();
+}
+
+class _WidgetNameState extends State<WidgetName> {
+  late String _value;
+
+  @override
+  void initState() {
+    super.initState();
+    _value = widget.initialValue;
+  }
+
+  void _handleChange(String newValue) {
+    setState(() {
+      _value = newValue;
+    });
+    widget.onChanged?.call(newValue);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      // Implementation based on design spec
+    );
+  }
+}
+```
+
+#### For ConsumerWidget (With Riverpod)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// {@template widget_name}
+/// A brief description of what this widget does.
+/// {@endtemplate}
+class WidgetName extends ConsumerWidget {
+  /// {@macro widget_name}
+  const WidgetName({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(widgetStateProvider);
+
+    return Container(
+      // Implementation based on design spec
+    );
+  }
+}
+```
+
+#### For HooksConsumerWidget (With Riverpod + Hooks)
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+/// {@template widget_name}
+/// A brief description of what this widget does.
+/// {@endtemplate}
+class WidgetName extends HookConsumerWidget {
+  /// {@macro widget_name}
+  const WidgetName({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final controller = useTextEditingController();
+    final state = ref.watch(widgetStateProvider);
+
+    return Container(
+      // Implementation based on design spec
+    );
+  }
+}
+```
+
+### Step 4: Implement Layout
+
+Based on the design specification's layout section:
+
+1. **Read layout mapping guide:**
+   ```
+   Read references/widget-patterns.md
+   ```
+
+2. **Apply layout widgets:**
+
+```dart
+// For vertical arrangement
+Column(
+  mainAxisAlignment: MainAxisAlignment.start,
+  crossAxisAlignment: CrossAxisAlignment.stretch,
+  children: [
+    // Children with SizedBox for spacing
+  ],
+)
+
+// For horizontal arrangement
+Row(
+  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+  crossAxisAlignment: CrossAxisAlignment.center,
+  children: [
+    // Children
+  ],
+)
+
+// For overlapping elements
+Stack(
+  children: [
+    // Background
+    Positioned(
+      top: 16,
+      right: 16,
+      child: // Overlay widget
+    ),
+  ],
+)
+```
+
+### Step 5: Apply Styling
+
+Based on the design specification's styling sections:
+
+```dart
+Container(
+  padding: EdgeInsets.symmetric(horizontal: 24, vertical: 16),
+  decoration: BoxDecoration(
+    color: Color(0xFF2196F3),
+    borderRadius: BorderRadius.circular(12),
+    boxShadow: [
+      BoxShadow(
+        color: Color(0x1A000000),
+        blurRadius: 8,
+        offset: Offset(0, 4),
+      ),
+    ],
+  ),
+  child: Text(
+    label,
+    style: TextStyle(
+      fontFamily: 'Roboto',
+      fontSize: 16,
+      fontWeight: FontWeight.w600,
+      color: Colors.white,
+    ),
+  ),
+)
+```
+
+### Step 6: Handle States and Variants
+
+Implement all states from the design specification:
+
+```dart
+class AppButton extends StatelessWidget {
+  const AppButton({
+    super.key,
+    required this.label,
+    this.onPressed,
+    this.variant = ButtonVariant.primary,
+    this.size = ButtonSize.medium,
+    this.isLoading = false,
+  });
+
+  final String label;
+  final VoidCallback? onPressed;
+  final ButtonVariant variant;
+  final ButtonSize size;
+  final bool isLoading;
+
+  bool get _isDisabled => onPressed == null || isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    return Opacity(
+      opacity: _isDisabled ? 0.5 : 1.0,
+      child: InkWell(
+        onTap: _isDisabled ? null : onPressed,
+        borderRadius: BorderRadius.circular(_borderRadius),
+        child: Container(
+          padding: _padding,
+          decoration: BoxDecoration(
+            color: _backgroundColor,
+            borderRadius: BorderRadius.circular(_borderRadius),
+            border: _border,
+          ),
+          child: isLoading
+              ? SizedBox(
+                  width: 20,
+                  height: 20,
+                  child: CircularProgressIndicator(
+                    strokeWidth: 2,
+                    color: _textColor,
+                  ),
+                )
+              : Text(
+                  label,
+                  style: TextStyle(
+                    fontSize: _fontSize,
+                    fontWeight: FontWeight.w600,
+                    color: _textColor,
+                  ),
+                ),
+        ),
+      ),
+    );
+  }
+
+  EdgeInsets get _padding {
+    switch (size) {
+      case ButtonSize.small:
+        return EdgeInsets.symmetric(horizontal: 16, vertical: 8);
+      case ButtonSize.medium:
+        return EdgeInsets.symmetric(horizontal: 24, vertical: 12);
+      case ButtonSize.large:
+        return EdgeInsets.symmetric(horizontal: 32, vertical: 16);
+    }
+  }
+
+  double get _fontSize {
+    switch (size) {
+      case ButtonSize.small:
+        return 14;
+      case ButtonSize.medium:
+        return 16;
+      case ButtonSize.large:
+        return 18;
+    }
+  }
+
+  double get _borderRadius => 8;
+
+  Color get _backgroundColor {
+    switch (variant) {
+      case ButtonVariant.primary:
+        return Color(0xFF2196F3);
+      case ButtonVariant.secondary:
+        return Colors.white;
+      case ButtonVariant.tertiary:
+        return Colors.transparent;
+    }
+  }
+
+  Color get _textColor {
+    switch (variant) {
+      case ButtonVariant.primary:
+        return Colors.white;
+      case ButtonVariant.secondary:
+      case ButtonVariant.tertiary:
+        return Color(0xFF2196F3);
+    }
+  }
+
+  Border? get _border {
+    switch (variant) {
+      case ButtonVariant.secondary:
+        return Border.all(color: Color(0xFF2196F3), width: 1);
+      default:
+        return null;
+    }
+  }
+}
+
+enum ButtonVariant { primary, secondary, tertiary }
+enum ButtonSize { small, medium, large }
+```
+
+### Step 7: Add Accessibility
+
+Implement accessibility features:
+
+```dart
+Semantics(
+  label: 'Submit button',
+  button: true,
+  enabled: !_isDisabled,
+  child: InkWell(
+    onTap: onPressed,
+    child: // Widget content
+  ),
+)
+```
+
+For custom widgets:
+```dart
+class AppButton extends StatelessWidget {
+  // ...
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: semanticLabel ?? label,
+      button: true,
+      enabled: !_isDisabled,
+      child: ExcludeSemantics(
+        child: // Visual widget
+      ),
+    );
+  }
+}
+```
+
+### Step 8: Generate Widget Tests
+
+Create comprehensive widget tests:
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_app/presentation/widgets/atoms/app_button/app_button.dart';
+
+void main() {
+  group('AppButton', () {
+    testWidgets('renders label correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppButton(
+              label: 'Test Button',
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Button'), findsOneWidget);
+    });
+
+    testWidgets('calls onPressed when tapped', (tester) async {
+      var pressed = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppButton(
+              label: 'Test',
+              onPressed: () => pressed = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(AppButton));
+      expect(pressed, isTrue);
+    });
+
+    testWidgets('shows loading indicator when isLoading is true', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppButton(
+              label: 'Test',
+              onPressed: () {},
+              isLoading: true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Test'), findsNothing);
+    });
+
+    testWidgets('is disabled when onPressed is null', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppButton(
+              label: 'Test',
+              onPressed: null,
+            ),
+          ),
+        ),
+      );
+
+      final opacity = tester.widget<Opacity>(find.byType(Opacity));
+      expect(opacity.opacity, 0.5);
+    });
+
+    group('variants', () {
+      testWidgets('primary variant has correct background color', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton(
+                label: 'Test',
+                onPressed: () {},
+                variant: ButtonVariant.primary,
+              ),
+            ),
+          ),
+        );
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(AppButton),
+            matching: find.byType(Container),
+          ),
+        );
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.color, Color(0xFF2196F3));
+      });
+
+      testWidgets('secondary variant has border', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton(
+                label: 'Test',
+                onPressed: () {},
+                variant: ButtonVariant.secondary,
+              ),
+            ),
+          ),
+        );
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(AppButton),
+            matching: find.byType(Container),
+          ),
+        );
+        final decoration = container.decoration as BoxDecoration;
+        expect(decoration.border, isNotNull);
+      });
+    });
+
+    group('sizes', () {
+      testWidgets('small size has correct padding', (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AppButton(
+                label: 'Test',
+                onPressed: () {},
+                size: ButtonSize.small,
+              ),
+            ),
+          ),
+        );
+
+        final container = tester.widget<Container>(
+          find.descendant(
+            of: find.byType(AppButton),
+            matching: find.byType(Container),
+          ),
+        );
+        expect(
+          container.padding,
+          EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+        );
+      });
+    });
+  });
+}
+```
+
+### Step 9: Handle Native Platform Integration
+
+When the design specification indicates native platform requirements:
+
+1. **Read native integration guide:**
+   ```
+   Read references/native-integration-guide.md
+   ```
+
+2. **Identify the integration pattern:**
+   - **MethodChannel**: For calling native code
+   - **EventChannel**: For streaming data from native
+   - **Platform Views**: For embedding native UI
+
+3. **Create platform interface:**
+
+```dart
+// lib/services/camera_service.dart
+import 'package:flutter/services.dart';
+
+class CameraService {
+  static const _channel = MethodChannel('app.example/camera');
+
+  Future<String?> takePicture() async {
+    try {
+      final result = await _channel.invokeMethod<String>('takePicture');
+      return result;
+    } on PlatformException catch (e) {
+      throw CameraException(e.message ?? 'Unknown error');
+    }
+  }
+}
+
+class CameraException implements Exception {
+  final String message;
+  CameraException(this.message);
+}
+```
+
+4. **Document native implementation requirements:**
+
+```markdown
+## Native Implementation Required
+
+### iOS (Swift)
+Use the `ios-development` skills for implementation:
+- `/swiftui-components` for camera UI
+- Reference: AVFoundation for camera access
+
+### Android (Kotlin)
+Create MethodChannel handler:
+- Use Camera2 API
+- Handle permissions
+```
+
+5. **Recommend related skills:**
+   - For iOS: `ios-development/swiftui-components`
+   - For Android: Reference Android development patterns
+
+### Step 10: Create Screen Implementation (For Pages)
+
+For screen-level widgets with MVVM pattern:
+
+**UIState (Immutable State Class):**
+```dart
+// lib/presentation/screens/product/product_list_ui_state.dart
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'product_list_ui_state.freezed.dart';
+
+@freezed
+class ProductListUIState with _$ProductListUIState {
+  const factory ProductListUIState({
+    @Default([]) List<Product> products,
+    @Default(false) bool isLoading,
+    String? error,
+    @Default('') String searchQuery,
+  }) = _ProductListUIState;
+}
+```
+
+**ViewModel (StateNotifier):**
+```dart
+// lib/presentation/screens/product/product_list_view_model.dart
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+final productListViewModelProvider =
+    StateNotifierProvider<ProductListViewModel, ProductListUIState>((ref) {
+  return ProductListViewModel(ref.read(productRepositoryProvider));
+});
+
+class ProductListViewModel extends StateNotifier<ProductListUIState> {
+  ProductListViewModel(this._repository) : super(const ProductListUIState());
+
+  final ProductRepository _repository;
+
+  Future<void> loadProducts() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final products = await _repository.getProducts();
+      state = state.copyWith(products: products, isLoading: false);
+    } catch (e) {
+      state = state.copyWith(error: e.toString(), isLoading: false);
+    }
+  }
+
+  void search(String query) {
+    state = state.copyWith(searchQuery: query);
+    // Implement search logic
+  }
+}
+```
+
+**Screen Widget:**
+```dart
+// lib/presentation/screens/product/product_list_screen.dart
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+
+@RoutePage()
+class ProductListScreen extends HookConsumerWidget {
+  const ProductListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(productListViewModelProvider);
+    final viewModel = ref.read(productListViewModelProvider.notifier);
+
+    useEffect(() {
+      viewModel.loadProducts();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Products'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.search),
+            onPressed: () => _showSearch(context),
+          ),
+        ],
+      ),
+      body: _buildBody(state),
+    );
+  }
+
+  Widget _buildBody(ProductListUIState state) {
+    if (state.isLoading) {
+      return Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null) {
+      return Center(child: Text('Error: ${state.error}'));
+    }
+
+    if (state.products.isEmpty) {
+      return Center(child: Text('No products found'));
+    }
+
+    return GridView.builder(
+      padding: EdgeInsets.all(16),
+      gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+        crossAxisCount: 2,
+        mainAxisSpacing: 16,
+        crossAxisSpacing: 16,
+        childAspectRatio: 0.75,
+      ),
+      itemCount: state.products.length,
+      itemBuilder: (context, index) => ProductCard(
+        product: state.products[index],
+      ),
+    );
+  }
+
+  void _showSearch(BuildContext context) {
+    // Implement search modal
+  }
+}
+```
+
+## Best Practices
+
+1. **Use const constructors:**
+   ```dart
+   const AppButton({super.key, required this.label});
+   ```
+
+2. **Document public APIs:**
+   ```dart
+   /// {@template app_button}
+   /// A customizable button widget.
+   /// {@endtemplate}
+   ```
+
+3. **Follow Flutter naming conventions:**
+   - Classes: PascalCase
+   - Variables/methods: camelCase
+   - Files: snake_case
+
+4. **Keep widgets focused:**
+   - Single responsibility
+   - Extract complex logic
+
+5. **Use theme when possible:**
+   ```dart
+   Theme.of(context).textTheme.bodyLarge
+   ```
+
+6. **Handle edge cases:**
+   - Empty states
+   - Loading states
+   - Error states
+
+## Resources
+
+This skill includes comprehensive guides:
+
+### references/
+
+- **widget-patterns.md**: Common widget implementation patterns
+- **riverpod-patterns.md**: State management with Riverpod
+- **testing-guide.md**: Widget testing best practices
+- **native-integration-guide.md**: Platform-specific integration (optional)
+
+## Common Pitfalls
+
+1. **Not using const:**
+   - Always use const for static widgets
+
+2. **Forgetting to dispose resources:**
+   - Dispose controllers, streams in StatefulWidget
+
+3. **Hardcoding values:**
+   - Use theme and design tokens
+
+4. **Missing null safety:**
+   - Handle nullable values properly
+
+5. **Not testing edge cases:**
+   - Test disabled, loading, error states
+
+6. **Ignoring accessibility:**
+   - Add semantic labels
+
+## Output Format
+
+The implementation should include:
+
+1. **Widget file** with proper documentation
+2. **Test file** with comprehensive tests
+3. **Supporting files** (enums, models if needed)
+4. **Integration notes** for native features (if applicable)
+
+## Related Skills
+
+- **figma-to-flutter**: Design specification extraction
+- **flutter-widget-assistant**: Architecture decision support
+- **ios-development/swiftui-components**: iOS native implementation
+- **android-test-runner**: Android test execution

--- a/flutter_development/skills/flutter-implementation/references/riverpod-patterns.md
+++ b/flutter_development/skills/flutter-implementation/references/riverpod-patterns.md
@@ -1,0 +1,587 @@
+# Riverpod Patterns Guide
+
+Common state management patterns using Riverpod in Flutter.
+
+## Provider Types
+
+### Provider (Read-Only)
+
+For computed values or simple read-only data:
+
+```dart
+final greetingProvider = Provider<String>((ref) {
+  final user = ref.watch(userProvider);
+  return 'Hello, ${user.name}!';
+});
+```
+
+### StateProvider (Simple State)
+
+For simple state that can be modified:
+
+```dart
+final counterProvider = StateProvider<int>((ref) => 0);
+
+// Usage in widget
+final count = ref.watch(counterProvider);
+ref.read(counterProvider.notifier).state++;
+```
+
+### StateNotifierProvider (Complex State)
+
+For complex state with multiple actions:
+
+```dart
+// State class (using freezed)
+@freezed
+class CartState with _$CartState {
+  const factory CartState({
+    @Default([]) List<CartItem> items,
+    @Default(false) bool isLoading,
+    String? error,
+  }) = _CartState;
+}
+
+// StateNotifier
+class CartNotifier extends StateNotifier<CartState> {
+  CartNotifier(this._repository) : super(const CartState());
+
+  final CartRepository _repository;
+
+  Future<void> addItem(Product product) async {
+    state = state.copyWith(isLoading: true);
+    try {
+      await _repository.addToCart(product);
+      state = state.copyWith(
+        items: [...state.items, CartItem(product: product, quantity: 1)],
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(error: e.toString(), isLoading: false);
+    }
+  }
+
+  void removeItem(String productId) {
+    state = state.copyWith(
+      items: state.items.where((item) => item.product.id != productId).toList(),
+    );
+  }
+
+  void clearCart() {
+    state = const CartState();
+  }
+}
+
+// Provider
+final cartProvider = StateNotifierProvider<CartNotifier, CartState>((ref) {
+  return CartNotifier(ref.read(cartRepositoryProvider));
+});
+```
+
+### FutureProvider (Async Data)
+
+For async data that doesn't change:
+
+```dart
+final userProfileProvider = FutureProvider<User>((ref) async {
+  final userId = ref.watch(currentUserIdProvider);
+  final repository = ref.read(userRepositoryProvider);
+  return repository.getUser(userId);
+});
+
+// Usage
+final userAsync = ref.watch(userProfileProvider);
+return userAsync.when(
+  data: (user) => Text(user.name),
+  loading: () => CircularProgressIndicator(),
+  error: (e, _) => Text('Error: $e'),
+);
+```
+
+### FutureProvider.family (Parameterized)
+
+For async data with parameters:
+
+```dart
+final productProvider = FutureProvider.family<Product, String>((ref, id) async {
+  final repository = ref.read(productRepositoryProvider);
+  return repository.getProduct(id);
+});
+
+// Usage
+final productAsync = ref.watch(productProvider(productId));
+```
+
+### StreamProvider (Real-time Data)
+
+For streams of data:
+
+```dart
+final messagesProvider = StreamProvider<List<Message>>((ref) {
+  final chatId = ref.watch(currentChatIdProvider);
+  return ref.read(chatRepositoryProvider).getMessages(chatId);
+});
+```
+
+### NotifierProvider (Riverpod 2.0)
+
+Modern approach for complex state:
+
+```dart
+@riverpod
+class Counter extends _$Counter {
+  @override
+  int build() => 0;
+
+  void increment() => state++;
+  void decrement() => state--;
+}
+
+// Generated provider: counterProvider
+```
+
+### AsyncNotifierProvider (Riverpod 2.0)
+
+For async state management:
+
+```dart
+@riverpod
+class Products extends _$Products {
+  @override
+  Future<List<Product>> build() async {
+    return ref.read(productRepositoryProvider).getProducts();
+  }
+
+  Future<void> refresh() async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      return ref.read(productRepositoryProvider).getProducts();
+    });
+  }
+
+  Future<void> addProduct(Product product) async {
+    state = const AsyncLoading();
+    state = await AsyncValue.guard(() async {
+      await ref.read(productRepositoryProvider).addProduct(product);
+      return ref.read(productRepositoryProvider).getProducts();
+    });
+  }
+}
+```
+
+## Common Patterns
+
+### Repository Pattern
+
+```dart
+// Abstract repository
+abstract class ProductRepository {
+  Future<List<Product>> getProducts();
+  Future<Product> getProduct(String id);
+  Future<void> addProduct(Product product);
+  Future<void> deleteProduct(String id);
+}
+
+// Implementation
+class ProductRepositoryImpl implements ProductRepository {
+  ProductRepositoryImpl(this._client);
+
+  final ApiClient _client;
+
+  @override
+  Future<List<Product>> getProducts() async {
+    final response = await _client.get('/products');
+    return (response.data as List)
+        .map((json) => Product.fromJson(json))
+        .toList();
+  }
+
+  // ... other methods
+}
+
+// Provider
+final productRepositoryProvider = Provider<ProductRepository>((ref) {
+  return ProductRepositoryImpl(ref.read(apiClientProvider));
+});
+```
+
+### ViewModel Pattern (MVVM)
+
+```dart
+// UIState
+@freezed
+class ProductListUIState with _$ProductListUIState {
+  const factory ProductListUIState({
+    @Default([]) List<Product> products,
+    @Default([]) List<Product> filteredProducts,
+    @Default(false) bool isLoading,
+    String? error,
+    @Default('') String searchQuery,
+    @Default(SortOrder.newest) SortOrder sortOrder,
+  }) = _ProductListUIState;
+}
+
+enum SortOrder { newest, oldest, priceHigh, priceLow }
+
+// ViewModel
+class ProductListViewModel extends StateNotifier<ProductListUIState> {
+  ProductListViewModel(this._repository) : super(const ProductListUIState());
+
+  final ProductRepository _repository;
+
+  Future<void> loadProducts() async {
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final products = await _repository.getProducts();
+      state = state.copyWith(
+        products: products,
+        filteredProducts: _applyFilters(products),
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(error: e.toString(), isLoading: false);
+    }
+  }
+
+  void search(String query) {
+    state = state.copyWith(
+      searchQuery: query,
+      filteredProducts: _applyFilters(state.products),
+    );
+  }
+
+  void setSortOrder(SortOrder order) {
+    state = state.copyWith(
+      sortOrder: order,
+      filteredProducts: _applyFilters(state.products),
+    );
+  }
+
+  List<Product> _applyFilters(List<Product> products) {
+    var filtered = products;
+
+    // Apply search
+    if (state.searchQuery.isNotEmpty) {
+      filtered = filtered
+          .where((p) =>
+              p.name.toLowerCase().contains(state.searchQuery.toLowerCase()))
+          .toList();
+    }
+
+    // Apply sort
+    switch (state.sortOrder) {
+      case SortOrder.newest:
+        filtered.sort((a, b) => b.createdAt.compareTo(a.createdAt));
+        break;
+      case SortOrder.oldest:
+        filtered.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+        break;
+      case SortOrder.priceHigh:
+        filtered.sort((a, b) => b.price.compareTo(a.price));
+        break;
+      case SortOrder.priceLow:
+        filtered.sort((a, b) => a.price.compareTo(b.price));
+        break;
+    }
+
+    return filtered;
+  }
+}
+
+// Provider
+final productListViewModelProvider =
+    StateNotifierProvider<ProductListViewModel, ProductListUIState>((ref) {
+  return ProductListViewModel(ref.read(productRepositoryProvider));
+});
+```
+
+### Combining Providers
+
+```dart
+// Combine multiple providers
+final dashboardProvider = Provider<DashboardData>((ref) {
+  final user = ref.watch(userProvider);
+  final orders = ref.watch(ordersProvider);
+  final notifications = ref.watch(notificationsProvider);
+
+  return DashboardData(
+    user: user,
+    recentOrders: orders.take(5).toList(),
+    unreadCount: notifications.where((n) => !n.isRead).length,
+  );
+});
+```
+
+### Scoped Providers
+
+```dart
+// Define provider
+final selectedProductProvider = Provider<Product>((ref) {
+  throw UnimplementedError();
+});
+
+// Override in widget tree
+ProviderScope(
+  overrides: [
+    selectedProductProvider.overrideWithValue(product),
+  ],
+  child: ProductDetailView(),
+)
+
+// Use in child widget
+final product = ref.watch(selectedProductProvider);
+```
+
+## Widget Integration
+
+### ConsumerWidget
+
+```dart
+class ProductListScreen extends ConsumerWidget {
+  const ProductListScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final state = ref.watch(productListViewModelProvider);
+    final viewModel = ref.read(productListViewModelProvider.notifier);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: Text('Products'),
+        actions: [
+          IconButton(
+            icon: Icon(Icons.refresh),
+            onPressed: viewModel.loadProducts,
+          ),
+        ],
+      ),
+      body: _buildBody(state),
+    );
+  }
+
+  Widget _buildBody(ProductListUIState state) {
+    if (state.isLoading) {
+      return Center(child: CircularProgressIndicator());
+    }
+
+    if (state.error != null) {
+      return Center(child: Text('Error: ${state.error}'));
+    }
+
+    return ListView.builder(
+      itemCount: state.filteredProducts.length,
+      itemBuilder: (context, index) {
+        return ProductListItem(product: state.filteredProducts[index]);
+      },
+    );
+  }
+}
+```
+
+### HookConsumerWidget
+
+```dart
+class ProductSearchScreen extends HookConsumerWidget {
+  const ProductSearchScreen({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final searchController = useTextEditingController();
+    final debouncer = useMemoized(() => Debouncer(milliseconds: 500));
+    final state = ref.watch(productListViewModelProvider);
+    final viewModel = ref.read(productListViewModelProvider.notifier);
+
+    useEffect(() {
+      viewModel.loadProducts();
+      return null;
+    }, []);
+
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          controller: searchController,
+          decoration: InputDecoration(
+            hintText: 'Search products...',
+            border: InputBorder.none,
+          ),
+          onChanged: (value) {
+            debouncer.run(() => viewModel.search(value));
+          },
+        ),
+      ),
+      body: state.isLoading
+          ? Center(child: CircularProgressIndicator())
+          : ListView.builder(
+              itemCount: state.filteredProducts.length,
+              itemBuilder: (context, index) {
+                return ProductListItem(product: state.filteredProducts[index]);
+              },
+            ),
+    );
+  }
+}
+```
+
+### Consumer (For Partial Rebuilds)
+
+```dart
+class ProductCard extends StatelessWidget {
+  const ProductCard({super.key, required this.product});
+
+  final Product product;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Column(
+        children: [
+          Image.network(product.imageUrl),
+          Text(product.name),
+          // Only this part rebuilds when cart changes
+          Consumer(
+            builder: (context, ref, child) {
+              final isInCart = ref.watch(
+                cartProvider.select(
+                  (state) => state.items.any((i) => i.product.id == product.id),
+                ),
+              );
+              return IconButton(
+                icon: Icon(
+                  isInCart ? Icons.shopping_cart : Icons.add_shopping_cart,
+                ),
+                onPressed: () {
+                  if (isInCart) {
+                    ref.read(cartProvider.notifier).removeItem(product.id);
+                  } else {
+                    ref.read(cartProvider.notifier).addItem(product);
+                  }
+                },
+              );
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## Best Practices
+
+### 1. Use select() for Granular Rebuilds
+
+```dart
+// Bad: Rebuilds on any cart change
+final cart = ref.watch(cartProvider);
+
+// Good: Only rebuilds when item count changes
+final itemCount = ref.watch(cartProvider.select((s) => s.items.length));
+```
+
+### 2. Keep Providers Small and Focused
+
+```dart
+// Bad: One massive provider
+final appStateProvider = StateNotifierProvider<AppStateNotifier, AppState>(...);
+
+// Good: Separate providers by domain
+final userProvider = StateNotifierProvider<UserNotifier, UserState>(...);
+final cartProvider = StateNotifierProvider<CartNotifier, CartState>(...);
+final settingsProvider = StateNotifierProvider<SettingsNotifier, Settings>(...);
+```
+
+### 3. Use AutoDispose When Appropriate
+
+```dart
+// Auto dispose when no longer listened to
+final searchResultsProvider = FutureProvider.autoDispose
+    .family<List<Product>, String>((ref, query) async {
+  return ref.read(productRepositoryProvider).search(query);
+});
+```
+
+### 4. Handle Loading and Error States
+
+```dart
+final productsAsync = ref.watch(productsProvider);
+
+return productsAsync.when(
+  data: (products) => ProductList(products: products),
+  loading: () => Center(child: CircularProgressIndicator()),
+  error: (error, stack) => ErrorView(
+    message: error.toString(),
+    onRetry: () => ref.refresh(productsProvider),
+  ),
+);
+```
+
+### 5. Use ref.listen for Side Effects
+
+```dart
+@override
+Widget build(BuildContext context, WidgetRef ref) {
+  // Listen for auth changes to navigate
+  ref.listen<AuthState>(authProvider, (previous, next) {
+    if (next.isLoggedOut) {
+      context.router.replace(LoginRoute());
+    }
+  });
+
+  // ...
+}
+```
+
+## Testing
+
+### Testing Providers
+
+```dart
+void main() {
+  test('CartNotifier adds item correctly', () {
+    final container = ProviderContainer(
+      overrides: [
+        cartRepositoryProvider.overrideWithValue(MockCartRepository()),
+      ],
+    );
+
+    final notifier = container.read(cartProvider.notifier);
+    final product = Product(id: '1', name: 'Test', price: 10);
+
+    notifier.addItem(product);
+
+    expect(container.read(cartProvider).items.length, 1);
+    expect(container.read(cartProvider).items.first.product, product);
+  });
+}
+```
+
+### Testing Widgets with Providers
+
+```dart
+void main() {
+  testWidgets('ProductListScreen shows products', (tester) async {
+    final products = [
+      Product(id: '1', name: 'Product 1', price: 10),
+      Product(id: '2', name: 'Product 2', price: 20),
+    ];
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          productListViewModelProvider.overrideWith(
+            (ref) => ProductListViewModel(MockProductRepository())
+              ..state = ProductListUIState(
+                products: products,
+                filteredProducts: products,
+              ),
+          ),
+        ],
+        child: MaterialApp(home: ProductListScreen()),
+      ),
+    );
+
+    expect(find.text('Product 1'), findsOneWidget);
+    expect(find.text('Product 2'), findsOneWidget);
+  });
+}
+```

--- a/flutter_development/skills/flutter-implementation/references/testing-guide.md
+++ b/flutter_development/skills/flutter-implementation/references/testing-guide.md
@@ -1,0 +1,584 @@
+# Flutter Widget Testing Guide
+
+Best practices and patterns for testing Flutter widgets.
+
+## Test Setup
+
+### Basic Test Structure
+
+```dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:your_app/widgets/app_button.dart';
+
+void main() {
+  group('AppButton', () {
+    testWidgets('renders label correctly', (tester) async {
+      // Arrange
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: AppButton(
+              label: 'Test Button',
+              onPressed: () {},
+            ),
+          ),
+        ),
+      );
+
+      // Assert
+      expect(find.text('Test Button'), findsOneWidget);
+    });
+  });
+}
+```
+
+### Test Helper Function
+
+```dart
+Widget createTestWidget(Widget child) {
+  return MaterialApp(
+    home: Scaffold(
+      body: child,
+    ),
+  );
+}
+
+// Usage
+await tester.pumpWidget(createTestWidget(AppButton(...)));
+```
+
+### Test with Theme
+
+```dart
+Widget createThemedTestWidget(Widget child) {
+  return MaterialApp(
+    theme: ThemeData(
+      primarySwatch: Colors.blue,
+      textTheme: TextTheme(
+        bodyLarge: TextStyle(fontSize: 16),
+      ),
+    ),
+    home: Scaffold(body: child),
+  );
+}
+```
+
+## Finding Widgets
+
+### Common Finders
+
+```dart
+// By text
+find.text('Hello')
+
+// By widget type
+find.byType(ElevatedButton)
+
+// By key
+find.byKey(Key('submit_button'))
+
+// By icon
+find.byIcon(Icons.search)
+
+// By widget predicate
+find.byWidgetPredicate(
+  (widget) => widget is Text && widget.data?.contains('Error') == true,
+)
+
+// Descendant finder
+find.descendant(
+  of: find.byType(Card),
+  matching: find.text('Title'),
+)
+
+// Ancestor finder
+find.ancestor(
+  of: find.text('Title'),
+  matching: find.byType(Card),
+)
+```
+
+### Finder Matchers
+
+```dart
+// Finds exactly one widget
+expect(find.text('Title'), findsOneWidget);
+
+// Finds nothing
+expect(find.text('Error'), findsNothing);
+
+// Finds multiple widgets
+expect(find.byType(ListTile), findsNWidgets(3));
+
+// Finds at least one
+expect(find.byType(Text), findsWidgets);
+```
+
+## Interactions
+
+### Tap
+
+```dart
+testWidgets('button tap calls onPressed', (tester) async {
+  var tapped = false;
+
+  await tester.pumpWidget(createTestWidget(
+    AppButton(
+      label: 'Tap Me',
+      onPressed: () => tapped = true,
+    ),
+  ));
+
+  await tester.tap(find.text('Tap Me'));
+  await tester.pump(); // Trigger rebuild
+
+  expect(tapped, isTrue);
+});
+```
+
+### Long Press
+
+```dart
+testWidgets('long press shows context menu', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    LongPressWidget(onLongPress: () {}),
+  ));
+
+  await tester.longPress(find.byType(LongPressWidget));
+  await tester.pump();
+
+  expect(find.text('Context Menu'), findsOneWidget);
+});
+```
+
+### Text Entry
+
+```dart
+testWidgets('text field accepts input', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    TextField(key: Key('email_field')),
+  ));
+
+  await tester.enterText(find.byKey(Key('email_field')), 'test@example.com');
+  await tester.pump();
+
+  expect(find.text('test@example.com'), findsOneWidget);
+});
+```
+
+### Scrolling
+
+```dart
+testWidgets('scrolls to show item', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    ListView.builder(
+      itemCount: 100,
+      itemBuilder: (_, i) => ListTile(title: Text('Item $i')),
+    ),
+  ));
+
+  // Scroll down
+  await tester.scrollUntilVisible(
+    find.text('Item 50'),
+    500.0, // scroll amount
+    scrollable: find.byType(Scrollable),
+  );
+
+  expect(find.text('Item 50'), findsOneWidget);
+});
+
+// Or use drag
+testWidgets('drags to scroll', (tester) async {
+  await tester.pumpWidget(createTestWidget(listView));
+
+  await tester.drag(find.byType(ListView), Offset(0, -300));
+  await tester.pump();
+});
+```
+
+### Form Submission
+
+```dart
+testWidgets('form submits with valid data', (tester) async {
+  var submittedEmail = '';
+
+  await tester.pumpWidget(createTestWidget(
+    LoginForm(onSubmit: (email, _) => submittedEmail = email),
+  ));
+
+  await tester.enterText(find.byKey(Key('email')), 'test@example.com');
+  await tester.enterText(find.byKey(Key('password')), 'password123');
+  await tester.tap(find.text('Submit'));
+  await tester.pump();
+
+  expect(submittedEmail, 'test@example.com');
+});
+```
+
+## Async Testing
+
+### Using pump() vs pumpAndSettle()
+
+```dart
+// pump() - advances one frame
+await tester.tap(find.text('Button'));
+await tester.pump(); // One frame
+
+// pump(duration) - advances by duration
+await tester.pump(Duration(milliseconds: 100));
+
+// pumpAndSettle() - pumps until no more frames scheduled
+// Good for animations
+await tester.tap(find.text('Button'));
+await tester.pumpAndSettle();
+
+// pumpAndSettle with timeout
+await tester.pumpAndSettle(Duration(seconds: 5));
+```
+
+### Testing Async Operations
+
+```dart
+testWidgets('shows loading then data', (tester) async {
+  final completer = Completer<List<Product>>();
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        productsProvider.overrideWith((ref) => completer.future),
+      ],
+      child: MaterialApp(home: ProductListScreen()),
+    ),
+  );
+
+  // Initially shows loading
+  expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
+  // Complete the future
+  completer.complete([Product(name: 'Test Product')]);
+  await tester.pumpAndSettle();
+
+  // Now shows data
+  expect(find.byType(CircularProgressIndicator), findsNothing);
+  expect(find.text('Test Product'), findsOneWidget);
+});
+```
+
+### Using FakeAsync
+
+```dart
+testWidgets('debounces search input', (tester) async {
+  await tester.runAsync(() async {
+    var searchCount = 0;
+
+    await tester.pumpWidget(createTestWidget(
+      SearchField(onSearch: (_) => searchCount++),
+    ));
+
+    await tester.enterText(find.byType(TextField), 'a');
+    await tester.enterText(find.byType(TextField), 'ab');
+    await tester.enterText(find.byType(TextField), 'abc');
+
+    // Wait for debounce (500ms)
+    await tester.pump(Duration(milliseconds: 600));
+
+    // Should only search once due to debounce
+    expect(searchCount, 1);
+  });
+});
+```
+
+## Testing with Riverpod
+
+### Basic Provider Override
+
+```dart
+testWidgets('displays user name from provider', (tester) async {
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        userProvider.overrideWithValue(
+          User(name: 'John Doe'),
+        ),
+      ],
+      child: MaterialApp(home: UserProfile()),
+    ),
+  );
+
+  expect(find.text('John Doe'), findsOneWidget);
+});
+```
+
+### Testing StateNotifier
+
+```dart
+testWidgets('cart updates when item added', (tester) async {
+  final container = ProviderContainer();
+
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: MaterialApp(home: CartScreen()),
+    ),
+  );
+
+  // Initial state
+  expect(find.text('Cart (0)'), findsOneWidget);
+
+  // Add item
+  container.read(cartProvider.notifier).addItem(
+    Product(id: '1', name: 'Test', price: 10),
+  );
+  await tester.pump();
+
+  // Updated state
+  expect(find.text('Cart (1)'), findsOneWidget);
+});
+```
+
+### Mocking Repository
+
+```dart
+class MockProductRepository extends Mock implements ProductRepository {}
+
+testWidgets('shows products from repository', (tester) async {
+  final mockRepo = MockProductRepository();
+  when(mockRepo.getProducts()).thenAnswer(
+    (_) async => [Product(name: 'Test Product')],
+  );
+
+  await tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        productRepositoryProvider.overrideWithValue(mockRepo),
+      ],
+      child: MaterialApp(home: ProductListScreen()),
+    ),
+  );
+
+  await tester.pumpAndSettle();
+
+  expect(find.text('Test Product'), findsOneWidget);
+  verify(mockRepo.getProducts()).called(1);
+});
+```
+
+## Testing States
+
+### Loading State
+
+```dart
+testWidgets('shows loading indicator while loading', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    DataWidget(isLoading: true),
+  ));
+
+  expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  expect(find.byType(DataContent), findsNothing);
+});
+```
+
+### Error State
+
+```dart
+testWidgets('shows error message on error', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    DataWidget(error: 'Something went wrong'),
+  ));
+
+  expect(find.text('Something went wrong'), findsOneWidget);
+  expect(find.byType(DataContent), findsNothing);
+});
+```
+
+### Empty State
+
+```dart
+testWidgets('shows empty state when no data', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    DataWidget(items: []),
+  ));
+
+  expect(find.text('No items found'), findsOneWidget);
+  expect(find.byType(ListView), findsNothing);
+});
+```
+
+### Disabled State
+
+```dart
+testWidgets('button is disabled when onPressed is null', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    AppButton(label: 'Disabled', onPressed: null),
+  ));
+
+  // Check visual indicator
+  final opacity = tester.widget<Opacity>(find.byType(Opacity));
+  expect(opacity.opacity, 0.5);
+
+  // Verify tap does nothing
+  var tapped = false;
+  await tester.tap(find.text('Disabled'));
+  expect(tapped, isFalse);
+});
+```
+
+## Testing Accessibility
+
+### Semantic Labels
+
+```dart
+testWidgets('has correct semantic label', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    AppButton(label: 'Submit', onPressed: () {}),
+  ));
+
+  final semantics = tester.getSemantics(find.byType(AppButton));
+  expect(semantics.label, 'Submit');
+  expect(semantics.hasFlag(SemanticsFlag.isButton), isTrue);
+});
+```
+
+### Testing with Semantics
+
+```dart
+testWidgets('meets accessibility guidelines', (tester) async {
+  final handle = tester.ensureSemantics();
+
+  await tester.pumpWidget(createTestWidget(
+    AppButton(label: 'Submit', onPressed: () {}),
+  ));
+
+  await expectLater(tester, meetsGuideline(labeledTapTargetGuideline));
+  await expectLater(tester, meetsGuideline(textContrastGuideline));
+
+  handle.dispose();
+});
+```
+
+## Golden Tests
+
+### Basic Golden Test
+
+```dart
+testWidgets('matches golden file', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    AppButton(label: 'Test', onPressed: () {}),
+  ));
+
+  await expectLater(
+    find.byType(AppButton),
+    matchesGoldenFile('goldens/app_button.png'),
+  );
+});
+```
+
+### Golden Test with Variants
+
+```dart
+testWidgets('button variants match golden', (tester) async {
+  await tester.pumpWidget(
+    MaterialApp(
+      home: Scaffold(
+        body: Column(
+          children: [
+            AppButton(label: 'Primary', variant: ButtonVariant.primary),
+            AppButton(label: 'Secondary', variant: ButtonVariant.secondary),
+            AppButton(label: 'Tertiary', variant: ButtonVariant.tertiary),
+          ],
+        ),
+      ),
+    ),
+  );
+
+  await expectLater(
+    find.byType(Column),
+    matchesGoldenFile('goldens/button_variants.png'),
+  );
+});
+```
+
+## Tips and Best Practices
+
+### 1. Use Keys for Finding Widgets
+
+```dart
+// In widget
+TextField(key: Key('email_input'))
+
+// In test
+find.byKey(Key('email_input'))
+```
+
+### 2. Group Related Tests
+
+```dart
+group('AppButton', () {
+  group('rendering', () {
+    testWidgets('renders label', ...);
+    testWidgets('renders icon when provided', ...);
+  });
+
+  group('interactions', () {
+    testWidgets('calls onPressed when tapped', ...);
+    testWidgets('does not call onPressed when disabled', ...);
+  });
+
+  group('variants', () {
+    testWidgets('primary has blue background', ...);
+    testWidgets('secondary has border', ...);
+  });
+});
+```
+
+### 3. Test Edge Cases
+
+```dart
+testWidgets('handles empty text', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    AppButton(label: '', onPressed: () {}),
+  ));
+  // Verify widget handles empty text gracefully
+});
+
+testWidgets('handles very long text', (tester) async {
+  await tester.pumpWidget(createTestWidget(
+    AppButton(
+      label: 'A' * 100, // Very long text
+      onPressed: () {},
+    ),
+  ));
+  // Verify widget handles overflow
+});
+```
+
+### 4. Clean Up Resources
+
+```dart
+late ProviderContainer container;
+
+setUp(() {
+  container = ProviderContainer();
+});
+
+tearDown(() {
+  container.dispose();
+});
+```
+
+### 5. Use testWidgets Over test
+
+Always use `testWidgets` for widget tests - it provides the `WidgetTester` and handles the widget lifecycle properly.
+
+```dart
+// Good
+testWidgets('widget test', (tester) async {
+  await tester.pumpWidget(...);
+});
+
+// Bad - don't use test() for widget tests
+test('widget test', () {
+  // Missing WidgetTester
+});
+```

--- a/flutter_development/skills/flutter-implementation/references/widget-patterns.md
+++ b/flutter_development/skills/flutter-implementation/references/widget-patterns.md
@@ -1,0 +1,740 @@
+# Flutter Widget Patterns Guide
+
+Common widget implementation patterns for Flutter development.
+
+## Basic Widget Patterns
+
+### Stateless Widget with Parameters
+
+```dart
+class AppCard extends StatelessWidget {
+  const AppCard({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.onTap,
+    this.padding = const EdgeInsets.all(16),
+  });
+
+  final String title;
+  final String? subtitle;
+  final Widget? leading;
+  final Widget? trailing;
+  final VoidCallback? onTap;
+  final EdgeInsets padding;
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(12),
+      child: Container(
+        padding: padding,
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(12),
+          boxShadow: [
+            BoxShadow(
+              color: Colors.black.withOpacity(0.1),
+              blurRadius: 8,
+              offset: Offset(0, 4),
+            ),
+          ],
+        ),
+        child: Row(
+          children: [
+            if (leading != null) ...[
+              leading!,
+              SizedBox(width: 12),
+            ],
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium,
+                  ),
+                  if (subtitle != null)
+                    Text(
+                      subtitle!,
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                ],
+              ),
+            ),
+            if (trailing != null) ...[
+              SizedBox(width: 12),
+              trailing!,
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+### Stateful Widget with Controller
+
+```dart
+class AppTextField extends StatefulWidget {
+  const AppTextField({
+    super.key,
+    this.controller,
+    this.label,
+    this.hint,
+    this.errorText,
+    this.onChanged,
+    this.obscureText = false,
+    this.keyboardType,
+  });
+
+  final TextEditingController? controller;
+  final String? label;
+  final String? hint;
+  final String? errorText;
+  final ValueChanged<String>? onChanged;
+  final bool obscureText;
+  final TextInputType? keyboardType;
+
+  @override
+  State<AppTextField> createState() => _AppTextFieldState();
+}
+
+class _AppTextFieldState extends State<AppTextField> {
+  late TextEditingController _controller;
+  bool _isObscured = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = widget.controller ?? TextEditingController();
+    _isObscured = widget.obscureText;
+  }
+
+  @override
+  void dispose() {
+    if (widget.controller == null) {
+      _controller.dispose();
+    }
+    super.dispose();
+  }
+
+  void _toggleObscure() {
+    setState(() {
+      _isObscured = !_isObscured;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        if (widget.label != null) ...[
+          Text(
+            widget.label!,
+            style: Theme.of(context).textTheme.labelMedium,
+          ),
+          SizedBox(height: 8),
+        ],
+        TextField(
+          controller: _controller,
+          obscureText: widget.obscureText && _isObscured,
+          keyboardType: widget.keyboardType,
+          onChanged: widget.onChanged,
+          decoration: InputDecoration(
+            hintText: widget.hint,
+            errorText: widget.errorText,
+            suffixIcon: widget.obscureText
+                ? IconButton(
+                    icon: Icon(
+                      _isObscured ? Icons.visibility : Icons.visibility_off,
+                    ),
+                    onPressed: _toggleObscure,
+                  )
+                : null,
+            border: OutlineInputBorder(
+              borderRadius: BorderRadius.circular(8),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Layout Patterns
+
+### Responsive Layout
+
+```dart
+class ResponsiveLayout extends StatelessWidget {
+  const ResponsiveLayout({
+    super.key,
+    required this.mobile,
+    this.tablet,
+    this.desktop,
+  });
+
+  final Widget mobile;
+  final Widget? tablet;
+  final Widget? desktop;
+
+  static const mobileBreakpoint = 600.0;
+  static const tabletBreakpoint = 1200.0;
+
+  @override
+  Widget build(BuildContext context) {
+    return LayoutBuilder(
+      builder: (context, constraints) {
+        if (constraints.maxWidth >= tabletBreakpoint && desktop != null) {
+          return desktop!;
+        }
+        if (constraints.maxWidth >= mobileBreakpoint && tablet != null) {
+          return tablet!;
+        }
+        return mobile;
+      },
+    );
+  }
+}
+
+// Usage
+ResponsiveLayout(
+  mobile: MobileProductList(),
+  tablet: TabletProductGrid(columns: 2),
+  desktop: DesktopProductGrid(columns: 4),
+)
+```
+
+### Sliver Layout
+
+```dart
+class ProductListScreen extends StatelessWidget {
+  const ProductListScreen({super.key, required this.products});
+
+  final List<Product> products;
+
+  @override
+  Widget build(BuildContext context) {
+    return CustomScrollView(
+      slivers: [
+        SliverAppBar(
+          expandedHeight: 200,
+          pinned: true,
+          flexibleSpace: FlexibleSpaceBar(
+            title: Text('Products'),
+            background: Image.asset(
+              'assets/header.png',
+              fit: BoxFit.cover,
+            ),
+          ),
+        ),
+        SliverPadding(
+          padding: EdgeInsets.all(16),
+          sliver: SliverGrid(
+            gridDelegate: SliverGridDelegateWithFixedCrossAxisCount(
+              crossAxisCount: 2,
+              mainAxisSpacing: 16,
+              crossAxisSpacing: 16,
+              childAspectRatio: 0.75,
+            ),
+            delegate: SliverChildBuilderDelegate(
+              (context, index) => ProductCard(product: products[index]),
+              childCount: products.length,
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+```
+
+## Animation Patterns
+
+### Implicit Animation
+
+```dart
+class AnimatedCard extends StatelessWidget {
+  const AnimatedCard({
+    super.key,
+    required this.child,
+    this.isSelected = false,
+  });
+
+  final Widget child;
+  final bool isSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return AnimatedContainer(
+      duration: Duration(milliseconds: 200),
+      curve: Curves.easeInOut,
+      transform: Matrix4.identity()..scale(isSelected ? 1.05 : 1.0),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(12),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withOpacity(isSelected ? 0.2 : 0.1),
+            blurRadius: isSelected ? 16 : 8,
+            offset: Offset(0, isSelected ? 8 : 4),
+          ),
+        ],
+      ),
+      child: child,
+    );
+  }
+}
+```
+
+### Explicit Animation with AnimationController
+
+```dart
+class PulseAnimation extends StatefulWidget {
+  const PulseAnimation({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<PulseAnimation> createState() => _PulseAnimationState();
+}
+
+class _PulseAnimationState extends State<PulseAnimation>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: Duration(milliseconds: 1000),
+      vsync: this,
+    );
+    _animation = Tween<double>(begin: 1.0, end: 1.2).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+    _controller.repeat(reverse: true);
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ScaleTransition(
+      scale: _animation,
+      child: widget.child,
+    );
+  }
+}
+```
+
+## Form Patterns
+
+### Form with Validation
+
+```dart
+class LoginForm extends StatefulWidget {
+  const LoginForm({super.key, required this.onSubmit});
+
+  final void Function(String email, String password) onSubmit;
+
+  @override
+  State<LoginForm> createState() => _LoginFormState();
+}
+
+class _LoginFormState extends State<LoginForm> {
+  final _formKey = GlobalKey<FormState>();
+  final _emailController = TextEditingController();
+  final _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _submit() {
+    if (_formKey.currentState?.validate() ?? false) {
+      widget.onSubmit(
+        _emailController.text,
+        _passwordController.text,
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.stretch,
+        children: [
+          TextFormField(
+            controller: _emailController,
+            decoration: InputDecoration(
+              labelText: 'Email',
+              border: OutlineInputBorder(),
+            ),
+            keyboardType: TextInputType.emailAddress,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter your email';
+              }
+              if (!value.contains('@')) {
+                return 'Please enter a valid email';
+              }
+              return null;
+            },
+          ),
+          SizedBox(height: 16),
+          TextFormField(
+            controller: _passwordController,
+            decoration: InputDecoration(
+              labelText: 'Password',
+              border: OutlineInputBorder(),
+            ),
+            obscureText: true,
+            validator: (value) {
+              if (value == null || value.isEmpty) {
+                return 'Please enter your password';
+              }
+              if (value.length < 8) {
+                return 'Password must be at least 8 characters';
+              }
+              return null;
+            },
+          ),
+          SizedBox(height: 24),
+          ElevatedButton(
+            onPressed: _submit,
+            child: Text('Login'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+```
+
+## List Patterns
+
+### Infinite Scroll List
+
+```dart
+class InfiniteScrollList extends StatefulWidget {
+  const InfiniteScrollList({
+    super.key,
+    required this.itemBuilder,
+    required this.onLoadMore,
+    required this.itemCount,
+    this.hasMore = true,
+  });
+
+  final Widget Function(BuildContext, int) itemBuilder;
+  final Future<void> Function() onLoadMore;
+  final int itemCount;
+  final bool hasMore;
+
+  @override
+  State<InfiniteScrollList> createState() => _InfiniteScrollListState();
+}
+
+class _InfiniteScrollListState extends State<InfiniteScrollList> {
+  final _scrollController = ScrollController();
+  bool _isLoading = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _scrollController.addListener(_onScroll);
+  }
+
+  @override
+  void dispose() {
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _onScroll() {
+    if (_scrollController.position.pixels >=
+        _scrollController.position.maxScrollExtent - 200) {
+      _loadMore();
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_isLoading || !widget.hasMore) return;
+    setState(() => _isLoading = true);
+    await widget.onLoadMore();
+    setState(() => _isLoading = false);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return ListView.builder(
+      controller: _scrollController,
+      itemCount: widget.itemCount + (widget.hasMore ? 1 : 0),
+      itemBuilder: (context, index) {
+        if (index == widget.itemCount) {
+          return Center(
+            child: Padding(
+              padding: EdgeInsets.all(16),
+              child: CircularProgressIndicator(),
+            ),
+          );
+        }
+        return widget.itemBuilder(context, index);
+      },
+    );
+  }
+}
+```
+
+### Grouped List
+
+```dart
+class GroupedList<T, G> extends StatelessWidget {
+  const GroupedList({
+    super.key,
+    required this.items,
+    required this.groupBy,
+    required this.groupBuilder,
+    required this.itemBuilder,
+    this.separator,
+  });
+
+  final List<T> items;
+  final G Function(T) groupBy;
+  final Widget Function(G group) groupBuilder;
+  final Widget Function(T item) itemBuilder;
+  final Widget? separator;
+
+  @override
+  Widget build(BuildContext context) {
+    final groups = <G, List<T>>{};
+    for (final item in items) {
+      final group = groupBy(item);
+      groups.putIfAbsent(group, () => []).add(item);
+    }
+
+    return ListView.builder(
+      itemCount: groups.length,
+      itemBuilder: (context, groupIndex) {
+        final group = groups.keys.elementAt(groupIndex);
+        final groupItems = groups[group]!;
+
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            groupBuilder(group),
+            ...groupItems.map(itemBuilder),
+            if (separator != null && groupIndex < groups.length - 1)
+              separator!,
+          ],
+        );
+      },
+    );
+  }
+}
+```
+
+## Dialog Patterns
+
+### Confirmation Dialog
+
+```dart
+class ConfirmationDialog extends StatelessWidget {
+  const ConfirmationDialog({
+    super.key,
+    required this.title,
+    required this.content,
+    this.confirmText = 'Confirm',
+    this.cancelText = 'Cancel',
+    this.isDestructive = false,
+  });
+
+  final String title;
+  final String content;
+  final String confirmText;
+  final String cancelText;
+  final bool isDestructive;
+
+  static Future<bool?> show(
+    BuildContext context, {
+    required String title,
+    required String content,
+    String confirmText = 'Confirm',
+    String cancelText = 'Cancel',
+    bool isDestructive = false,
+  }) {
+    return showDialog<bool>(
+      context: context,
+      builder: (context) => ConfirmationDialog(
+        title: title,
+        content: content,
+        confirmText: confirmText,
+        cancelText: cancelText,
+        isDestructive: isDestructive,
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(title),
+      content: Text(content),
+      actions: [
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(false),
+          child: Text(cancelText),
+        ),
+        TextButton(
+          onPressed: () => Navigator.of(context).pop(true),
+          style: TextButton.styleFrom(
+            foregroundColor: isDestructive ? Colors.red : null,
+          ),
+          child: Text(confirmText),
+        ),
+      ],
+    );
+  }
+}
+
+// Usage
+final confirmed = await ConfirmationDialog.show(
+  context,
+  title: 'Delete Item',
+  content: 'Are you sure you want to delete this item?',
+  confirmText: 'Delete',
+  isDestructive: true,
+);
+```
+
+## Error Handling Patterns
+
+### Error Widget with Retry
+
+```dart
+class ErrorView extends StatelessWidget {
+  const ErrorView({
+    super.key,
+    required this.message,
+    this.onRetry,
+    this.icon = Icons.error_outline,
+  });
+
+  final String message;
+  final VoidCallback? onRetry;
+  final IconData icon;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: Colors.grey),
+            SizedBox(height: 16),
+            Text(
+              message,
+              textAlign: TextAlign.center,
+              style: Theme.of(context).textTheme.bodyLarge,
+            ),
+            if (onRetry != null) ...[
+              SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: onRetry,
+                child: Text('Retry'),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+### Empty State Widget
+
+```dart
+class EmptyState extends StatelessWidget {
+  const EmptyState({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.icon = Icons.inbox,
+    this.action,
+    this.actionLabel,
+  });
+
+  final String title;
+  final String? subtitle;
+  final IconData icon;
+  final VoidCallback? action;
+  final String? actionLabel;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.all(24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(icon, size: 64, color: Colors.grey[400]),
+            SizedBox(height: 16),
+            Text(
+              title,
+              style: Theme.of(context).textTheme.titleMedium,
+              textAlign: TextAlign.center,
+            ),
+            if (subtitle != null) ...[
+              SizedBox(height: 8),
+              Text(
+                subtitle!,
+                style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                      color: Colors.grey[600],
+                    ),
+                textAlign: TextAlign.center,
+              ),
+            ],
+            if (action != null && actionLabel != null) ...[
+              SizedBox(height: 24),
+              ElevatedButton(
+                onPressed: action,
+                child: Text(actionLabel!),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+}
+```
+
+## Tips
+
+1. **Extract reusable widgets**: If a pattern is used more than twice, create a widget
+2. **Use const constructors**: Improves performance
+3. **Keep widgets small**: Break complex widgets into smaller pieces
+4. **Document public APIs**: Use doc comments for public widgets
+5. **Consider accessibility**: Add semantic labels
+6. **Handle edge cases**: Empty states, loading, errors


### PR DESCRIPTION
## Summary

- FigmaデザインからFlutter実装までのワークフローを支援する2つの新しいスキルを追加
- flutter-developmentプラグインをv0.2.0にアップデート

### 新規スキル

#### 1. figma-to-flutter
FigmaデザインをFlutter向け設計仕様書に変換するスキル

- Figma MCPツール連携
- レイアウト分析（Auto Layout → Row/Column/Stack）
- スペーシング抽出（→ EdgeInsets）
- タイポグラフィ抽出（→ TextStyle）
- Atomic Designに基づくコンポーネント分類

#### 2. flutter-implementation
設計仕様書からFlutterコードを生成するスキル

- Widget生成（StatelessWidget/StatefulWidget/ConsumerWidget）
- Riverpod状態管理パターン
- Widget testガイド
- ネイティブプラットフォーム連携ガイド（iOS/Android）

### ワークフロー

```
[Figmaデザイン]
      │
      ▼
/figma-to-flutter ──→ [設計仕様書.md]
      │
      ▼
/flutter-implementation ──→ [Flutter Widget + Test]
      │
      ├─ iOS必要? → ios-development スキル参照
      └─ Android必要? → android スキル参照
```

## Test plan

- [ ] figma-to-flutterスキルでFigmaノードから仕様書が生成できることを確認
- [ ] flutter-implementationスキルで仕様書からWidgetコードが生成できることを確認
- [ ] 既存のflutter-widget-assistantスキルが引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)