### PR TITLE
chore: bump development-workflows to 0.4.0 (figma-spec-extractor 0.2.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -63,7 +63,7 @@
             "name": "development-workflows",
             "source": "./development_workflows",
             "description": "開発ワークフロー向けスキル群（コードレビュー、PRトリアージ、Figma仕様抽出など）",
-            "version": "0.3.0",
+            "version": "0.4.0",
             "author": {
                 "name": "TOYOTA, Yoichi"
             }

--- a/development_workflows/.claude-plugin/marketplace.json
+++ b/development_workflows/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
     "name": "development-workflows",
     "description": "開発ワークフロー向けスキル群（コードレビュー、PRトリアージ、Figma仕様抽出など）",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "owner": {
         "name": "TOYOTA, Yoichi",
         "email": "y.toyota@xtone.co.jp"
@@ -20,12 +20,12 @@
         {
             "name": "figma-spec-extractor",
             "source": "./skills/figma-spec-extractor",
-            "description": "Figmaのワイヤーフレームから仕様書一式（ページ・ユースケース・アクター・データモデル・コンポーネント・レビュー）を13ステップで段階的に抽出し、docs/配下にMarkdownで出力します。Figma MCPと連携し、ページ単位の並列サブエージェント実行で品質と効率を両立します。",
-            "version": "0.1.0",
+            "description": "Figmaのワイヤーフレームから仕様書一式（ページ・ユースケース・アクター・データモデル・コンポーネント・レビュー）を15ステップで段階的に抽出し、docs/配下にMarkdownで出力します。extensionモードでは既存リポジトリへの機能拡張時に既存モデル・ルーティング・ビューの再利用を優先し、Step 14のレビュー反復反映では質問ループで方針を確定しドキュメントに反映します。Figma MCPと連携し、ページ単位の並列サブエージェント実行で品質と効率を両立します。",
+            "version": "0.2.0",
             "author": {
                 "name": "TOYOTA, Yoichi"
             },
-            "tags": ["figma", "spec-extraction", "documentation", "wireframe", "use-case", "data-model", "atomic-design"]
+            "tags": ["figma", "spec-extraction", "documentation", "wireframe", "use-case", "data-model", "atomic-design", "extension-mode", "review-iteration"]
         }
     ]
 }


### PR DESCRIPTION
## Summary

PR #119（extension モード + Step 14 レビュー反復反映）のマージに伴い、Claude marketplace でプラグインの更新を検知できるようバージョンを更新します。

## バージョン更新

| 対象 | 旧 | 新 |
|---|---|---|
| プラグイン `development-workflows` | 0.3.0 | **0.4.0** |
| スキル `figma-spec-extractor` | 0.1.0 | **0.2.0** |

minor bump の根拠: `figma-spec-extractor` に extension モード（既存リポジトリ統合）と Step 14 レビュー反復反映の 2 機能を追加（後方互換あり）。

## description 更新

`figma-spec-extractor` の description が 13 ステップ表記のままだったため、新機能を含む 15 ステップ構成に合わせて更新：

- 「13ステップ」→「15ステップ」
- extensionモードと Step 14 レビュー反復反映の言及を追加
- tags に `extension-mode`, `review-iteration` を追加

ルートの `.claude-plugin/marketplace.json` と `development_workflows/.claude-plugin/marketplace.json` の両方を更新しています。

## Test plan

- [ ] 両 `marketplace.json` が有効な JSON として parse できる
- [ ] `development-workflows` のバージョンが両ファイルで一致している
- [ ] Claude marketplace 上でプラグインを更新 → 0.4.0 が取得できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)