### PR TITLE
feat: add android-development plugin marketplace configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Claude Code用の開発支援ツールとプラグインのコレクションで
 - **[frontend-nextjs-development](./frontend_nextjs_development/README.md)** - Next.js開発向けのツール群（Figmaデザイン抽出、コンポーネント生成など）
 - **[backend-development](./backend_development/README.md)** - Ruby on Rails/PostgreSQLバックエンド開発向けのツール群（JSON仕様からAPI・管理画面の実装までをサポート）
 - **[flutter-development](./flutter_development/README.md)** - Flutter開発向けのツール群（Widget実装アシスタントなど）
+- **[android-development](./android_development/README.md)** - Android/Jetpack Compose開発向けのツール群（アーキテクチャ設計、テスト自動生成、Figma変換など）
 
 ## プラグインのインストール方法
 
@@ -46,6 +47,7 @@ Claude Codeのマーケットプレイス機能を使用して、プラグイン
 /plugin install frontend-nextjs-development@xtone-ai-development-tools
 /plugin install backend-development@xtone-ai-development-tools
 /plugin install flutter-development@xtone-ai-development-tools
+/plugin install android-development@xtone-ai-development-tools
 ```
 
 プラグインをインストールすると、以下が自動的に行われます:

--- a/android_development/.claude-plugin/marketplace.json
+++ b/android_development/.claude-plugin/marketplace.json
@@ -1,0 +1,81 @@
+{
+    "name": "android-development",
+    "description": "Android/Jetpack Compose開発向けのツール群。アーキテクチャ設計、UI実装、テスト自動生成、Figmaからのコード変換までをサポート",
+    "version": "0.1.0",
+    "owner": {
+        "name": "ISHIHARA, Masaya",
+        "email": "m.ishihara@xtone.co.jp"
+    },
+    "skills": [
+        {
+            "name": "android-architecture",
+            "source": "./.claude/skills/android-architecture",
+            "description": "Androidプロジェクトのアーキテクチャ設計を支援。MVI/MVVM/シンプルComposeから最適なパターンを提案し、パッケージ構造の設計を行う",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "architecture", "mvi", "mvvm", "jetpack-compose"]
+        },
+        {
+            "name": "android-api-client",
+            "source": "./.claude/skills/android-api-client",
+            "description": "Retrofit + OkHttpを使用したAPIクライアント実装のベストプラクティスを提供",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "retrofit", "okhttp", "api", "networking"]
+        },
+        {
+            "name": "android-ui-guidelines",
+            "source": "./.claude/skills/android-ui-guidelines",
+            "description": "Jetpack ComposeによるUI実装のコーディングガイドライン",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "jetpack-compose", "ui", "coding-guidelines"]
+        },
+        {
+            "name": "android-data-layer",
+            "source": "./.claude/skills/android-data-layer",
+            "description": "Room Database、DataStore、Repositoryパターンの実装ガイド",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "room", "datastore", "repository", "data-layer"]
+        },
+        {
+            "name": "android-test-runner",
+            "source": "./.claude/skills/android-test-runner",
+            "description": "Androidテストの実行と失敗分析を自動化。Multi-variantプロジェクト対応",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "testing", "junit", "gradle", "automation"]
+        },
+        {
+            "name": "android-test-generator",
+            "source": "./.claude/skills/android-test-generator",
+            "description": "実装コードからテストコードを自動生成。MVIアーキテクチャの各レイヤーに対応",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "testing", "code-generation", "mvi"]
+        },
+        {
+            "name": "figma-to-compose",
+            "source": "./.claude/skills/figma-to-compose",
+            "description": "FigmaデザインからJetpack Composeコードを高精度で生成。Figma APIから正確な値を取得し95%以上の準拠率を実現",
+            "version": "1.0.0",
+            "author": {
+                "name": "ISHIHARA, Masaya"
+            },
+            "tags": ["android", "figma", "jetpack-compose", "design-to-code"]
+        }
+    ]
+}

--- a/android_development/.claude-plugin/plugin.json
+++ b/android_development/.claude-plugin/plugin.json
@@ -1,0 +1,3 @@
+{
+  "name": "android-development"
+}

--- a/android_development/README.md
+++ b/android_development/README.md
@@ -1,0 +1,49 @@
+# Android Development Skills
+
+Android/Jetpack Compose開発用のClaude Codeスキル集。
+
+## インストール
+
+```bash
+# マーケットプレイスを追加
+/plugin marketplace add xtone/ai_development_tools
+
+# プラグインをインストール
+/plugin install android-development@xtone-ai-development-tools
+```
+
+## スキル一覧
+
+| スキル | 説明 |
+|--------|------|
+| **android-architecture** | MVI/MVVM/シンプルComposeから最適なアーキテクチャを提案 |
+| **android-api-client** | Retrofit + OkHttpによるAPIクライアント実装ガイド |
+| **android-ui-guidelines** | Jetpack ComposeのUI実装コーディングガイドライン |
+| **android-data-layer** | Room/DataStore/Repositoryパターンの実装ガイド |
+| **android-test-runner** | テスト実行と失敗分析の自動化 |
+| **android-test-generator** | 実装コードからテストコードを自動生成 |
+| **figma-to-compose** | FigmaデザインからJetpack Composeコードを生成 |
+
+## ディレクトリ構造
+
+```
+android_development/
+├── .claude-plugin/
+│   ├── marketplace.json    # マーケットプレイス設定
+│   └── plugin.json         # プラグイン基本情報
+├── .claude/
+│   └── skills/
+│       ├── android-architecture/
+│       ├── android-api-client/
+│       ├── android-ui-guidelines/
+│       ├── android-data-layer/
+│       ├── android-test-runner/
+│       ├── android-test-generator/
+│       └── figma-to-compose/
+└── README.md
+```
+
+## 関連リンク
+
+- [Claude Code Plugins - 公式ドキュメント](https://docs.claude.com/en/docs/claude-code/plugins)
+- [ai_development_tools リポジトリ](https://github.com/xtone/ai_development_tools)


### PR DESCRIPTION
## Summary
- Android開発向けプラグインをClaude Code Marketplaceに対応
- ルートREADMEに android-development を追加

## 追加ファイル
- `android_development/.claude-plugin/marketplace.json`
- `android_development/.claude-plugin/plugin.json`
- `android_development/README.md`

## 含まれるスキル（7個）
| スキル | 説明 |
|--------|------|
| android-architecture | MVI/MVVM/シンプルComposeから最適なアーキテクチャを提案 |
| android-api-client | Retrofit + OkHttpによるAPIクライアント実装ガイド |
| android-ui-guidelines | Jetpack ComposeのUI実装コーディングガイドライン |
| android-data-layer | Room/DataStore/Repositoryパターンの実装ガイド |
| android-test-runner | テスト実行と失敗分析の自動化 |
| android-test-generator | 実装コードからテストコードを自動生成 |
| figma-to-compose | FigmaデザインからJetpack Composeコードを生成 |

## インストール方法
```bash
/plugin marketplace add xtone/ai_development_tools
/plugin install android-development@xtone-ai-development-tools
```

## Test plan
- [ ] マーケットプレイスからインストールできること
- [ ] 各スキルが正しく読み込まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)