### PR TITLE
feat: android-test-generator v1.0

### DIFF
--- a/android_development/.claude/skills/android-test-generator/README.md
+++ b/android_development/.claude/skills/android-test-generator/README.md
@@ -1,0 +1,167 @@
+# Android Test Generator v1.0
+
+Android実装コードから適切なテストケースを自動生成するClaude Codeスキル。
+
+## 概要
+
+```
+実装コード → Test Generator → テストコード
+              ↓
+         クラス種別を自動判定
+         プロジェクトのパターンに準拠
+         Given-When-Then構造
+         MockK + runTest
+```
+
+## 対応テスト対象
+
+| 対象 | サポート状況 | テンプレート | 層 |
+|------|-------------|-------------|-----|
+| Reducer | ✅ v1.0 | `templates/reducer-test.md` | UI |
+| StateManager | ✅ v1.0 | `templates/statemanager-test.md` | UI |
+| Presenter | ✅ v1.0 | `templates/presenter-test.md` | UI |
+| ViewModel (MVI) | ✅ v1.0 | `templates/viewmodel-test.md` | UI |
+| ViewModel (AAC) | ✅ v1.0 | `templates/viewmodel-test.md` | UI |
+| Handler | ✅ v1.0 | `templates/handler-test.md` | UI |
+| UseCase | ✅ v0.1 | `templates/usecase-test.md` | Domain |
+| Repository | ✅ v0.1 | `templates/repository-test.md` | Data |
+| ApiService | ✅ v1.0 | `templates/api-service-test.md` | Data |
+| Mapper | ✅ v1.0 | `templates/mapper-test.md` | Data |
+
+## 使い方
+
+### 1. 手動モード
+
+```
+「GetFavoriteArticlesUseCaseのテストを作って」
+「このクラスのテストを生成して」
+「app/src/main/.../MyRepository.kt のテストを作成」
+```
+
+### 2. クラス種別自動判定
+
+実装コードを解析し、以下のパターンでテンプレートを自動選択:
+
+| 優先度 | 判定条件 | テンプレート |
+|--------|---------|-------------|
+| 1 | `fun reduce(state:` 検出 | Reducer |
+| 2 | `processIntent` + `handleAction` 検出 | StateManager |
+| 3 | クラス名に `Presenter` + UseCase依存 | Presenter |
+| 4 | クラス名に `ViewModel` + StateManager依存 | ViewModel (MVI) |
+| 5 | クラス名に `ViewModel` + UseCase依存 | ViewModel (AAC) |
+| 6 | クラス名に `Handler` | Handler |
+| 7 | クラス名に `UseCase` | UseCase |
+| 8 | クラス名に `Repository` + ApiService依存 | Repository |
+| 9 | クラス名に `Mapper` or `toXxx()` 拡張関数 | Mapper |
+
+### 3. PR作成時の自動チェック（将来対応）
+
+PR作成時にテストがない変更を検出し、テスト生成を提案。
+
+## 生成されるテストの特徴
+
+### 構造
+- **Given-When-Then** 形式
+- バッククォートによるテストメソッド命名
+- 日本語/英語の混在対応
+- `@file:Suppress` 自動付与
+
+### 技術スタック
+- **Mock**: MockK (`coEvery`, `coVerify`, `every`, `verify`)
+- **Coroutine**: `runTest` / `testScope.runTest` + `StandardTestDispatcher`
+- **アサーション**: JUnit Assert / Google Truth（層に応じて使い分け）
+- **HTTP**: MockWebServer（ApiServiceテスト用）
+
+### モジュール別設定
+
+| 層 | アサーション | コルーチン | Mockポリシー | Flow検証 |
+|----|------------|-----------|------------|---------|
+| Domain | JUnit Assert | `runTest` | strict | `first()` |
+| Data | Truth | `runTest` | relaxed | `first()` |
+| UI | Truth | `testScope.runTest` | mixed | manual collect |
+
+## プロジェクト設定
+
+`knowledge/project-config.md` でプロジェクト固有の設定が可能:
+
+```yaml
+# モジュール別設定
+domain:
+  assertion: "junit"
+  coroutine: "runTest"
+  mock_policy: "strict"
+
+data:
+  assertion: "truth"
+  coroutine: "runTest"
+  mock_policy: "relaxed"
+
+ui:
+  assertion: "truth"
+  coroutine: "testScope_runTest"
+  mock_policy: "mixed"
+
+# 共通設定
+naming:
+  language: "mixed"
+  use_backtick: true
+```
+
+## ディレクトリ構成
+
+```
+android-test-generator/
+├── SKILL.md                          # スキル定義（メイン）
+├── README.md                         # このファイル
+├── knowledge/
+│   └── project-config.md             # プロジェクト設定テンプレート
+└── templates/
+    ├── reducer-test.md               # Reducerテストテンプレート
+    ├── statemanager-test.md          # StateManagerテストテンプレート
+    ├── presenter-test.md             # Presenterテストテンプレート
+    ├── viewmodel-test.md             # ViewModelテストテンプレート（MVI/AAC）
+    ├── handler-test.md               # Handlerテストテンプレート
+    ├── usecase-test.md               # UseCaseテストテンプレート
+    ├── repository-test.md            # Repositoryテストテンプレート
+    ├── api-service-test.md           # ApiServiceテストテンプレート
+    └── mapper-test.md                # Mapperテストテンプレート
+```
+
+## インストール
+
+### 汎用版として使用
+
+```bash
+# ai_development_tools リポジトリから
+cp -r .claude/skills/android-test-generator ~/.claude/skills/
+```
+
+### プロジェクト固有版として使用
+
+```bash
+# プロジェクトの .claude/skills/ にコピー
+cp -r android-test-generator your-project/.claude/skills/
+
+# プロジェクト設定を編集
+vi your-project/.claude/skills/android-test-generator/knowledge/project-config.md
+```
+
+## 関連スキル
+
+- **android-test-runner**: 生成したテストの実行・失敗分析
+
+```
+開発フロー:
+実装 → Test Generator → テスト生成 → Test Runner → テスト実行
+```
+
+## バージョン履歴
+
+| バージョン | 日付 | 内容 |
+|-----------|------|------|
+| v1.0 | 2026-02-02 | MVI 4層テンプレート追加、Data層テンプレート追加、Handler追加、モジュール別設定対応、クラス種別自動判定 |
+| v0.1 | 2025-12-02 | 初版作成（dmenu-news分析結果に基づく） |
+
+## ライセンス
+
+MIT License

