### PR TITLE
fix: video-keyframe-analyzer がセッション再起動で認識されない問題を修正

### DIFF
--- a/common_development/skills/video-keyframe-analyzer/SKILL.md
+++ b/common_development/skills/video-keyframe-analyzer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: video-keyframe-analyzer
-description: Extract keyframes from videos for cost-efficient analysis. Reduces Claude API costs by 93% (from ~$4.50 to ~$0.24 for 5-sec video) by extracting only significant frames with frame difference detection and quality optimization.
+description: "動画からキーフレームを抽出してコスト効率的に分析するスキル。フレーム差分検出と画質最適化により、Claude APIコストを約93%削減する。`/video-keyframe-analyzer <動画パス>` で使用。"
 ---
 
 # Video Keyframe Analyzer


### PR DESCRIPTION
## Summary

- video-keyframe-analyzer の SKILL.md フロントマター `description` がクォートなしで `$4.50`、`$0.24`、`%`、括弧等の YAML 特殊文字を含んでおり、パース失敗でスキルが認識されない問題を修正
- 他のスキル（lessons, review-learn）と同様にダブルクォートで囲み、日本語に統一

### Before
```yaml
description: Extract keyframes...93% (from ~$4.50 to ~$0.24 for 5-sec video)...
```

### After
```yaml
description: "動画からキーフレームを抽出してコスト効率的に分析するスキル。..."
```

## Test plan

- [ ] toryu-web でセッション再起動後に `/video-keyframe-analyzer` が認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)