### PR TITLE
fix(ci): claude-code-actionを動作実績のあるSHAにpin

### DIFF
--- a/.github/workflows/pr-review-vertex-ai.yml
+++ b/.github/workflows/pr-review-vertex-ai.yml
@@ -56,7 +56,13 @@ jobs:
         run: npx -y skills add xtone/ai_development_tools --skill pr-triage --agent claude-code --yes
 
       - name: Run Triage with Haiku
-        uses: anthropics/claude-code-action@v1
+        # サードパーティ action は commit SHA による immutable 参照で利用する
+        # （GitHub 公式の Security hardening ガイドラインで推奨）:
+        # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
+        # pin 先 cd77b50d は PR #115 (2026-03-16) 時点でグリーンだった動作確認済み
+        # リビジョン。更新は互換性確認後に手動で bump する。@v1 等のタグ参照には
+        # 戻さない（過去の tag drift 事例: PR #117）。
+        uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
           CLOUD_ML_REGION: global
@@ -139,7 +145,8 @@ jobs:
           npx -y skills add vercel-labs/agent-skills --skill vercel-react-best-practices --agent claude-code --yes
 
       - name: Run Claude Code PR Review via Vertex AI
-        uses: anthropics/claude-code-action@v1
+        # 上記 triage ジョブと同一 SHA を pin（詳細は上のコメント参照）
+        uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1
         env:
           ANTHROPIC_VERTEX_PROJECT_ID: ${{ steps.auth.outputs.project_id }}
           CLOUD_ML_REGION: global


### PR DESCRIPTION
## Summary

- `anthropics/claude-code-action` を commit SHA に pin する
- SHA pinning は GitHub 公式の [Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) でサードパーティ action に対する推奨実装
- 直近の `@v1` タグ更新で発生した triage CI 破損（[詳細](#背景)）への直接対処も兼ねる

## 背景

`anthropics/claude-code-action@v1` の `v1` タグが追従する SHA が更新され、PR ヘッドの `.claude/` ディレクトリを origin/main から復元する挙動が入った結果、`npx -y skills add ... --skill pr-triage` で直前にインストールされた `.claude/skills/pr-triage` が上書き削除され、Haiku 実行時に `/pr-triage` スキルが呼び出せず triage ジョブが失敗する事象が発生した（PR #116 の triage run で顕在化）。

これは **「タグ参照を用いているため、上流がタグの指す先を動かせば挙動が変わる」** という、SHA pinning で防げる典型的な tag drift 問題。

## 方針（恒久対応）

GitHub 公式が推奨するとおり、サードパーティ action は **commit SHA による immutable 参照** を用いる。

> Pinning an action to a full length commit SHA is currently the only way to use an action as an immutable release.
> — [GitHub Docs: Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)

pin 先 SHA `cd77b50d2b0808657f8e6774085c8bf54484351c` は、PR #115 (2026-03-16) 時点でグリーンだったバージョン。tag drift 発生以前の、動作確認済みのリビジョン。

## 運用

- SHA の更新は手動で実施する（`@v1` 等のタグ参照には戻さない）
- Dependabot / Renovate で action update 通知を受け取る場合は、更新ごとに動作検証してから pin 先を bump
- pin 先 bump 時は、本 PR で発生した種類の互換性問題（skill install の消失等）がないか verify

## 変更

`.github/workflows/pr-review-vertex-ai.yml` の `triage` ジョブと `review` ジョブの 2 箇所：

```diff
- uses: anthropics/claude-code-action@v1
+ uses: anthropics/claude-code-action@cd77b50d2b0808657f8e6774085c8bf54484351c # v1
```

## Test plan

### 事前検証済み（merge 前）

- [x] workflow YAML が構文的に有効（`python3 -c "import yaml; yaml.safe_load(...)"` で確認済）
- [x] 両ジョブ（triage / review）の action 参照が指定 SHA に pin されていること（`grep` で 2 箇所確認済）
- [x] pin 先 SHA `cd77b50d…` が PR #115 成功時の SHA と一致すること
- [x] GitHub 公式が SHA pinning を推奨していること（[Security hardening for GitHub Actions](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions)）

> 注: この PR 自体の CI は workflow の `paths-ignore: '.github/workflows/**'` により発火しないため、pin の効果は本 PR では検証できない（merge 後検証で確認）。

### Merge 後に検証

- [ ] PR #116 (terraform-architecture-diagram skill) の CI を `gh run rerun <run-id> --failed` で再実行し、triage ジョブが success になること
- [ ] 今後新規に作られる PR で triage ジョブが動作すること（`.pr-triage.json` / `.pr-review-state.json` が生成されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)