--- a/android_development/.claude/skills/android-test-generator/SKILL.md
+++ b/android_development/.claude/skills/android-test-generator/SKILL.md
@@ -1,0 +1,386 @@
+# Android Test Generator スキル v1.0
+
+## Description
+
+Android実装コードから適切なテストケースを自動生成するスキル。MVI 4層（Reducer / StateManager / Presenter / ViewModel）、Domain層（UseCase）、Data層（Repository / ApiService / Mapper）、横断的関心事（Handler）に対応し、プロジェクトのテストパターンに準拠したテストコードを生成する。
+
+---
+
+## Trigger
+
+以下のようなリクエストで起動:
+- 「このクラスのテストを作って」
+- 「〇〇UseCaseのテストを生成して」
+- 「このファイルのテストケースを作成」
+- 「テストを自動生成」
+
+---
+
+## System Instructions
+
+### 1. 実装コードの分析とクラス種別自動判定
+
+テスト対象のクラスを読み込み、以下の判定ロジックで種別を特定する:
+
+```
+入力ファイル解析 → 以下のパターンで判定（上から順に評価）:
+
+ 1. "fun reduce(state:" 検出
+    → Reducer テンプレート（templates/reducer-test.md）
+
+ 2. "processIntent" + "handleAction" 検出
+    → StateManager テンプレート（templates/statemanager-test.md）
+
+ 3. "Presenter" in クラス名 + UseCase依存
+    → Presenter テンプレート（templates/presenter-test.md）
+
+ 4. "ViewModel" in クラス名 + StateManager依存
+    → ViewModel(薄いラッパー) テンプレート（templates/viewmodel-test.md MVI版）
+
+ 5. "ViewModel" in クラス名 + UseCase依存
+    → ViewModel(AAC) テンプレート（templates/viewmodel-test.md AAC版）
+
+ 6. "Handler" in クラス名
+    → Handler テンプレート（templates/handler-test.md）
+
+ 7. "UseCase" in クラス名
+    → UseCase テンプレート（templates/usecase-test.md）
+
+ 8. "Repository" in クラス名 + ApiService依存
+    → Repository テンプレート（templates/repository-test.md）
+    ※ MockWebServerパターンが適切な場合は templates/api-service-test.md も参照
+
+ 9. "Repository" in クラス名 + Dao依存
+    → Repository(MockK) テンプレート（templates/repository-test.md）
+
+10. "Mapper" in クラス名 or "toXxx()" 拡張関数
+    → Mapper テンプレート（templates/mapper-test.md）
+```
+
+判定後、以下を特定:
+- 依存関係（コンストラクタ引数）
+- 公開メソッド（テスト対象）
+- 戻り値の型（Result<T> / Flow<T> / 単純な値）
+
+### 2. プロジェクト設定の確認
+
+`knowledge/project-config.md` を読み込み、プロジェクト固有の設定を適用:
+
+- **モジュール別設定**: テスト対象の属する層（Domain/Data/UI）に応じた設定
+  - アサーションライブラリ（JUnit Assert / Google Truth）
+  - コルーチンパターン（runTest / testScope.runTest）
+  - Mockポリシー（strict / relaxed / mixed）
+  - Flow検証方法（first / manual_collect）
+- 命名規則（日本語/英語）
+- 追加のimport
+
+設定ファイルがない場合はデフォルト設定を使用。
+
+### 3. テストコード生成ルール
+
+#### @file:Suppress 自動付与
+
+テスト名に日本語を含む場合（naming: japanese or mixed）、ファイル先頭に自動付与:
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+```
+
+#### Import aliasing（同名クラス問題）
+
+Entity名とDomainModel名が同名の場合、import aliasを自動適用:
+
+```kotlin
+import jp.co.example.data.entity.Article as ArticleEntity
+import jp.co.example.domain.model.Article as ArticleModel
+```
+
+#### 値クラス（`@JvmInline value class`）の扱い
+
+MockKは `@JvmInline value class` をモックできない（`unbox-impl()` エラーになる）。
+値クラスのフィールドには実インスタンスを使用すること:
+
+```kotlin
+// NG - MockKで値クラスをモックするとunbox-implエラー
+every { article.id } returns mockk<ArticleId>()  // ❌ 失敗
+
+// OK - 実インスタンスを使用
+every { article.id } returns ArticleId("article-1")  // ✅ 成功
+```
+
+プロジェクトで使われる値クラスの例: `ArticleId`, `CategoryId`, `TabId`, `PhotoId` 等
+
+#### Android Framework依存クラスのテスト制約
+
+`Intent`、`Activity`、`Uri` 等のAndroid Frameworkクラスに依存するメソッドは、
+純粋JUnitテストでは制約がある:
+
+- **`Uri.parse()`**: `mockkStatic(Uri::class)` でモック可能
+- **`Intent` コンストラクタ**: `returnDefaultValues = true` 未設定の場合 "Method not mocked" エラー
+- **`Activity.createIntent()`等の静的メソッド**: Activity クラスのロード自体が失敗する
+
+**対処法（優先順）**:
+1. Android Framework非依存のロジック（アナリティクス判定、ブラックリスト判定等）に検証を集中
+2. `testOptions.unitTests.returnDefaultValues = true` をbuild.gradleに設定
+3. Robolectric を導入して統合テストとして実行
+
+#### ネストされた型参照の注意
+
+APIレスポンスモデルで、別クラスのネスト型を参照しているケースがある:
+
+```kotlin
+// GetArticleResponse の rows フィールドが GetTimelineResponse.Row を参照
+val rows: List<GetTimelineResponse.Row>?  // ← GetArticleResponse.Row ではない
+```
+
+テスト生成時は、フィールドの実際の型定義を確認し、正しいimportを使用すること。
+
+#### coEvery vs every の使い分け
+
+| 対象 | Mock関数 | Verify関数 |
+|------|---------|-----------|
+| suspend関数（Repository.getData()等） | `coEvery` | `coVerify` |
+| 通常関数（UseCase.observe()等） | `every` | `verify` |
+| Flow返却関数 | `every` | `verify` |
+| Unit返却関数（analytics等） | `relaxUnitFun = true` | `verify` |
+
+#### runTest vs testScope.runTest の使い分け
+
+| 層・種別 | パターン | 理由 |
+|---------|---------|------|
+| UseCase | `= runTest { }` | 単純なsuspend関数 |
+| Repository | `= runTest { }` | API呼び出しモック |
+| Mapper | なし | 純粋関数 |
+| Reducer | なし | 純粋関数 |
+| StateManager | `= testScope.runTest { }` | Flow collect + advanceUntilIdle |
+| Presenter | `= testScope.runTest { }` | 複数UseCase + analytics |
+| ViewModel (MVI) | `= testScope.runTest { }` | StateManager委譲検証 |
+| ViewModel (AAC) | `= runTest { }` | LiveData/StateFlow直接検証 |
+| Handler (sync) | なし | 非コルーチン |
+| Handler (async) | `= runTest { }` | suspend関数呼び出し |
+
+### 4. テストケース生成
+
+判定されたクラス種別に基づき、対応するテンプレートを使用してテストコードを生成。
+
+各テンプレートで定義された置換プレースホルダーを実装コードの情報で置換する。
+
+### 5. テストメソッド命名規則
+
+**英語パターン（デフォルト）**:
+```kotlin
+@Test
+fun `invoke should return success when repository succeeds`()
+```
+
+**日本語パターン**:
+```kotlin
+@Test
+fun `リポジトリが成功した場合、成功を返すこと`()
+```
+
+**混在パターン**:
+```kotlin
+@Test
+fun `processIntent - Initialize を受け取った場合、データを読み込むこと`()
+```
+
+### 6. Given-When-Then 構造
+
+すべてのテストメソッドは以下の構造で生成:
+
+```kotlin
+@Test
+fun `テスト名`() = runTest {
+    // Given - 前提条件のセットアップ
+    val expected = ...
+    coEvery { repository.method() } returns Result.success(expected)
+
+    // When - テスト対象の実行
+    val result = useCase()
+
+    // Then - 結果の検証
+    assertTrue(result.isSuccess)
+    assertEquals(expected, result.getOrNull())
+    coVerify(exactly = 1) { repository.method() }
+}
+```
+
+### 7. 必須import
+
+生成するテストには適切なimportを含める:
+
+**共通**:
+```kotlin
+import io.mockk.mockk
+import org.junit.Before
+import org.junit.Test
+```
+
+**Domain層（UseCase）追加**:
+```kotlin
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+```
+
+**Data層（Repository）追加**:
+```kotlin
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+```
+
+**Data層（Mapper）**:
+```kotlin
+import org.junit.Assert.*
+// Mock/コルーチン import 不要
+```
+
+**Data層（ApiService + MockWebServer）**:
+```kotlin
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+```
+
+**UI層（StateManager / Presenter / ViewModel MVI版）追加**:
+```kotlin
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+```
+
+**UI層（Reducer）**:
+```kotlin
+import com.google.common.truth.Truth.assertThat
+// Mock/コルーチン import 不要
+```
+
+**UI層（Handler）**:
+```kotlin
+import io.mockk.MockKAnnotations
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.verify
+```
+
+---
+
+## 生成パターン詳細
+
+### Result<T> を返すメソッド
+
+| ケース | Mock設定 | アサーション |
+|-------|---------|------------|
+| 成功 | `returns Result.success(data)` | `assertTrue(result.isSuccess)` |
+| 失敗 | `returns Result.failure(exception)` | `assertTrue(result.isFailure)` |
+| 空 | `returns Result.success(emptyList())` | `assertTrue(result.getOrNull()!!.isEmpty())` |
+
+### Flow<T> を返すメソッド
+
+**パターン1: first() で検証（Domain/Data層）**
+```kotlin
+@Test
+fun `should emit expected value`() = runTest {
+    coEvery { repository.observe() } returns flowOf(expected)
+
+    val result = useCase().first()
+
+    assertEquals(expected, result)
+}
+```
+
+**パターン2: collect + advanceUntilIdle で検証（UI層）**
+```kotlin
+@Test
+fun `should emit multiple values`() = testScope.runTest {
+    val values = mutableListOf<T>()
+    val job = launch { flow.collect { values.add(it) } }
+    advanceUntilIdle()
+
+    assertThat(values).hasSize(expectedSize)
+    job.cancel()
+}
+```
+
+---
+
+## 出力フォーマット
+
+生成完了後、以下の形式で出力:
+
+```markdown
+## テスト生成完了
+
+### 対象クラス
+{ClassName} ({クラス種別})
+
+### 判定理由
+{自動判定で使用したパターン}
+
+### 適用設定
+- モジュール: {Domain / Data / UI}
+- アサーション: {JUnit Assert / Google Truth}
+- コルーチン: {runTest / testScope.runTest / なし}
+
+### 生成したテストケース
+1. {テストメソッド名1}
+2. {テストメソッド名2}
+3. {テストメソッド名3}
+
+### ファイル出力先
+{テストファイルパス}
+
+### 追加が推奨されるテストケース
+- {手動で追加すべきケースがあれば}
+```
+
+---
+
+## 関連ファイル
+
+### テンプレート
+
+| テンプレート | 対象 | 層 |
+|------------|------|-----|
+| `templates/reducer-test.md` | Reducer（純粋関数） | UI |
+| `templates/statemanager-test.md` | StateManager（Intent→Action） | UI |
+| `templates/presenter-test.md` | Presenter（UseCase + analytics） | UI |
+| `templates/viewmodel-test.md` | ViewModel（MVI薄いラッパー / AAC） | UI |
+| `templates/handler-test.md` | Handler（横断的関心事） | UI |
+| `templates/usecase-test.md` | UseCase | Domain |
+| `templates/repository-test.md` | Repository（MockK） | Data |
+| `templates/api-service-test.md` | ApiService（MockWebServer） | Data |
+| `templates/mapper-test.md` | Mapper（純粋関数） | Data |
+
+### ナレッジ
+
+- `knowledge/project-config.md` - プロジェクト固有設定（モジュール別設定含む）
+
+---
+
+## 関連スキル
+
+- `android-test-runner`: 生成したテストの実行・検証に使用
+
+---
+
+## 更新履歴
+
+| 日付 | 内容 |
+|------|------|
+| 2025-12-02 | 初版作成（dmenu-news分析結果に基づく） |
+| 2026-02-02 | v1.0: MVI 4層テンプレート追加、Data層テンプレート追加、Handler追加、モジュール別設定、クラス種別自動判定、値クラス/Android Framework制約/ネスト型の実践知見追加 |

--- a/android_development/.claude/skills/android-test-generator/knowledge/project-config.md
+++ b/android_development/.claude/skills/android-test-generator/knowledge/project-config.md
@@ -1,0 +1,372 @@
+# プロジェクト設定テンプレート
+
+このファイルをプロジェクトの `.claude/skills/android-test-generator/knowledge/` にコピーし、プロジェクト固有の設定を記述してください。
+
+---
+
+## 基本設定
+
+```yaml
+# プロジェクト名
+project_name: "your-project-name"
+
+# テスト対象パッケージ
+test_package: "com.example.app"
+
+# テストディレクトリ
+test_directory: "app/src/test/java"
+```
+
+---
+
+## モジュール別設定
+
+各モジュール（層）ごとにテスト設定を定義する。テスト対象クラスの属するモジュールに応じて設定が自動適用される。
+
+### Domain 層（UseCase / DomainModel）
+
+```yaml
+domain:
+  assertion: "junit"              # JUnit Assert が主力
+  coroutine: "runTest"            # runTest のみ（TestScope不要）
+  mock_policy: "strict"           # すべてのモックに明示的設定
+  flow_verification: "first"      # first() で単一値検証
+  suppress: []                    # 通常不要
+```
+
+**特徴**:
+- 純粋なビジネスロジックのテスト
+- `runTest { }` で直接実行
+- `coEvery` / `coVerify` でRepository呼び出しを検証
+- `Result<T>` の成功/失敗パターン
+
+### Data 層（Repository / ApiService / Mapper）
+
+```yaml
+data:
+  assertion: "truth"              # Google Truth が主力
+  coroutine: "runTest"            # runTest のみ（TestScope不要）
+  mock_policy: "relaxed"          # secondary依存は relaxed
+  flow_verification: "first"      # first() で単一値検証
+  suppress:
+    - "NonAsciiCharacters"
+    - "TestFunctionName"
+```
+
+**特徴**:
+- API/DataSource のモック
+- MockWebServer を使った統合テスト
+- Mapper は純粋関数（runTest不要）
+- Entity⇔DomainModel 変換テスト
+
+### UI 層（ViewModel / StateManager / Presenter / Reducer / Handler）
+
+```yaml
+ui:
+  assertion: "truth"              # Google Truth が主力
+  coroutine: "testScope_runTest"  # testScope.runTest + Dispatchers.setMain 手動管理
+  mock_policy: "mixed"            # Reducer: relaxed, UseCase: strict
+  flow_verification: "manual_collect"  # mutableListOf + launch collect + advanceUntilIdle
+  suppress:
+    - "NonAsciiCharacters"
+    - "TestFunctionName"
+```
+
+**特徴**:
+- `TestScope` + `StandardTestDispatcher` 必須
+- `Dispatchers.setMain` / `resetMain` の手動管理
+- State / Event / Action の Flow 検証
+- アナリティクスイベント検証
+
+---
+
+## アサーションライブラリ
+
+使用するアサーションライブラリを指定:
+
+```yaml
+assertion:
+  # primary: junit | truth | both
+  primary: "junit"
+
+  # UI層（ViewModel/StateManager）で Truth を使用するか
+  use_truth_for_ui: true
+```
+
+**JUnit Assert**:
+```kotlin
+assertTrue(result.isSuccess)
+assertEquals(expected, actual)
+assertNotNull(value)
+```
+
+**Google Truth**:
+```kotlin
+assertThat(result.isSuccess).isTrue()
+assertThat(actual).isEqualTo(expected)
+assertThat(value).isNotNull()
+```
+
+---
+
+## Coroutine テスト設定
+
+```yaml
+coroutine:
+  # dispatcher_rule: standard | main_dispatcher_rule
+  dispatcher_rule: "standard"
+
+  # Dispatchers.setMain/resetMain を使用するか
+  manual_main_dispatcher: true
+```
+
+**standard（デフォルト）**:
+```kotlin
+private val testDispatcher = StandardTestDispatcher()
+
+@Before
+fun setUp() {
+    Dispatchers.setMain(testDispatcher)
+}
+
+@After
+fun tearDown() {
+    Dispatchers.resetMain()
+}
+```
+
+**main_dispatcher_rule**:
+```kotlin
+@get:Rule
+val mainDispatcherRule = MainDispatcherRule()
+```
+
+### runTest vs testScope.runTest 使い分け
+
+| 層 | パターン | 理由 |
+|----|---------|------|
+| Domain (UseCase) | `runTest { }` | TestScope不要、単純なsuspend関数呼び出し |
+| Data (Repository) | `runTest { }` | TestScope不要、API呼び出しのモック検証 |
+| Data (Mapper) | なし | 純粋関数、コルーチン不使用 |
+| UI (Reducer) | なし | 純粋関数、コルーチン不使用 |
+| UI (StateManager) | `testScope.runTest { }` | TestScope必須、Flow collect + advanceUntilIdle |
+| UI (Presenter) | `testScope.runTest { }` | TestScope必須、複数UseCase + アナリティクス |
+| UI (ViewModel - MVI) | `testScope.runTest { }` | TestScope必須、StateManager委譲検証 |
+| UI (ViewModel - AAC) | `runTest { }` | LiveData/StateFlow直接検証 |
+
+---
+
+## Flow テスト設定
+
+```yaml
+flow:
+  # verification: first | collect | turbine
+  verification: "collect"
+```
+
+**first()（Domain/Data層向け）**:
+```kotlin
+val result = useCase().first()
+assertEquals(expected, result)
+```
+
+**collect + advanceUntilIdle（UI層向け）**:
+```kotlin
+val values = mutableListOf<T>()
+val job = launch { flow.collect { values.add(it) } }
+advanceUntilIdle()
+// assertions
+job.cancel()
+```
+
+**turbine**:
+```kotlin
+flow.test {
+    assertEquals(expected, awaitItem())
+    awaitComplete()
+}
+```
+
+---
+
+## 命名規則
+
+```yaml
+naming:
+  # language: english | japanese | mixed
+  language: "english"
+
+  # backtick: true | false
+  use_backtick: true
+```
+
+**english（デフォルト）**:
+```kotlin
+fun `invoke should return success when repository succeeds`()
+```
+
+**japanese**:
+```kotlin
+fun `リポジトリが成功した場合、成功を返すこと`()
+```
+
+**mixed**:
+```kotlin
+fun `invoke should return success - リポジトリ成功時`()
+```
+
+---
+
+## Mock 設定
+
+```yaml
+mock:
+  # library: mockk（現在はMockKのみサポート）
+  library: "mockk"
+
+  # relaxed使用ポリシー: strict | relaxed_for_secondary | mixed
+  relaxed_policy: "strict"
+```
+
+**strict（デフォルト）**: すべてのモックに明示的な設定が必要
+**relaxed_for_secondary**: 主要でない依存関係には `relaxed = true` を使用
+**mixed**: Reducer/Handler は relaxed、UseCase は strict
+
+### coEvery vs every 使い分け
+
+| 対象 | 使用する関数 | 理由 |
+|------|------------|------|
+| suspend関数 | `coEvery` / `coVerify` | コルーチン対応 |
+| 通常関数 | `every` / `verify` | 非suspend |
+| Flow返却関数 | `every` | Flow自体はsuspendでない |
+| Unit返却関数 | `relaxUnitFun = true` | 明示的設定不要 |
+
+```kotlin
+// suspend関数
+coEvery { repository.getData() } returns Result.success(data)
+
+// 通常関数（Flow返却）
+every { useCase.observe() } returns flowOf(data)
+
+// アナリティクス（非suspend、Unit返却）
+// → MockKAnnotations.init(this, relaxUnitFun = true) で自動
+verify { tracker.trackEvent(any(), any()) }
+```
+
+---
+
+## @file:Suppress 自動付与ルール
+
+テストファイルの先頭に自動付与する `@file:Suppress`:
+
+```yaml
+suppress:
+  # 日本語テスト名を使用する場合
+  non_ascii: true     # → @file:Suppress("NonAsciiCharacters")
+  test_fn_name: true  # → @file:Suppress("TestFunctionName")
+```
+
+```kotlin
+// 日本語テスト名を使う場合（mixed / japanese）
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+```
+
+---
+
+## Import aliasing ルール
+
+Entity名とDomainModel名が同名の場合に使用:
+
+```yaml
+import_alias:
+  enabled: true
+  pattern: "{TypeName}Entity"  # data層のEntityに"Entity"サフィックスを付与
+```
+
+```kotlin
+// 同名クラスの衝突を回避
+import jp.co.example.data.entity.Article as ArticleEntity
+import jp.co.example.domain.model.Article as ArticleModel
+```
+
+---
+
+## 追加 import
+
+プロジェクト固有の追加importを指定:
+
+```yaml
+additional_imports:
+  - "com.example.app.testing.TestUtils"
+  - "com.example.app.testing.FakeData"
+```
+
+---
+
+## テストケース生成ルール
+
+```yaml
+test_cases:
+  # 必ず生成するケース
+  required:
+    - success
+    - failure
+
+  # オプションで生成するケース
+  optional:
+    - empty_result
+    - null_handling
+    - boundary_values
+```
+
+---
+
+## サンプル設定（dmenu-news）
+
+```yaml
+project_name: "dmenu-news"
+test_package: "jp.co.nttdocomo.dmenunews"
+test_directory: "app/src/test/java"
+
+# モジュール別設定
+domain:
+  assertion: "junit"
+  coroutine: "runTest"
+  mock_policy: "strict"
+  flow_verification: "first"
+
+data:
+  assertion: "truth"
+  coroutine: "runTest"
+  mock_policy: "relaxed"
+  flow_verification: "first"
+
+ui:
+  assertion: "truth"
+  coroutine: "testScope_runTest"
+  mock_policy: "mixed"
+  flow_verification: "manual_collect"
+
+# 共通設定
+naming:
+  language: "mixed"
+  use_backtick: true
+
+mock:
+  library: "mockk"
+  relaxed_policy: "mixed"
+
+suppress:
+  non_ascii: true
+  test_fn_name: true
+
+import_alias:
+  enabled: true
+
+test_cases:
+  required:
+    - success
+    - failure
+  optional:
+    - empty_result
+```

--- a/android_development/.claude/skills/android-test-generator/templates/api-service-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/api-service-test.md
@@ -1,0 +1,286 @@
+# API Service テストテンプレート（MockWebServer）
+
+MockWebServer を使用した API Service のテスト。
+JSON fixture ファイルを使ったレスポンス検証パターン。
+
+---
+
+## 基本構造（ApiTestBase 継承パターン）
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import okhttp3.mockwebserver.Dispatcher
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import java.net.HttpURLConnection
+
+class {ClassName}Test {
+
+    private lateinit var mockWebServer: MockWebServer
+    private lateinit var apiService: {ClassName}
+
+    @Before
+    fun setUp() {
+        mockWebServer = MockWebServer()
+        mockWebServer.start()
+
+        val retrofit = Retrofit.Builder()
+            .baseUrl(mockWebServer.url("/"))
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+
+        apiService = retrofit.create({ClassName}::class.java)
+    }
+
+    @After
+    fun tearDown() {
+        mockWebServer.shutdown()
+    }
+}
+```
+
+---
+
+## JSON fixture を使ったレスポンス設定
+
+```kotlin
+private fun loadJsonFromResource(fileName: String): String {
+    return javaClass.classLoader!!
+        .getResourceAsStream("fixtures/$fileName")!!
+        .bufferedReader()
+        .readText()
+}
+
+private fun enqueueResponse(fileName: String, code: Int = HttpURLConnection.HTTP_OK) {
+    val json = loadJsonFromResource(fileName)
+    mockWebServer.enqueue(
+        MockResponse()
+            .setResponseCode(code)
+            .setBody(json)
+            .addHeader("Content-Type", "application/json")
+    )
+}
+```
+
+---
+
+## 正常系テスト
+
+```kotlin
+@Test
+fun `{method} - 正常レスポンスの場合、正しくパースされること`() = runTest {
+    // Given
+    enqueueResponse("{fixture_file}.json")
+
+    // When
+    val response = apiService.{method}()
+
+    // Then
+    assertThat(response.isSuccessful).isTrue()
+    val body = response.body()!!
+    assertThat(body.{field}).isEqualTo({expectedValue})
+    assertThat(body.items).hasSize({expectedSize})
+}
+
+@Test
+fun `{method} - リクエストパスが正しいこと`() = runTest {
+    // Given
+    enqueueResponse("{fixture_file}.json")
+
+    // When
+    apiService.{method}(param1 = "value1", param2 = "value2")
+
+    // Then
+    val request = mockWebServer.takeRequest()
+    assertThat(request.path).isEqualTo("/{expected_path}?param1=value1&param2=value2")
+    assertThat(request.method).isEqualTo("GET")
+}
+
+@Test
+fun `{method} - リクエストヘッダーが正しいこと`() = runTest {
+    // Given
+    enqueueResponse("{fixture_file}.json")
+
+    // When
+    apiService.{method}()
+
+    // Then
+    val request = mockWebServer.takeRequest()
+    assertThat(request.getHeader("Content-Type")).isEqualTo("application/json")
+}
+```
+
+---
+
+## 異常系テスト
+
+```kotlin
+@Test
+fun `{method} - 404エラーの場合、レスポンスコードが404であること`() = runTest {
+    // Given
+    mockWebServer.enqueue(
+        MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+            .setBody("""{"error": "Not Found"}""")
+    )
+
+    // When
+    val response = apiService.{method}()
+
+    // Then
+    assertThat(response.isSuccessful).isFalse()
+    assertThat(response.code()).isEqualTo(404)
+}
+
+@Test
+fun `{method} - 500エラーの場合、レスポンスコードが500であること`() = runTest {
+    // Given
+    mockWebServer.enqueue(
+        MockResponse()
+            .setResponseCode(HttpURLConnection.HTTP_INTERNAL_ERROR)
+    )
+
+    // When
+    val response = apiService.{method}()
+
+    // Then
+    assertThat(response.isSuccessful).isFalse()
+    assertThat(response.code()).isEqualTo(500)
+}
+
+@Test
+fun `{method} - 空レスポンスの場合、正しく処理されること`() = runTest {
+    // Given
+    enqueueResponse("{fixture_file_empty}.json")
+
+    // When
+    val response = apiService.{method}()
+
+    // Then
+    assertThat(response.isSuccessful).isTrue()
+    assertThat(response.body()!!.items).isEmpty()
+}
+```
+
+---
+
+## Dispatcher を使った複数エンドポイントテスト
+
+```kotlin
+@Test
+fun `複数APIを連続呼び出しした場合、それぞれ正しいレスポンスを返すこと`() = runTest {
+    // Given
+    mockWebServer.dispatcher = object : Dispatcher() {
+        override fun dispatch(request: RecordedRequest): MockResponse {
+            return when (request.path) {
+                "/{path1}" -> MockResponse()
+                    .setResponseCode(HttpURLConnection.HTTP_OK)
+                    .setBody(loadJsonFromResource("{fixture1}.json"))
+                "/{path2}" -> MockResponse()
+                    .setResponseCode(HttpURLConnection.HTTP_OK)
+                    .setBody(loadJsonFromResource("{fixture2}.json"))
+                else -> MockResponse().setResponseCode(HttpURLConnection.HTTP_NOT_FOUND)
+            }
+        }
+    }
+
+    // When
+    val response1 = apiService.{method1}()
+    val response2 = apiService.{method2}()
+
+    // Then
+    assertThat(response1.body()!!.{field}).isEqualTo({expected1})
+    assertThat(response2.body()!!.{field}).isEqualTo({expected2})
+}
+```
+
+---
+
+## POST リクエストのボディ検証
+
+```kotlin
+@Test
+fun `{method} - POSTリクエストのボディが正しいこと`() = runTest {
+    // Given
+    enqueueResponse("{fixture_file}.json")
+    val requestBody = {RequestBody}(
+        title = "Test",
+        content = "Content"
+    )
+
+    // When
+    apiService.{method}(requestBody)
+
+    // Then
+    val request = mockWebServer.takeRequest()
+    assertThat(request.method).isEqualTo("POST")
+    val bodyJson = request.body.readUtf8()
+    assertThat(bodyJson).contains("\"title\":\"Test\"")
+    assertThat(bodyJson).contains("\"content\":\"Content\"")
+}
+```
+
+---
+
+## JSON fixture ファイル配置
+
+```
+src/test/resources/fixtures/
+├── {feature}_success.json        # 正常系レスポンス
+├── {feature}_empty.json          # 空レスポンス
+└── {feature}_error.json          # エラーレスポンス
+```
+
+**fixture例** (`articles_success.json`):
+```json
+{
+  "status": "ok",
+  "articles": [
+    {
+      "id": "1",
+      "title": "Test Article",
+      "publishedAt": "2025-01-01T00:00:00Z"
+    }
+  ],
+  "totalCount": 1
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | 値 |
+|------|-----|
+| runTest | `runTest`（MockWebServerはコルーチン不要だが Retrofit suspend関数のため） |
+| アサーション | Truth (`assertThat`) |
+| Mock | MockWebServer（実際のHTTP通信をシミュレート） |
+| fixture | `src/test/resources/fixtures/` に配置 |
+| 注意点 | `mockWebServer.shutdown()` を `@After` で必ず呼ぶ |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.data.api` |
+| `{ClassName}` | APIサービスインターフェース名 | `ArticleApiService` |
+| `{method}` | APIメソッド名 | `getArticles` |
+| `{fixture_file}` | JSONフィクスチャファイル名 | `articles_success` |
+| `{expected_path}` | 期待されるリクエストパス | `api/v1/articles` |
+| `{RequestBody}` | リクエストボディ型 | `CreateArticleRequest` |
+| `{field}` | レスポンスフィールド名 | `totalCount` |
+| `{expectedValue}` | 期待される値 | `1` |
+| `{expectedSize}` | 期待されるリストサイズ | `3` |

--- a/android_development/.claude/skills/android-test-generator/templates/handler-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/handler-test.md
@@ -1,0 +1,332 @@
+# Handler テストテンプレート
+
+Handlerはアナリティクス送信・ディープリンク処理・ログ出力など横断的関心事を担当する。
+MockKAnnotations.init + @RelaxedMockK アノテーションパターンを使用。
+
+---
+
+## 基本構造
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import io.mockk.MockKAnnotations
+import io.mockk.RelaxedMockK
+import io.mockk.every
+import io.mockk.impl.annotations.RelaxedMockK
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Before
+import org.junit.Test
+
+class {ClassName}Test {
+
+    // === 依存関係（@RelaxedMockK）===
+    @RelaxedMockK
+    private lateinit var {dependency1Name}: {Dependency1Type}
+
+    @RelaxedMockK
+    private lateinit var {dependency2Name}: {Dependency2Type}
+
+    // === テスト対象 ===
+    private lateinit var handler: {ClassName}
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+
+        handler = {ClassName}(
+            {dependency1Name} = {dependency1Name},
+            {dependency2Name} = {dependency2Name}
+        )
+    }
+}
+```
+
+---
+
+## アナリティクスイベント送信テスト
+
+```kotlin
+@Test
+fun `handle - イベントが正しいパラメータで送信されること`() {
+    // Given
+    val eventData = {EventData}(
+        articleId = "123",
+        category = "news",
+        action = "click"
+    )
+
+    // When
+    handler.handle(eventData)
+
+    // Then
+    verify(exactly = 1) {
+        {dependency1Name}.trackEvent(
+            eventName = eq("article_click"),
+            params = match {
+                it["article_id"] == "123" &&
+                it["category"] == "news" &&
+                it["action"] == "click"
+            }
+        )
+    }
+}
+
+@Test
+fun `handle - 画面表示イベントが送信されること`() {
+    // When
+    handler.onScreenView("{screenName}")
+
+    // Then
+    verify(exactly = 1) {
+        {dependency1Name}.trackScreenView("{screenName}")
+    }
+}
+
+@Test
+fun `handle - 複数のトラッカーに同時送信されること`() {
+    // Given
+    val eventData = {EventData}(action = "purchase")
+
+    // When
+    handler.handle(eventData)
+
+    // Then
+    verify(exactly = 1) { {dependency1Name}.trackEvent(any(), any()) }
+    verify(exactly = 1) { {dependency2Name}.logEvent(any()) }
+}
+```
+
+---
+
+## 引数マッチャーを使った検証
+
+```kotlin
+@Test
+fun `handle - anyマッチャーで呼び出しを検証`() {
+    // When
+    handler.handle({EventData}(articleId = "123"))
+
+    // Then
+    verify { {dependency1Name}.trackEvent(any(), any()) }
+}
+
+@Test
+fun `handle - match式で部分一致を検証`() {
+    // When
+    handler.handle({EventData}(
+        articleId = "123",
+        category = "news",
+        position = 5
+    ))
+
+    // Then
+    verify {
+        {dependency1Name}.trackEvent(
+            eventName = any(),
+            params = match { params ->
+                params.containsKey("article_id") &&
+                params["position"] == "5"
+            }
+        )
+    }
+}
+
+@Test
+fun `handle - captureで引数を取得して検証`() {
+    // Given
+    val paramsSlot = slot<Map<String, String>>()
+
+    // When
+    handler.handle({EventData}(articleId = "123", category = "news"))
+
+    // Then
+    verify {
+        {dependency1Name}.trackEvent(
+            eventName = any(),
+            params = capture(paramsSlot)
+        )
+    }
+    val captured = paramsSlot.captured
+    assertThat(captured["article_id"]).isEqualTo("123")
+    assertThat(captured["category"]).isEqualTo("news")
+}
+```
+
+---
+
+## 条件分岐テスト
+
+```kotlin
+@Test
+fun `handle - フラグがONの場合のみイベントを送信すること`() {
+    // Given
+    every { {dependency2Name}.isEnabled() } returns true
+
+    // When
+    handler.handle({EventData}(action = "click"))
+
+    // Then
+    verify(exactly = 1) { {dependency1Name}.trackEvent(any(), any()) }
+}
+
+@Test
+fun `handle - フラグがOFFの場合はイベントを送信しないこと`() {
+    // Given
+    every { {dependency2Name}.isEnabled() } returns false
+
+    // When
+    handler.handle({EventData}(action = "click"))
+
+    // Then
+    verify(exactly = 0) { {dependency1Name}.trackEvent(any(), any()) }
+}
+```
+
+---
+
+## ディープリンクHandler パターン
+
+```kotlin
+class {DeepLinkHandlerClass}Test {
+
+    @RelaxedMockK
+    private lateinit var router: {RouterType}
+
+    @RelaxedMockK
+    private lateinit var analyticsTracker: {AnalyticsType}
+
+    private lateinit var handler: {DeepLinkHandlerClass}
+
+    @Before
+    fun setUp() {
+        MockKAnnotations.init(this, relaxUnitFun = true)
+        handler = {DeepLinkHandlerClass}(router, analyticsTracker)
+    }
+
+    @Test
+    fun `handle - 記事ディープリンクの場合、記事詳細画面に遷移すること`() {
+        // Given
+        val deepLink = "app://article/123"
+
+        // When
+        handler.handle(deepLink)
+
+        // Then
+        verify(exactly = 1) { router.navigateTo("article_detail", match { it["id"] == "123" }) }
+    }
+
+    @Test
+    fun `handle - 不明なディープリンクの場合、ホーム画面に遷移すること`() {
+        // Given
+        val deepLink = "app://unknown/path"
+
+        // When
+        handler.handle(deepLink)
+
+        // Then
+        verify(exactly = 1) { router.navigateTo("home", any()) }
+    }
+}
+```
+
+---
+
+## Coroutine を使う Handler
+
+suspend関数を含むHandlerの場合:
+
+```kotlin
+import io.mockk.coEvery
+import io.mockk.coVerify
+import kotlinx.coroutines.test.runTest
+
+@Test
+fun `handle - 非同期イベント送信が成功すること`() = runTest {
+    // Given
+    coEvery { {dependency1Name}.sendAsync(any()) } returns Result.success(Unit)
+
+    // When
+    handler.handleAsync({EventData}(action = "purchase"))
+
+    // Then
+    coVerify(exactly = 1) { {dependency1Name}.sendAsync(any()) }
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | 値 |
+|------|-----|
+| runTest | 基本不要（suspend関数がある場合のみ `runTest`） |
+| アサーション | MockK `verify` が主力、値検証は Truth |
+| Mock | `MockKAnnotations.init(this, relaxUnitFun = true)` + `@RelaxedMockK` |
+| 検証方法 | `verify` + 引数マッチャー（`eq`, `match`, `any`, `capture`） |
+| 注意点 | Unit返却関数は `relaxUnitFun = true` で自動リラックス |
+
+## 実プロジェクトでの注意事項
+
+### Android Framework 依存
+
+Intent/Activity/Context に依存するHandler（画面遷移Handler、ディープリンクHandler等）は
+純粋JUnitテストに制約がある:
+
+- `Intent` コンストラクタ、`Activity.createIntent()` 等は Android ランタイムが必要
+- `Uri.parse()` は `mockkStatic(Uri::class)` でモック可能
+- `Timber.d()` はテスト用 Tree を plant するか `mockkStatic` で対応
+
+**推奨アプローチ**: Android非依存のロジック（アナリティクス送信判定、ブラックリスト判定、
+条件分岐ロジック等）に検証を集中し、Intent生成・画面遷移は Robolectric 導入後にテスト。
+
+```kotlin
+// Uri.parse モック
+mockkStatic(Uri::class)
+every { Uri.parse(any()) } returns mockk(relaxed = true)
+
+// Timber モック
+Timber.plant(object : Timber.Tree() {
+    override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {}
+})
+
+// tearDown で必ずクリーンアップ
+@After
+fun tearDown() {
+    Timber.uprootAll()
+    unmockkAll()
+}
+```
+
+### 値クラス（`@JvmInline value class`）
+
+`ArticleId`, `CategoryId` 等の値クラスはMockKでモックできない。実インスタンスを使用:
+
+```kotlin
+// NG
+every { item.id } returns mockk<ArticleId>()  // unbox-impl エラー
+
+// OK
+every { item.id } returns ArticleId("article-1")
+```
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.ui.handler` |
+| `{ClassName}` | Handlerクラス名 | `ArticleAnalyticsHandler` |
+| `{dependency1Name}` | 依存変数名1 | `analyticsTracker` |
+| `{Dependency1Type}` | 依存型1 | `AnalyticsTracker` |
+| `{dependency2Name}` | 依存変数名2 | `featureFlag` |
+| `{Dependency2Type}` | 依存型2 | `FeatureFlag` |
+| `{EventData}` | イベントデータ型 | `AnalyticsEvent` |
+| `{screenName}` | 画面名 | `article_list` |
+| `{DeepLinkHandlerClass}` | ディープリンクHandler | `DeepLinkHandler` |
+| `{RouterType}` | ルーター型 | `AppRouter` |
+| `{AnalyticsType}` | アナリティクス型 | `AnalyticsTracker` |

--- a/android_development/.claude/skills/android-test-generator/templates/mapper-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/mapper-test.md
@@ -1,0 +1,333 @@
+# Mapper テストテンプレート
+
+Mapperは純粋関数（Entity→DomainModel変換）であり、`runTest` やコルーチン設定は不要。
+JUnit Assert を主力に使用。
+
+> **注意**: 依存関係を持つMapper（RemoteConfig参照、他Mapper委譲等）は「依存ありMapperパターン」を参照。
+
+---
+
+## 基本構造（クラスベースMapper）
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class {ClassName}Test {
+
+    // === テスト対象 ===
+    private lateinit var mapper: {ClassName}
+
+    @Before
+    fun setUp() {
+        mapper = {ClassName}()
+    }
+
+    // === 正常系テスト ===
+
+    @Test
+    fun `map - 全フィールドが正しく変換されること`() {
+        // Given
+        val entity = {EntityType}(
+            id = "123",
+            title = "Test Title",
+            description = "Test Description",
+            createdAt = "2025-01-01T00:00:00Z",
+            status = 1
+        )
+
+        // When
+        val result = mapper.map(entity)
+
+        // Then
+        assertEquals("123", result.id)
+        assertEquals("Test Title", result.title)
+        assertEquals("Test Description", result.description)
+        assertNotNull(result.createdAt)
+        assertEquals({StatusEnum}.ACTIVE, result.status)
+    }
+
+    @Test
+    fun `map - リストが正しく変換されること`() {
+        // Given
+        val entities = listOf(
+            {EntityType}(id = "1", title = "First"),
+            {EntityType}(id = "2", title = "Second")
+        )
+
+        // When
+        val results = mapper.mapList(entities)
+
+        // Then
+        assertEquals(2, results.size)
+        assertEquals("1", results[0].id)
+        assertEquals("2", results[1].id)
+    }
+}
+```
+
+---
+
+## 拡張関数ベースMapper
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class {ClassName}MapperTest {
+
+    @Test
+    fun `toXxx - 全フィールドが正しく変換されること`() {
+        // Given
+        val entity = {EntityType}(
+            id = "123",
+            title = "Test Title",
+            imageUrl = "https://example.com/image.jpg"
+        )
+
+        // When
+        val result = entity.to{DomainType}()
+
+        // Then
+        assertEquals("123", result.id)
+        assertEquals("Test Title", result.title)
+        assertEquals("https://example.com/image.jpg", result.imageUrl)
+    }
+
+    @Test
+    fun `toXxx - リスト変換が正しく動作すること`() {
+        // Given
+        val entities = listOf(
+            {EntityType}(id = "1"),
+            {EntityType}(id = "2")
+        )
+
+        // When
+        val results = entities.map { it.to{DomainType}() }
+
+        // Then
+        assertEquals(2, results.size)
+    }
+}
+```
+
+---
+
+## null値・デフォルト値変換テスト
+
+```kotlin
+@Test
+fun `map - nullフィールドがデフォルト値に変換されること`() {
+    // Given
+    val entity = {EntityType}(
+        id = "123",
+        title = null,
+        description = null,
+        imageUrl = null
+    )
+
+    // When
+    val result = mapper.map(entity)
+
+    // Then
+    assertEquals("123", result.id)
+    assertEquals("", result.title)           // null → 空文字
+    assertNull(result.description)            // null許容フィールド
+    assertEquals({DefaultImage}, result.imageUrl)  // null → デフォルト画像
+}
+
+@Test
+fun `map - 空文字列が正しく変換されること`() {
+    // Given
+    val entity = {EntityType}(
+        id = "",
+        title = ""
+    )
+
+    // When
+    val result = mapper.map(entity)
+
+    // Then
+    assertEquals("", result.id)
+    assertEquals("", result.title)
+}
+```
+
+---
+
+## Enum・型変換テスト
+
+```kotlin
+@Test
+fun `map - ステータスコードがEnumに正しく変換されること`() {
+    // Given - When - Then
+    assertEquals({StatusEnum}.ACTIVE, mapper.mapStatus(1))
+    assertEquals({StatusEnum}.INACTIVE, mapper.mapStatus(0))
+    assertEquals({StatusEnum}.UNKNOWN, mapper.mapStatus(-1))
+}
+
+@Test
+fun `map - 日付文字列がDateオブジェクトに変換されること`() {
+    // Given
+    val entity = {EntityType}(
+        createdAt = "2025-01-15T10:30:00Z"
+    )
+
+    // When
+    val result = mapper.map(entity)
+
+    // Then
+    assertNotNull(result.createdAt)
+}
+
+@Test
+fun `map - 不正な日付文字列の場合、nullになること`() {
+    // Given
+    val entity = {EntityType}(
+        createdAt = "invalid-date"
+    )
+
+    // When
+    val result = mapper.map(entity)
+
+    // Then
+    assertNull(result.createdAt)
+}
+```
+
+---
+
+## 同名Entity問題（import aliasing）
+
+Entity名とDomainModel名が同名の場合、import aliasを使用:
+
+```kotlin
+import {data_package}.entity.Article as ArticleEntity
+import {domain_package}.model.Article as ArticleModel
+
+class ArticleMapperTest {
+
+    @Test
+    fun `map - ArticleEntityがArticleModelに変換されること`() {
+        // Given
+        val entity = ArticleEntity(id = "1", title = "Test")
+
+        // When
+        val result = mapper.map(entity)
+
+        // Then - result は ArticleModel 型
+        assertEquals("1", result.id)
+    }
+}
+```
+
+---
+
+## 依存ありMapperパターン
+
+RemoteConfig参照・他Mapper委譲・Photo変換等の依存を持つMapperの場合:
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+
+class {ClassName}Test {
+
+    // === 依存関係（モック） ===
+    private lateinit var {subMapperName}: {SubMapperType}
+    private lateinit var {configName}: {ConfigType}
+
+    // === テスト対象 ===
+    private lateinit var mapper: {ClassName}
+
+    @Before
+    fun setUp() {
+        {subMapperName} = mockk()
+        {configName} = mockk()
+        mapper = {ClassName}({subMapperName}, {configName})
+    }
+
+    @Test
+    fun `map - 依存Mapperの結果が正しく統合されること`() {
+        // Given
+        val input = mockk<{InputType}>(relaxed = true) {
+            every { rows } returns listOf(mockk())
+        }
+
+        every { {subMapperName}.map(any(), any()) } returns listOf({ExpectedItem}(...))
+        every { {configName}.getValue(any()) } returns {ConfigValue}
+
+        // When
+        val result = mapper.map(input, 0)
+
+        // Then
+        assertNotNull(result)
+        assertEquals(1, result.items.size)
+    }
+}
+```
+
+### ネストされた型参照の注意
+
+APIレスポンスモデルで、フィールドの型が別クラスのネスト型を参照しているケースがある:
+
+```kotlin
+// GetArticleResponse.rows は GetTimelineResponse.Row を参照
+val rows: List<GetTimelineResponse.Row>?  // ← GetArticleResponse.Row ではない！
+
+// テストでの正しいモック
+val rows = listOf(mockk<GetTimelineResponse.Row>())  // ✅
+val rows = listOf(mockk<GetArticleResponse.Row>())    // ❌ 存在しない型
+```
+
+テスト生成時は、フィールドの型定義を必ず確認すること。
+
+---
+
+## 設計ポイント
+
+| 項目 | 純粋関数Mapper | 依存ありMapper |
+|------|--------------|---------------|
+| runTest | **不要** | **不要**（非suspend） |
+| アサーション | JUnit Assert | JUnit Assert |
+| Mock | **不要** | MockK（依存をモック） |
+| テストパターン | 入力Entity → 出力DomainModel | 入力 + Mock設定 → 出力 |
+| 注意点 | エッジケース網羅 | ネスト型・戻り値型の正確な把握 |
+| import alias | 同名クラス時に使用 | 同名クラス時に使用 |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.data.mapper` |
+| `{ClassName}` | Mapperクラス名 | `ArticleMapper` |
+| `{EntityType}` | Entity型（API/DB） | `ArticleEntity` |
+| `{DomainType}` | ドメインモデル型 | `Article` |
+| `{StatusEnum}` | ステータスEnum | `ArticleStatus` |
+| `{DefaultImage}` | デフォルト画像URL | `""` |
+| `{data_package}` | dataパッケージ | `jp.co.nttdocomo.dmenunews.data` |
+| `{domain_package}` | domainパッケージ | `jp.co.nttdocomo.dmenunews.domain` |

--- a/android_development/.claude/skills/android-test-generator/templates/presenter-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/presenter-test.md
@@ -1,0 +1,273 @@
+# Presenter テストテンプレート
+
+PresenterはUseCase呼び出し・データ加工・アナリティクスイベント送信を担当する。
+TestScope + Dispatchers.setMain/resetMain の手動管理パターンを使用。
+
+---
+
+## 基本構造
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class {ClassName}Test {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var testScope: TestScope
+
+    // === 依存関係 ===
+    private lateinit var {useCase1Name}: {UseCase1Type}
+    private lateinit var {useCase2Name}: {UseCase2Type}
+    private lateinit var analyticsTracker: {AnalyticsTrackerType}
+
+    // === テスト対象 ===
+    private lateinit var presenter: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        {useCase1Name} = mockk()
+        {useCase2Name} = mockk()
+        analyticsTracker = mockk(relaxUnitFun = true)
+
+        presenter = {ClassName}(
+            {useCase1Name} = {useCase1Name},
+            {useCase2Name} = {useCase2Name},
+            analyticsTracker = analyticsTracker,
+            scope = testScope
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+---
+
+## データロードテスト（UseCase呼び出し検証）
+
+```kotlin
+@Test
+fun `loadData - 成功時、UIにデータが反映されること`() = testScope.runTest {
+    // Given
+    val articles = listOf({ArticleType}(id = "1", title = "Test Article"))
+    coEvery { {useCase1Name}() } returns Result.success(articles)
+
+    // When
+    presenter.loadData()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.articles).isEqualTo(articles)
+    assertThat(presenter.uiState.value.isLoading).isFalse()
+}
+
+@Test
+fun `loadData - 失敗時、エラー状態になること`() = testScope.runTest {
+    // Given
+    val exception = Exception("Network error")
+    coEvery { {useCase1Name}() } returns Result.failure(exception)
+
+    // When
+    presenter.loadData()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.error).isNotNull()
+    assertThat(presenter.uiState.value.isLoading).isFalse()
+}
+```
+
+---
+
+## Flow返却UseCaseのテスト
+
+```kotlin
+@Test
+fun `observe - Flowからデータを受信してUIに反映すること`() = testScope.runTest {
+    // Given
+    val item1 = {ItemType}(id = "1")
+    val item2 = {ItemType}(id = "2")
+    every { {useCase2Name}() } returns flowOf(listOf(item1), listOf(item1, item2))
+
+    // When
+    presenter.startObserving()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.items).hasSize(2)
+}
+
+@Test
+fun `observe - Flow購読中にエラーが発生した場合、エラーハンドリングすること`() = testScope.runTest {
+    // Given
+    every { {useCase2Name}() } returns kotlinx.coroutines.flow.flow {
+        emit(listOf({ItemType}(id = "1")))
+        throw Exception("Stream error")
+    }
+
+    // When
+    presenter.startObserving()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.error).isNotNull()
+}
+```
+
+---
+
+## アナリティクスイベント検証
+
+```kotlin
+@Test
+fun `onItemClick - アナリティクスイベントを送信すること`() = testScope.runTest {
+    // Given
+    val articleId = "123"
+    val articleTitle = "Test Article"
+
+    // When
+    presenter.onItemClick(articleId, articleTitle)
+    advanceUntilIdle()
+
+    // Then
+    verify(exactly = 1) {
+        analyticsTracker.trackEvent(
+            eventName = "article_click",
+            params = match {
+                it["article_id"] == articleId && it["article_title"] == articleTitle
+            }
+        )
+    }
+}
+
+@Test
+fun `onScreenView - 画面表示イベントを送信すること`() = testScope.runTest {
+    // When
+    presenter.onScreenView()
+    advanceUntilIdle()
+
+    // Then
+    verify(exactly = 1) {
+        analyticsTracker.trackScreenView("{ScreenName}")
+    }
+}
+
+@Test
+fun `onBookmark - ブックマークイベントとUseCase呼び出しの両方を実行すること`() = testScope.runTest {
+    // Given
+    val articleId = "123"
+    coEvery { {useCase2Name}(articleId) } returns Result.success(Unit)
+
+    // When
+    presenter.onBookmark(articleId)
+    advanceUntilIdle()
+
+    // Then
+    coVerify(exactly = 1) { {useCase2Name}(articleId) }
+    verify(exactly = 1) {
+        analyticsTracker.trackEvent(
+            eventName = "bookmark_toggle",
+            params = match { it["article_id"] == articleId }
+        )
+    }
+}
+```
+
+---
+
+## 複数UseCase連携テスト
+
+```kotlin
+@Test
+fun `loadData - 複数UseCaseを並行呼び出しして結果を統合すること`() = testScope.runTest {
+    // Given
+    val articles = listOf({ArticleType}(id = "1"))
+    val categories = listOf({CategoryType}(id = "cat1"))
+    coEvery { {useCase1Name}() } returns Result.success(articles)
+    coEvery { {useCase2Name}() } returns Result.success(categories)
+
+    // When
+    presenter.loadData()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.articles).isEqualTo(articles)
+    assertThat(presenter.uiState.value.categories).isEqualTo(categories)
+}
+
+@Test
+fun `loadData - 一方のUseCaseが失敗しても他方の結果は反映すること`() = testScope.runTest {
+    // Given
+    val articles = listOf({ArticleType}(id = "1"))
+    coEvery { {useCase1Name}() } returns Result.success(articles)
+    coEvery { {useCase2Name}() } returns Result.failure(Exception("error"))
+
+    // When
+    presenter.loadData()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(presenter.uiState.value.articles).isEqualTo(articles)
+    assertThat(presenter.uiState.value.partialError).isTrue()
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | 値 |
+|------|-----|
+| runTest | `testScope.runTest` |
+| アサーション | Truth (`assertThat`) |
+| Mock | MockK（analyticsTracker は `relaxUnitFun = true`） |
+| Dispatcher | `StandardTestDispatcher` + `TestScope` + `Dispatchers.setMain/resetMain` 手動管理 |
+| coEvery vs every | suspend関数 → `coEvery`、通常関数（Flow返却等） → `every` |
+| 注意点 | アナリティクス検証は `verify`（非suspend）、UseCase呼び出しは `coVerify` |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.ui.article` |
+| `{ClassName}` | Presenterクラス名 | `ArticleDetailPresenter` |
+| `{useCase1Name}` | UseCase1変数名 | `getArticleDetailUseCase` |
+| `{UseCase1Type}` | UseCase1型 | `GetArticleDetailUseCase` |
+| `{useCase2Name}` | UseCase2変数名 | `bookmarkArticleUseCase` |
+| `{UseCase2Type}` | UseCase2型 | `BookmarkArticleUseCase` |
+| `{AnalyticsTrackerType}` | アナリティクス型 | `AnalyticsTracker` |
+| `{ScreenName}` | 画面名 | `article_detail` |
+| `{ArticleType}` | 記事モデル型 | `ArticleDetail` |
+| `{CategoryType}` | カテゴリ型 | `Category` |
+| `{ItemType}` | アイテム型 | `ArticleItem` |

--- a/android_development/.claude/skills/android-test-generator/templates/reducer-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/reducer-test.md
@@ -1,0 +1,174 @@
+# Reducer テストテンプレート
+
+Reducerは純粋関数であり、`runTest` やコルーチン設定は不要。
+入力（現在のState + Action）に対して期待されるStateを返すことを検証する。
+
+---
+
+## 基本構造
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Before
+import org.junit.Test
+
+class {ClassName}Test {
+
+    // === テスト対象 ===
+    private lateinit var reducer: {ClassName}
+
+    @Before
+    fun setUp() {
+        reducer = {ClassName}()
+    }
+
+    // === 状態遷移テスト ===
+
+    @Test
+    fun `reduce - {Action} を受け取った場合、{期待される状態} になること`() {
+        // Given
+        val currentState = {StateType}(
+            isLoading = false,
+            items = emptyList()
+        )
+        val action = {ActionType}.{ActionName}
+
+        // When
+        val newState = reducer.reduce(currentState, action)
+
+        // Then
+        assertThat(newState.isLoading).isTrue()
+    }
+
+    @Test
+    fun `reduce - LoadSuccess を受け取った場合、データが設定されること`() {
+        // Given
+        val currentState = {StateType}(isLoading = true)
+        val items = listOf({ItemType}(id = "1", title = "Test"))
+        val action = {ActionType}.LoadSuccess(items)
+
+        // When
+        val newState = reducer.reduce(currentState, action)
+
+        // Then
+        assertThat(newState.isLoading).isFalse()
+        assertThat(newState.items).isEqualTo(items)
+    }
+
+    @Test
+    fun `reduce - LoadFailure を受け取った場合、エラー状態になること`() {
+        // Given
+        val currentState = {StateType}(isLoading = true)
+        val error = Exception("Network error")
+        val action = {ActionType}.LoadFailure(error)
+
+        // When
+        val newState = reducer.reduce(currentState, action)
+
+        // Then
+        assertThat(newState.isLoading).isFalse()
+        assertThat(newState.error).isEqualTo(error)
+    }
+}
+```
+
+---
+
+## 冪等性テスト
+
+同じActionを2回適用しても結果が変わらないことを検証:
+
+```kotlin
+@Test
+fun `reduce - 同じActionを2回適用しても結果が変わらないこと`() {
+    // Given
+    val initialState = {StateType}()
+    val action = {ActionType}.{ActionName}
+
+    // When
+    val state1 = reducer.reduce(initialState, action)
+    val state2 = reducer.reduce(state1, action)
+
+    // Then
+    assertThat(state1).isEqualTo(state2)
+}
+```
+
+---
+
+## 複数Action連続適用テスト
+
+```kotlin
+@Test
+fun `reduce - Loading → LoadSuccess の連続適用で正しい状態になること`() {
+    // Given
+    val initialState = {StateType}()
+    val items = listOf({ItemType}(id = "1"))
+
+    // When
+    val loadingState = reducer.reduce(initialState, {ActionType}.StartLoading)
+    val successState = reducer.reduce(loadingState, {ActionType}.LoadSuccess(items))
+
+    // Then
+    assertThat(loadingState.isLoading).isTrue()
+    assertThat(successState.isLoading).isFalse()
+    assertThat(successState.items).hasSize(1)
+}
+```
+
+---
+
+## 部分更新テスト
+
+既存Stateの他のフィールドが保持されることを検証:
+
+```kotlin
+@Test
+fun `reduce - LoadSuccess で既存のフィルター設定が保持されること`() {
+    // Given
+    val currentState = {StateType}(
+        isLoading = true,
+        filterType = FilterType.FAVORITES,
+        selectedTab = 2
+    )
+    val items = listOf({ItemType}(id = "1"))
+    val action = {ActionType}.LoadSuccess(items)
+
+    // When
+    val newState = reducer.reduce(currentState, action)
+
+    // Then
+    assertThat(newState.items).isEqualTo(items)
+    assertThat(newState.filterType).isEqualTo(FilterType.FAVORITES)
+    assertThat(newState.selectedTab).isEqualTo(2)
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | 値 |
+|------|-----|
+| runTest | **不要**（純粋関数） |
+| アサーション | Truth (`assertThat`) |
+| Mock | **不要**（依存関係なし） |
+| テストパターン | `[前State] + [Action] → [次State]` |
+| 注意点 | 副作用がないことを前提とする |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.ui.mylist` |
+| `{ClassName}` | Reducerクラス名 | `MyListReducer` |
+| `{StateType}` | State型 | `MyListState` |
+| `{ActionType}` | Action sealed class | `MyListAction` |
+| `{ActionName}` | 具体的なAction | `StartLoading` |
+| `{ItemType}` | リスト項目の型 | `ArticleItem` |

--- a/android_development/.claude/skills/android-test-generator/templates/repository-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/repository-test.md
@@ -1,0 +1,265 @@
+# Repository テストテンプレート
+
+## 基本構造
+
+```kotlin
+package {test_package}
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import java.io.IOException
+
+class {ClassName}Test {
+
+    // === 依存関係（API/DataSource）===
+    private lateinit var {apiName}: {ApiType}
+
+    // === テスト対象 ===
+    private lateinit var repository: {ClassName}
+
+    @Before
+    fun setup() {
+        {apiName} = mockk()
+        repository = {ClassNameImpl}({apiName})
+    }
+
+    // === テストケース ===
+
+    @Test
+    fun `{method} should return success when api succeeds`() = runTest {
+        // Given
+        val apiResponse = {ApiResponse}(...)
+        val expected = {DomainModel}(...)
+        coEvery { {apiName}.{apiMethod}() } returns apiResponse
+
+        // When
+        val result = repository.{method}()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+    }
+
+    @Test
+    fun `{method} should return failure when api throws exception`() = runTest {
+        // Given
+        val exception = IOException("Network error")
+        coEvery { {apiName}.{apiMethod}() } throws exception
+
+        // When
+        val result = repository.{method}()
+
+        // Then
+        assertTrue(result.isFailure)
+        assertTrue(result.exceptionOrNull() is IOException)
+    }
+
+    @Test
+    fun `{method} should return failure when api returns error response`() = runTest {
+        // Given
+        coEvery { {apiName}.{apiMethod}() } returns {ErrorResponse}(...)
+
+        // When
+        val result = repository.{method}()
+
+        // Then
+        assertTrue(result.isFailure)
+    }
+}
+```
+
+---
+
+## API呼び出しパラメータの検証
+
+```kotlin
+@Test
+fun `{method} should pass correct parameters to api`() = runTest {
+    // Given
+    val param1 = {value1}
+    val param2 = {value2}
+    coEvery {
+        {apiName}.{apiMethod}(
+            param1 = any(),
+            param2 = any()
+        )
+    } returns {ApiResponse}(...)
+
+    // When
+    repository.{method}(param1, param2)
+
+    // Then
+    coVerify(exactly = 1) {
+        {apiName}.{apiMethod}(
+            param1 = param1,
+            param2 = param2
+        )
+    }
+}
+```
+
+---
+
+## キャッシュ付きRepositoryのパターン
+
+```kotlin
+class {ClassName}Test {
+
+    private lateinit var api: {ApiType}
+    private lateinit var cache: {CacheType}
+    private lateinit var repository: {ClassName}
+
+    @Before
+    fun setup() {
+        api = mockk()
+        cache = mockk(relaxed = true)
+        repository = {ClassNameImpl}(api, cache)
+    }
+
+    @Test
+    fun `{method} should return cached data when available`() = runTest {
+        // Given
+        val cachedData = {CachedData}(...)
+        coEvery { cache.get() } returns cachedData
+
+        // When
+        val result = repository.{method}()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(cachedData, result.getOrNull())
+        coVerify(exactly = 0) { api.{apiMethod}() }
+    }
+
+    @Test
+    fun `{method} should fetch from api when cache is empty`() = runTest {
+        // Given
+        coEvery { cache.get() } returns null
+        val apiResponse = {ApiResponse}(...)
+        coEvery { api.{apiMethod}() } returns apiResponse
+
+        // When
+        val result = repository.{method}()
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { api.{apiMethod}() }
+        coVerify(exactly = 1) { cache.save(any()) }
+    }
+
+    @Test
+    fun `{method} should update cache after fetching from api`() = runTest {
+        // Given
+        coEvery { cache.get() } returns null
+        val apiResponse = {ApiResponse}(...)
+        val expected = {DomainModel}(...)
+        coEvery { api.{apiMethod}() } returns apiResponse
+
+        // When
+        repository.{method}()
+
+        // Then
+        coVerify { cache.save(expected) }
+    }
+
+    @Test
+    fun `{method} with forceRefresh should skip cache`() = runTest {
+        // Given
+        val cachedData = {CachedData}(...)
+        coEvery { cache.get() } returns cachedData
+        val apiResponse = {ApiResponse}(...)
+        coEvery { api.{apiMethod}() } returns apiResponse
+
+        // When
+        val result = repository.{method}(forceRefresh = true)
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify(exactly = 1) { api.{apiMethod}() }
+    }
+}
+```
+
+---
+
+## Flow を返すRepositoryのパターン
+
+```kotlin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+
+@Test
+fun `observe should emit data from data source`() = runTest {
+    // Given
+    val data = {Data}(...)
+    coEvery { dataSource.observe() } returns flowOf(data)
+
+    // When
+    val result = repository.observe().first()
+
+    // Then
+    assertEquals(data, result)
+}
+
+@Test
+fun `observe should transform api model to domain model`() = runTest {
+    // Given
+    val apiModel = {ApiModel}(...)
+    val expectedDomain = {DomainModel}(...)
+    coEvery { dataSource.observe() } returns flowOf(apiModel)
+
+    // When
+    val result = repository.observe().first()
+
+    // Then
+    assertEquals(expectedDomain, result)
+}
+```
+
+---
+
+## マッピング検証パターン
+
+```kotlin
+@Test
+fun `{method} should map api response to domain model correctly`() = runTest {
+    // Given
+    val apiResponse = {ApiResponse}(
+        id = "123",
+        title = "Test Title",
+        createdAt = "2025-01-01T00:00:00Z"
+    )
+    coEvery { api.{apiMethod}() } returns apiResponse
+
+    // When
+    val result = repository.{method}()
+
+    // Then
+    assertTrue(result.isSuccess)
+    val domainModel = result.getOrNull()!!
+    assertEquals("123", domainModel.id)
+    assertEquals("Test Title", domainModel.title)
+    assertNotNull(domainModel.createdAt)
+}
+```
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `com.example.app.data.repository` |
+| `{ClassName}` | テスト対象クラス名 | `MyListRepositoryImpl` |
+| `{ClassNameImpl}` | 実装クラス名 | `MyListRepositoryImpl` |
+| `{apiName}` | API変数名 | `myListApi` |
+| `{ApiType}` | API型 | `MyListApi` |
+| `{apiMethod}` | API メソッド名 | `getFavoriteArticles` |
+| `{method}` | Repository メソッド名 | `getFavoriteArticles` |
+| `{ApiResponse}` | APIレスポンス型 | `FavoriteArticlesResponse` |
+| `{DomainModel}` | ドメインモデル型 | `FavoriteArticle` |

--- a/android_development/.claude/skills/android-test-generator/templates/statemanager-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/statemanager-test.md
@@ -1,0 +1,263 @@
+# StateManager テストテンプレート
+
+StateManagerはIntent→Action変換とEvent発行を担当する。
+TestScope + StandardTestDispatcher を使用し、コルーチン制御下でテストする。
+
+---
+
+## 基本構造
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class {ClassName}Test {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var testScope: TestScope
+
+    // === 依存関係 ===
+    private lateinit var reducer: {ReducerType}
+    private lateinit var {useCaseName}: {UseCaseType}
+
+    // === テスト対象 ===
+    private lateinit var stateManager: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        reducer = mockk(relaxed = true)
+        {useCaseName} = mockk()
+
+        stateManager = {ClassName}(
+            reducer = reducer,
+            {useCaseName} = {useCaseName},
+            scope = testScope
+        )
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+}
+```
+
+---
+
+## Intent→Action 変換テスト（processIntent の戻り値検証）
+
+```kotlin
+@Test
+fun `processIntent - Initialize を受け取った場合、LoadStart アクションを返すこと`() = testScope.runTest {
+    // Given
+    coEvery { {useCaseName}() } returns Result.success({expectedData})
+
+    // When
+    stateManager.processIntent({IntentType}.Initialize)
+    advanceUntilIdle()
+
+    // Then
+    coVerify { {useCaseName}() }
+}
+
+@Test
+fun `processIntent - Refresh を受け取った場合、データを再取得すること`() = testScope.runTest {
+    // Given
+    val expected = {ExpectedData}(...)
+    coEvery { {useCaseName}() } returns Result.success(expected)
+
+    // When
+    stateManager.processIntent({IntentType}.Refresh)
+    advanceUntilIdle()
+
+    // Then
+    coVerify(exactly = 1) { {useCaseName}() }
+}
+
+@Test
+fun `processIntent - UseCase失敗時、エラーアクションを発行すること`() = testScope.runTest {
+    // Given
+    val exception = Exception("Network error")
+    coEvery { {useCaseName}() } returns Result.failure(exception)
+
+    // When
+    stateManager.processIntent({IntentType}.Initialize)
+    advanceUntilIdle()
+
+    // Then
+    // reducer への LoadFailure アクション発行を検証
+    coVerify { reducer.reduce(any(), match { it is {ActionType}.LoadFailure }) }
+}
+```
+
+---
+
+## Event 発行テスト
+
+SharedFlow/Channel 経由のワンショットイベントを検証:
+
+```kotlin
+@Test
+fun `processIntent - アイテムクリック時、NavigateToDetail イベントを発行すること`() = testScope.runTest {
+    // Given
+    val events = mutableListOf<{EventType}>()
+    val job = launch { stateManager.events.collect { events.add(it) } }
+    advanceUntilIdle()
+
+    // When
+    stateManager.processIntent({IntentType}.OnItemClick(itemId = "123"))
+    advanceUntilIdle()
+
+    // Then
+    assertThat(events).contains({EventType}.NavigateToDetail("123"))
+    job.cancel()
+}
+
+@Test
+fun `processIntent - エラー時、ShowError イベントを発行すること`() = testScope.runTest {
+    // Given
+    val events = mutableListOf<{EventType}>()
+    val job = launch { stateManager.events.collect { events.add(it) } }
+    advanceUntilIdle()
+
+    coEvery { {useCaseName}() } returns Result.failure(Exception("error"))
+
+    // When
+    stateManager.processIntent({IntentType}.Initialize)
+    advanceUntilIdle()
+
+    // Then
+    assertThat(events.any { it is {EventType}.ShowError }).isTrue()
+    job.cancel()
+}
+```
+
+---
+
+## State 参照テスト
+
+StateManagerがReducer経由で正しくStateを更新することを検証:
+
+```kotlin
+@Test
+fun `state - 初期状態が正しいこと`() = testScope.runTest {
+    assertThat(stateManager.state.value).isEqualTo({StateType}())
+}
+
+@Test
+fun `state - Initialize後にデータが反映されること`() = testScope.runTest {
+    // Given
+    val items = listOf({ItemType}(id = "1"))
+    coEvery { {useCaseName}() } returns Result.success(items)
+
+    // Reducer の挙動を設定
+    coEvery { reducer.reduce(any(), any()) } answers {
+        val currentState = firstArg<{StateType}>()
+        currentState.copy(items = items, isLoading = false)
+    }
+
+    // When
+    stateManager.processIntent({IntentType}.Initialize)
+    advanceUntilIdle()
+
+    // Then
+    assertThat(stateManager.state.value.items).isEqualTo(items)
+}
+```
+
+---
+
+## 複数UseCase依存パターン
+
+```kotlin
+class {ClassName}Test {
+
+    // 複数のUseCase
+    private lateinit var getDataUseCase: GetDataUseCase
+    private lateinit var bookmarkUseCase: BookmarkUseCase
+    private lateinit var stateManager: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        reducer = mockk(relaxed = true)
+        getDataUseCase = mockk()
+        bookmarkUseCase = mockk()
+
+        stateManager = {ClassName}(
+            reducer = reducer,
+            getDataUseCase = getDataUseCase,
+            bookmarkUseCase = bookmarkUseCase,
+            scope = testScope
+        )
+    }
+
+    @Test
+    fun `processIntent - Bookmark時、bookmarkUseCaseを呼び出すこと`() = testScope.runTest {
+        // Given
+        coEvery { bookmarkUseCase(any()) } returns Result.success(Unit)
+
+        // When
+        stateManager.processIntent({IntentType}.ToggleBookmark(articleId = "123"))
+        advanceUntilIdle()
+
+        // Then
+        coVerify(exactly = 1) { bookmarkUseCase("123") }
+    }
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | 値 |
+|------|-----|
+| runTest | `testScope.runTest` |
+| アサーション | Truth (`assertThat`) |
+| Mock | MockK（reducer は `relaxed = true`） |
+| Dispatcher | `StandardTestDispatcher` + `TestScope` |
+| Event検証 | `mutableListOf` + `launch { collect }` + `advanceUntilIdle` |
+| 注意点 | reducer は relaxed mock にして StateManager のロジックに集中 |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.ui.mylist` |
+| `{ClassName}` | StateManagerクラス名 | `MyListStateManager` |
+| `{ReducerType}` | Reducer型 | `MyListReducer` |
+| `{useCaseName}` | UseCase変数名 | `getArticlesUseCase` |
+| `{UseCaseType}` | UseCase型 | `GetArticlesUseCase` |
+| `{IntentType}` | Intent sealed class | `MyListIntent` |
+| `{ActionType}` | Action sealed class | `MyListAction` |
+| `{EventType}` | Event sealed class | `MyListEvent` |
+| `{StateType}` | State data class | `MyListState` |
+| `{ItemType}` | リスト項目の型 | `ArticleItem` |
+| `{ExpectedData}` | 期待するデータ | `listOf(Article(...))` |

--- a/android_development/.claude/skills/android-test-generator/templates/usecase-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/usecase-test.md
@@ -1,0 +1,205 @@
+# UseCase テストテンプレート
+
+## 基本構造
+
+```kotlin
+package {test_package}
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+class {ClassName}Test {
+
+    // === 依存関係 ===
+    private lateinit var {repositoryName}: {RepositoryType}
+
+    // === テスト対象 ===
+    private lateinit var useCase: {ClassName}
+
+    @Before
+    fun setup() {
+        {repositoryName} = mockk()
+        useCase = {ClassNameImpl}({repositoryName})
+    }
+
+    // === テストケース ===
+
+    @Test
+    fun `invoke should return success when repository succeeds`() = runTest {
+        // Given
+        val expected = {expectedData}
+        coEvery { {repositoryName}.{method}() } returns Result.success(expected)
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertEquals(expected, result.getOrNull())
+        coVerify(exactly = 1) { {repositoryName}.{method}() }
+    }
+
+    @Test
+    fun `invoke should return failure when repository fails`() = runTest {
+        // Given
+        val exception = {ExceptionType}("{error message}")
+        coEvery { {repositoryName}.{method}() } returns Result.failure(exception)
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertTrue(result.isFailure)
+        assertEquals(exception, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `invoke should return empty list when no data exists`() = runTest {
+        // Given
+        coEvery { {repositoryName}.{method}() } returns Result.success(emptyList())
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()!!.isEmpty())
+    }
+}
+```
+
+---
+
+## 引数ありUseCaseのパターン
+
+```kotlin
+@Test
+fun `invoke should pass parameters to repository`() = runTest {
+    // Given
+    val param = {paramValue}
+    val expected = {expectedData}
+    coEvery { {repositoryName}.{method}(param) } returns Result.success(expected)
+
+    // When
+    val result = useCase(param)
+
+    // Then
+    assertTrue(result.isSuccess)
+    coVerify(exactly = 1) { {repositoryName}.{method}(param) }
+}
+
+@Test
+fun `invoke should handle any parameter with any()`() = runTest {
+    // Given
+    coEvery {
+        {repositoryName}.{method}(
+            param1 = any(),
+            param2 = any()
+        )
+    } returns Result.success({expectedData})
+
+    // When
+    val result = useCase({param1}, {param2})
+
+    // Then
+    assertTrue(result.isSuccess)
+}
+```
+
+---
+
+## Flow を返すUseCaseのパターン
+
+```kotlin
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+
+class {ClassName}Test {
+
+    @Test
+    fun `invoke should emit value from repository`() = runTest {
+        // Given
+        val expected = {expectedData}
+        coEvery { {repositoryName}.{method}() } returns flowOf(expected)
+
+        // When
+        val result = useCase().first()
+
+        // Then
+        assertEquals(expected, result)
+    }
+
+    @Test
+    fun `invoke should emit multiple values`() = runTest {
+        // Given
+        val values = listOf({value1}, {value2}, {value3})
+        coEvery { {repositoryName}.{method}() } returns flowOf(*values.toTypedArray())
+
+        // When
+        val results = mutableListOf<{Type}>()
+        val job = launch { useCase().collect { results.add(it) } }
+        advanceUntilIdle()
+
+        // Then
+        assertEquals(values.size, results.size)
+        job.cancel()
+    }
+}
+```
+
+---
+
+## 複数依存関係のパターン
+
+```kotlin
+class {ClassName}Test {
+
+    private lateinit var repository1: {Repository1Type}
+    private lateinit var repository2: {Repository2Type}
+    private lateinit var useCase: {ClassName}
+
+    @Before
+    fun setup() {
+        repository1 = mockk()
+        repository2 = mockk()
+        useCase = {ClassNameImpl}(repository1, repository2)
+    }
+
+    @Test
+    fun `invoke should coordinate multiple repositories`() = runTest {
+        // Given
+        coEvery { repository1.{method1}() } returns Result.success({data1})
+        coEvery { repository2.{method2}(any()) } returns Result.success({data2})
+
+        // When
+        val result = useCase()
+
+        // Then
+        assertTrue(result.isSuccess)
+        coVerify(ordering = Ordering.ORDERED) {
+            repository1.{method1}()
+            repository2.{method2}(any())
+        }
+    }
+}
+```
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `com.example.app.domain.usecase` |
+| `{ClassName}` | テスト対象クラス名 | `GetFavoriteArticlesUseCase` |
+| `{ClassNameImpl}` | 実装クラス名 | `GetFavoriteArticlesUseCaseImpl` |
+| `{repositoryName}` | 依存リポジトリ変数名 | `myListRepository` |
+| `{RepositoryType}` | リポジトリ型 | `MyListRepository` |
+| `{method}` | 呼び出すメソッド名 | `getFavoriteArticles` |
+| `{expectedData}` | 期待するデータ | `listOf(FavoriteArticle(...))` |
+| `{ExceptionType}` | 例外の型 | `IOException` |

--- a/android_development/.claude/skills/android-test-generator/templates/viewmodel-test.md
+++ b/android_development/.claude/skills/android-test-generator/templates/viewmodel-test.md
@@ -1,0 +1,348 @@
+# ViewModel テストテンプレート
+
+MVI版（薄いラッパー）とAAC版（フル実装）の2パターンに対応。
+
+> **注意**: StateManagerのテストは `statemanager-test.md` を参照してください。
+
+---
+
+## MVI版 ViewModel（薄いラッパーパターン）
+
+MVI版ViewModelはStateManagerへの委譲のみを行う薄いラッパー。
+StateManager をモックして委譲の正しさを検証する。
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import com.google.common.truth.Truth.assertThat
+import io.mockk.Ordering
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestScope
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class {ClassName}Test {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private lateinit var testScope: TestScope
+
+    // === 依存関係 ===
+    private lateinit var stateManager: {StateManagerType}
+
+    // === テスト対象 ===
+    private lateinit var viewModel: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        testScope = TestScope(testDispatcher)
+
+        stateManager = mockk(relaxed = true)
+
+        viewModel = {ClassName}(stateManager)
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    // === State委譲テスト ===
+
+    @Test
+    fun `state - StateManagerのstateが公開されていること`() = testScope.runTest {
+        // Given
+        val expectedState = {StateType}(isLoading = false, items = emptyList())
+        every { stateManager.state } returns MutableStateFlow(expectedState)
+
+        // When
+        val result = viewModel.state.value
+
+        // Then
+        assertThat(result).isEqualTo(expectedState)
+    }
+
+    // === Intent委譲テスト ===
+
+    @Test
+    fun `processIntent - StateManagerにIntentが委譲されること`() = testScope.runTest {
+        // When
+        viewModel.processIntent({IntentType}.Initialize)
+        advanceUntilIdle()
+
+        // Then
+        coVerify(exactly = 1) { stateManager.processIntent({IntentType}.Initialize) }
+    }
+
+    @Test
+    fun `processIntent - 複数のIntentが順序通りに委譲されること`() = testScope.runTest {
+        // When
+        viewModel.processIntent({IntentType}.Initialize)
+        viewModel.processIntent({IntentType}.Refresh)
+        advanceUntilIdle()
+
+        // Then
+        coVerify(ordering = Ordering.ORDERED) {
+            stateManager.processIntent({IntentType}.Initialize)
+            stateManager.processIntent({IntentType}.Refresh)
+        }
+    }
+
+    // === Event委譲テスト ===
+
+    @Test
+    fun `events - StateManagerのeventsが公開されていること`() = testScope.runTest {
+        // Given
+        val eventsFlow = MutableSharedFlow<{EventType}>()
+        every { stateManager.events } returns eventsFlow
+
+        val collected = mutableListOf<{EventType}>()
+        val job = launch { viewModel.events.collect { collected.add(it) } }
+        advanceUntilIdle()
+
+        // When
+        eventsFlow.emit({EventType}.NavigateToDetail("123"))
+        advanceUntilIdle()
+
+        // Then
+        assertThat(collected).contains({EventType}.NavigateToDetail("123"))
+        job.cancel()
+    }
+}
+```
+
+---
+
+## AAC版 ViewModel（フル実装パターン）
+
+UseCase を直接呼び出す従来のAAC ViewModelパターン。
+
+```kotlin
+@file:Suppress("NonAsciiCharacters", "TestFunctionName")
+
+package {test_package}
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class {ClassName}Test {
+
+    @get:Rule
+    val instantTaskExecutorRule = InstantTaskExecutorRule()
+
+    private val testDispatcher = StandardTestDispatcher()
+
+    // === 依存関係 ===
+    private lateinit var {useCaseName}: {UseCaseType}
+
+    // === テスト対象 ===
+    private lateinit var viewModel: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        {useCaseName} = mockk()
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): {ClassName} {
+        return {ClassName}({useCaseName})
+    }
+
+    // === データロードテスト ===
+
+    @Test
+    fun `uiState - データロード成功時、Success状態になること`() = runTest {
+        // Given
+        val expected = {ExpectedData}(...)
+        coEvery { {useCaseName}() } returns Result.success(expected)
+
+        // When
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Then
+        val state = viewModel.uiState.value
+        assertTrue(state is {ClassName}UiState.Success)
+        assertEquals(expected, (state as {ClassName}UiState.Success).data)
+    }
+
+    @Test
+    fun `uiState - データロード失敗時、Error状態になること`() = runTest {
+        // Given
+        coEvery { {useCaseName}() } returns Result.failure(Exception("error"))
+
+        // When
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        // Then
+        assertThat(viewModel.uiState.value).isInstanceOf(
+            {ClassName}UiState.Error::class.java
+        )
+    }
+}
+```
+
+---
+
+## ユーザーアクションの検証（AAC版）
+
+```kotlin
+@Test
+fun `onRefresh - データを再取得すること`() = runTest {
+    // Given
+    val initialData = {Data}(id = "1")
+    val refreshedData = {Data}(id = "2")
+    coEvery { {useCaseName}() } returnsMany listOf(
+        Result.success(initialData),
+        Result.success(refreshedData)
+    )
+
+    viewModel = createViewModel()
+    advanceUntilIdle()
+
+    // When
+    viewModel.onRefresh()
+    advanceUntilIdle()
+
+    // Then
+    val state = viewModel.uiState.value as {ClassName}UiState.Success
+    assertThat(state.data).isEqualTo(refreshedData)
+    coVerify(exactly = 2) { {useCaseName}() }
+}
+
+@Test
+fun `onRetry - エラー後にデータを再取得すること`() = runTest {
+    // Given
+    coEvery { {useCaseName}() } returnsMany listOf(
+        Result.failure(Exception()),
+        Result.success({data})
+    )
+
+    viewModel = createViewModel()
+    advanceUntilIdle()
+
+    // エラー状態を確認
+    assertThat(viewModel.uiState.value).isInstanceOf(
+        {ClassName}UiState.Error::class.java
+    )
+
+    // When
+    viewModel.onRetry()
+    advanceUntilIdle()
+
+    // Then
+    assertThat(viewModel.uiState.value).isInstanceOf(
+        {ClassName}UiState.Success::class.java
+    )
+}
+```
+
+---
+
+## 複数UseCase依存のパターン（AAC版）
+
+```kotlin
+class {ClassName}Test {
+
+    private lateinit var getDataUseCase: GetDataUseCase
+    private lateinit var saveDataUseCase: SaveDataUseCase
+    private lateinit var viewModel: {ClassName}
+
+    @Before
+    fun setUp() {
+        Dispatchers.setMain(testDispatcher)
+        getDataUseCase = mockk()
+        saveDataUseCase = mockk()
+    }
+
+    private fun createViewModel(): {ClassName} {
+        return {ClassName}(getDataUseCase, saveDataUseCase)
+    }
+
+    @Test
+    fun `onSave - saveDataUseCaseを呼び出すこと`() = runTest {
+        // Given
+        coEvery { getDataUseCase() } returns Result.success({data})
+        viewModel = createViewModel()
+        advanceUntilIdle()
+
+        val dataToSave = {Data}(...)
+        coEvery { saveDataUseCase(dataToSave) } returns Result.success(Unit)
+
+        // When
+        viewModel.onSave(dataToSave)
+        advanceUntilIdle()
+
+        // Then
+        coVerify(exactly = 1) { saveDataUseCase(dataToSave) }
+    }
+}
+```
+
+---
+
+## 設計ポイント
+
+| 項目 | MVI版（薄いラッパー） | AAC版（フル実装） |
+|------|---------------------|-------------------|
+| runTest | `testScope.runTest` | `runTest` |
+| アサーション | Truth | Truth + JUnit Assert |
+| Mock | StateManager を `relaxed = true` | UseCase を `mockk()` |
+| Dispatcher | `TestScope` + `setMain/resetMain` | `setMain/resetMain` |
+| テスト焦点 | 委譲の正しさ | ビジネスロジック・状態遷移 |
+
+---
+
+## 置換プレースホルダー
+
+| プレースホルダー | 説明 | 例 |
+|----------------|------|-----|
+| `{test_package}` | テストパッケージ名 | `jp.co.nttdocomo.dmenunews.ui.mylist` |
+| `{ClassName}` | ViewModelクラス名 | `MyListViewModel` |
+| `{StateManagerType}` | StateManager型 | `MyListStateManager` |
+| `{StateType}` | State型 | `MyListState` |
+| `{IntentType}` | Intent sealed class | `MyListIntent` |
+| `{EventType}` | Event sealed class | `MyListEvent` |
+| `{useCaseName}` | UseCase変数名 | `getArticlesUseCase` |
+| `{UseCaseType}` | UseCase型 | `GetArticlesUseCase` |
+| `{ClassName}UiState` | UI状態クラス | `MyListUiState` |
+| `{ExpectedData}` | 期待するデータ | `listOf(Article(...))` |


### PR DESCRIPTION
## Summary
- android-test-generatorスキルをv1.0として完成
- MVI 4層テンプレート追加（Reducer, StateManager, Presenter, ViewModel薄いラッパー）
- Data層テンプレート追加（ApiService MockWebServer, Mapper依存あり/なし）
- Handlerテンプレート追加（アナリティクス/横断的関心事）
- モジュール別設定対応（Domain/Data/UI層ごとのアサーション・コルーチン・Mockポリシー）
- クラス種別自動判定ロジック（10パターン）
- Dmenunews実プロジェクト検証で判明した知見を反映（値クラス制約、Android Framework制約、ネスト型参照）

## 変更ファイル（12ファイル）

| 操作 | ファイル | 内容 |
|------|---------|------|
| 新規 | `templates/reducer-test.md` | 純粋関数テスト、冪等性・部分更新 |
| 新規 | `templates/statemanager-test.md` | Intent→Action変換、Event発行 |
| 新規 | `templates/presenter-test.md` | 複数UseCase、アナリティクス検証 |
| 新規 | `templates/api-service-test.md` | MockWebServer + JSON fixture |
| 新規 | `templates/mapper-test.md` | Entity→DomainModel、依存ありMapper |
| 新規 | `templates/handler-test.md` | @RelaxedMockK、引数マッチャー |
| 更新 | `templates/viewmodel-test.md` | MVI薄いラッパーパターン追加 |
| 更新 | `templates/usecase-test.md` | 既存（変更なし） |
| 更新 | `templates/repository-test.md` | 既存（変更なし） |
| 更新 | `knowledge/project-config.md` | モジュール別設定拡張 |
| 更新 | `SKILL.md` | 自動判定ロジック、実践知見 |
| 更新 | `README.md` | v1.0、対応10種 |

## Test plan
- [x] Dmenunews domain層（GetPickupKeywordsUseCase）でテスト生成・実行 → 5テスト全パス
- [x] Dmenunews data層（GetArticleResponseToArticleMapper）でテスト生成・実行 → 6テスト全パス
- [x] Dmenunews UI層 ViewModel（SearchNewsViewModel）でテスト生成・実行 → 9テスト全パス
- [x] Dmenunews UI層 Handler（TimelineItemClickHandler）でテスト生成・実行 → 5テスト全パス

Relates to #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)