### PR TITLE
feat(B-01 / #126): I/O契約スキーマの本実装（T-011〜013）

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/agents/authentication-architect.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/agents/authentication-architect.md
@@ -14,7 +14,7 @@ model: opus
 
 ## 入出力
 
-- 入力: `schemas/requirements.schema.json` 準拠の要件（特に `use_cases` / `non_functional_requirements` の認証関連）
+- 入力: `schemas/requirements.schema.json` 準拠の要件（特に `representative_use_cases` / `functional_requirements` / `non_functional_requirements` の認証関連）
 - 出力: `schemas/design.schema.json` 準拠の設計、必要に応じ `docs/adr/ADR-NNN.md`
 
 ## 検討する判断ポイント（必ず複数スタックを比較する）

--- a/ai-delivery/plugins/xtone-auth-plugin/agents/requirements-analyst.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/agents/requirements-analyst.md
@@ -14,7 +14,7 @@ model: opus
 ## 入出力
 
 - 入力: クライアント要件の説明テキスト
-- 出力: requirements.schema.json（T-011 の7フィールド: project_name / overview / actors / use_cases / functional_requirements / non_functional_requirements / undecided）
+- 出力: requirements.schema.json（T-011 本実装。必須: scope / representative_use_cases / functional_requirements / non_functional_requirements / domain_tags / stakeholders / client_approval ＋ warn_and_document 用の undecided）
 
 ## 手順
 

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
@@ -1,38 +1,43 @@
 # 架空案件「みんなの読書会」の設計成果物（design.yaml サンプル）
 # firebase-auth-design スキル / authentication-architect の出力例。
-# schemas/design.schema.json 準拠（YAML 表現。CI では JSON に変換して検証可能）。
+# schemas/design.schema.json（T-011 本実装, #126）準拠。YAML 表現（同内容を JSON 化すれば jsonschema で検証可能）。
 
-tech_stack:
-  - "Firebase Auth"          # DP-007 採用（MVP 推奨）
-  - "Rails (API / JWT 認可)"
-  - "React (Web SPA)"
-  - "iOS / Android (ネイティブ)"
+architecture:
+  stack: "Rails 8 (API) + React (Web SPA) + iOS/Android"
+  cloud: "Firebase（認証）+ アプリサーバ（任意）"
+  db_type: "PostgreSQL（本番）/ SQLite（パイロット）"
+  rationale: >
+    認証は AuthAdapter インターフェース越しに呼び、Firebase 固有処理は FirebaseAuthAdapter
+    に閉じ込める(DP-007 差し替え可能設計)。バックエンド(Rails)は API ミドルウェアで
+    Firebase 発行の ID トークン(JWT)を検証してユーザーを解決。Web/アプリは ID トークンと
+    リフレッシュトークンを保持し API リクエストに Bearer 付与。セッションは ID トークン
+    TTL=1h、リフレッシュで更新、退会時は Firebase ユーザー削除 + サーバ側論理削除。
 
-architecture: |
-  認証は AuthAdapter インターフェース越しに呼び、Firebase 固有処理は FirebaseAuthAdapter
-  に閉じ込める(DP-007 差し替え可能設計)。バックエンド(Rails)は API ミドルウェアで
-  Firebase 発行の ID トークン(JWT)を検証してユーザーを解決。Web/アプリは ID トークンと
-  リフレッシュトークンを保持し、API リクエストに Bearer 付与。セッションは ID トークン
-  TTL=1h、リフレッシュで更新、退会時は Firebase ユーザー削除 + サーバ側論理削除。
+db_schema:
+  er_diagram_url: "https://www.figma.com/(架空)/minna-bookclub-er"
+  normalization_level: "3NF"
+  tables:
+    - { name: "users", columns: ["uid", "email", "providers", "mfa_enabled", "deleted_at"] }
 
-modules:
-  - id: "MOD-001"
-    name: "認証"
-    adapter: "AuthAdapter (FirebaseAuthAdapter を実装)"
+api_spec:
+  openapi_path: "docs/openapi.yaml"
+  style: "REST"
 
-data_model:
-  users:
-    - { field: "uid", note: "Firebase UID(主キー)" }
-    - { field: "email", note: "メールアドレス" }
-    - { field: "providers", note: "連携済み認証方式(password/google.com/apple.com)" }
-    - { field: "mfa_enabled", note: "MFA 有効フラグ(オプトイン)" }
-    - { field: "deleted_at", note: "退会(論理削除)" }
+authentication:
+  stack: "Firebase Auth"          # DP-007 採用（MVP 推奨、AuthAdapter で差し替え可能）
+  mfa_requirement: "optional"     # DP-008（運営管理者は必須、一般はオプトイン）
 
-api_design:
-  - { method: "POST", path: "/auth/session", note: "ID トークン検証→セッション確立" }
-  - { method: "DELETE", path: "/auth/session", note: "ログアウト" }
-  - { method: "POST", path: "/auth/link", note: "認証方式の追加(アカウント連携)" }
-  - { method: "DELETE", path: "/account", note: "退会" }
+adr_list:
+  - { id: "ADR-001", title: "認証スタックに Firebase Auth を採用", status: "accepted", path: "delivery/adr/ADR-001-auth-stack.md" }
+
+design_review_completed:
+  approved: true
+  approved_by: "豊田"
+  approved_at: "2026-05-25T10:00:00+09:00"
+
+domain_specific_checks:
+  dAccount: false       # DP-015 非該当（docomo 連携なし）
+  pci_dss: false        # DP-016 非該当（決済なし）
 
 decision_record:
   - dp_id: "DP-007"
@@ -44,7 +49,7 @@ decision_record:
       チームに Firebase 経験があり、メール/パスワードレス/OIDC を標準機能で満たせる。
       代替の Devise+OmniAuth はパスワードレスや Apple ログインで追加実装が増える。
       ベンダーロックイン懸念は AuthAdapter 層で差し替え可能にして緩和。
-    adr_ref: "docs/adr/ADR-001-auth-stack.md"
+    adr_ref: "delivery/adr/ADR-001-auth-stack.md"
   - dp_id: "DP-008"
     chosen: "オプトイン(運営管理者は必須)"
     decided_by: "豊田"
@@ -57,8 +62,5 @@ decision_record:
     decided_by: "豊田"
     decided_at: "2026-05-25T10:00:00+09:00"
     rationale: "docomo / dメニュー連携の予定がないため適用外。"
-
-adr_refs:
-  - "docs/adr/ADR-001-auth-stack.md"
 
 undecided: []

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/implementation-plan.json
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/implementation-plan.json
@@ -1,5 +1,19 @@
 {
-  "$comment": "架空案件「みんなの読書会」の実装計画成果物。firebase-auth-setup スキル / implementer の出力例。schemas/implementation-plan.schema.json 準拠。",
+  "$comment": "架空案件「みんなの読書会」の実装計画成果物。firebase-auth-setup スキル / implementer の出力例。schemas/implementation-plan.schema.json（T-011 本実装, #126）準拠。",
+  "modules": [
+    { "module_ref": "MOD-001", "priority": 1 }
+  ],
+  "tdd_strategy": "TestAfter",
+  "test_coverage_target": 70,
+  "ci_cd_config": {
+    "type": "GitHub Actions",
+    "hooks": ["lint", "test", "build"]
+  },
+  "pr_strategy": {
+    "pr_max_size_lines": 400,
+    "branch_naming": "feat/<scope>",
+    "merge_strategy": "squash"
+  },
   "tasks": [
     { "id": "T-A01", "title": "AuthAdapter インターフェース定義(差し替え可能設計の核, DP-007)", "module": "MOD-001" },
     { "id": "T-A02", "title": "FirebaseAuthAdapter 実装(ID トークン検証/サインイン/ユーザ取得)" },

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/requirements.json
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/requirements.json
@@ -1,31 +1,50 @@
 {
-  "$comment": "架空案件「みんなの読書会」の要件定義成果物。auth-requirements-extraction スキルの出力例。schemas/requirements.schema.json 準拠。",
+  "$comment": "架空案件「みんなの読書会」の要件定義成果物。auth-requirements-extraction スキルの出力例。schemas/requirements.schema.json（T-011 本実装, #126）準拠。",
   "project_name": "みんなの読書会",
   "overview": "本好きが読書記録を共有しオンライン読書会を開く BtoC コミュニティアプリ。Web(SPA) とスマホアプリ(iOS/Android) を提供する。認証モジュール(MOD-001) の要件を抽出した。",
-  "actors": ["一般ユーザー", "ホストユーザー", "運営管理者"],
-  "use_cases": [
-    { "id": "UC-A01", "name": "メール+パスワードで登録・ログイン", "module": "MOD-001" },
-    { "id": "UC-A02", "name": "パスワードレス(メール一時トークン)でログイン", "module": "MOD-001" },
-    { "id": "UC-A03", "name": "Google / Apple ID でログイン(OIDC)", "module": "MOD-001" },
-    { "id": "UC-A04", "name": "既存アカウントへ認証方式を追加", "module": "MOD-001" },
-    { "id": "UC-A05", "name": "パスワード変更・リセット", "module": "MOD-001" },
-    { "id": "UC-A06", "name": "メールアドレス変更", "module": "MOD-001" },
-    { "id": "UC-A07", "name": "退会(アカウント削除)", "module": "MOD-001" }
+  "scope": {
+    "must": [
+      { "id": "UC-A01", "title": "メール+パスワードで登録・ログイン" },
+      { "id": "UC-A02", "title": "パスワードレス(メール一時トークン)でログイン" },
+      { "id": "UC-A03", "title": "Google / Apple ID でログイン(OIDC)" },
+      { "id": "UC-A05", "title": "パスワード変更・リセット" },
+      { "id": "UC-A07", "title": "退会(アカウント削除)" }
+    ],
+    "should": [
+      { "id": "UC-A04", "title": "既存アカウントへ認証方式を追加" },
+      { "id": "UC-A06", "title": "メールアドレス変更" }
+    ],
+    "could": []
+  },
+  "representative_use_cases": [
+    { "id": "UC-A01", "name": "メール+パスワードで登録・ログイン", "kind": "core" },
+    { "id": "UC-A03", "name": "Google / Apple ID でログイン(OIDC)", "kind": "core" },
+    { "id": "UC-A07", "name": "退会(アカウント削除)", "kind": "sub" }
   ],
   "functional_requirements": [
-    "メールアドレス+パスワード認証",
-    "メールアドレス+一時トークンによるパスワードレス認証",
-    "Google / Apple ID による OIDC 認証",
-    "認証方式の追加(アカウント連携)",
-    "パスワード変更・リセット / メールアドレス変更 / 退会",
-    "バックエンド(Rails) で API の JWT 認可とログインセッション保持",
-    "フロント(Web SPA)・アプリでのセッション保持と JWT 付きAPIリクエスト"
+    { "id": "FR-01", "description": "メールアドレス+パスワード認証" },
+    { "id": "FR-02", "description": "メールアドレス+一時トークンによるパスワードレス認証" },
+    { "id": "FR-03", "description": "Google / Apple ID による OIDC 認証" },
+    { "id": "FR-04", "description": "認証方式の追加(アカウント連携)" },
+    { "id": "FR-05", "description": "パスワード変更・リセット / メールアドレス変更 / 退会" },
+    { "id": "FR-06", "description": "バックエンド(Rails) で API の JWT 認可とログインセッション保持" },
+    { "id": "FR-07", "description": "フロント(Web SPA)・アプリでのセッション保持と JWT 付き API リクエスト" }
   ],
   "non_functional_requirements": [
-    "想定ユーザー規模: 初年度で数万人",
-    "規制の厳しい業界ではない / docomo・dメニュー連携なし(DP-015 非該当)",
-    "将来的な認証基盤の差し替え余地を残す(ベンダーロックイン回避)",
-    "開発チームは Firebase 利用経験あり"
+    { "category": "security", "description": "将来的な認証基盤の差し替え余地を残す(ベンダーロックイン回避)。docomo・dメニュー連携なし(DP-015 非該当)" },
+    { "category": "performance", "description": "想定ユーザー規模: 初年度で数万人" },
+    { "category": "maintainability", "description": "開発チームは Firebase 利用経験あり" }
   ],
+  "domain_tags": ["BtoC SaaS", "全ドメイン共通"],
+  "stakeholders": {
+    "client": "みんなの読書会 運営",
+    "pm": "(架空)PM",
+    "lead": "豊田"
+  },
+  "client_approval": {
+    "approved": true,
+    "approved_by": "みんなの読書会 運営",
+    "approved_at": "2026-05-25T09:00:00+09:00"
+  },
   "undecided": ["DP-007", "DP-008"]
 }

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/SKILL.md
@@ -20,7 +20,7 @@ description: Firebase Auth を使った認証設計をガイドするスキル�
 
 ## 手順
 
-1. requirements の `use_cases` / `non_functional_requirements` から認証要件（ログイン方式・MFA・規制・ユーザ規模）を読み取る。
+1. requirements の `representative_use_cases` / `functional_requirements` / `non_functional_requirements` から認証要件（ログイン方式・MFA・規制・ユーザ規模）を読み取る。
 2. **DP-007**: Firebase Auth と代替（例: Devise+OmniAuth / Cognito）を比較表にし、MVP 推奨と根拠を述べる。`tech_stack` に採用案を入れ、差し替え可能設計（認証アダプタ層）を `architecture` に明記する。
 3. **DP-008**: MFA 方針を案件条件に当てはめ、決められなければ推奨だけ提示。
 4. **DP-015**: docomo 系案件なら dAccount 規約遵守タイミングを設計に織り込む。非該当ならスコープ外と明記。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/requirements/auth-requirements-extraction/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/requirements/auth-requirements-extraction/SKILL.md
@@ -9,18 +9,18 @@ description: クライアント要件の説明から認証関連要件を抽出�
 
 ## 概要
 
-クライアント要件の説明テキストから **認証モジュール（MOD-001）に関わる要件**を抽出し、`requirements.schema.json` の `use_cases` / `functional_requirements` / `non_functional_requirements` / `undecided` に反映する。要件定義フェーズ（`/req-collect`）の認証特化版。
+クライアント要件の説明テキストから **認証モジュール（MOD-001）に関わる要件**を抽出し、`requirements.schema.json`（T-011 本実装）の `scope` / `representative_use_cases` / `functional_requirements` / `non_functional_requirements` 等に反映する。要件定義フェーズ（`/req-collect`）の認証特化版。
 
 ## 入出力（スキーマ）
 
 - 入力: クライアント要件の説明テキスト
-- 出力: `schemas/requirements.schema.json`（7フィールド: project_name / overview / actors / use_cases / functional_requirements / non_functional_requirements / undecided）
+- 出力: `schemas/requirements.schema.json`（T-011 本実装。必須: scope / representative_use_cases / functional_requirements / non_functional_requirements / domain_tags / stakeholders / client_approval。warn_and_document 用に undecided を追加保持）
 
 スキーマは編集しない（`schemas/` は xtone-shared-plugin への symlink, CONV-14）。
 
 ## 抽出チェックリスト（認証ユースケース／T-004 スコープ）
 
-以下の有無・要否を必ず確認し、`use_cases` / `functional_requirements` に落とす。
+以下の有無・要否を必ず確認し、`representative_use_cases` / `functional_requirements` / `scope` に落とす。
 
 - [ ] メールアドレス + パスワード認証
 - [ ] メールアドレス + 一時トークン（パスワードレス）認証
@@ -41,7 +41,7 @@ description: クライアント要件の説明から認証関連要件を抽出�
 ## 手順
 
 1. 説明テキストを読み、上記チェックリストで認証要件を洗い出す。
-2. 7フィールドへマッピングする（`project_name` / `overview` は案件全体、認証は `use_cases` 等へ）。
+2. 各フィールドへマッピングする（`scope` で Must/Should/Could を振り分け、認証ユースケースは `representative_use_cases` / `functional_requirements` へ）。
 3. 不足・曖昧な点は人間に質問する。
 4. 人間判断が必要な点（スタック・MFA・dAccount 等）は勝手に決めず、`undecided` に `DP-007` / `DP-008` / `DP-015` を追加し、`docs/pending-decisions.md` に起票する。
 

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/decision-point.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/decision-point.schema.json
@@ -1,45 +1,84 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/decision-point.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式定義は Notion 判断ポイントスキーマDB（DPS-, data_source_id: fd4eec27-907d-4abc-9395-a3031ff9e10c）を真実の源とする。Subagent/Hook が status と decision_record を参照する中核スキーマ。",
+  "$comment": "T-012 判断ポイントスキーマDB（DPS-, fd4eec27-907d-4abc-9395-a3031ff9e10c）を真実の源とする本実装（#126 / B-01）。Subagent / Hook が status と decision_record を参照する中核スキーマ（T-002 warn_and_document）。",
   "title": "DecisionPoint",
-  "description": "人間判断を要するポイント1件。warn_and_document の検出対象（T-002 本決定）。",
+  "description": "人間判断を要するポイント1件。undecided の間は pending-watcher / 各 Hook が警告として可視化する。",
   "type": "object",
-  "required": ["id", "title", "status"],
+  "required": ["id", "name", "phase", "modules", "domains", "options", "decision_axes", "status"],
   "properties": {
     "id": {
       "type": "string",
       "pattern": "^DP-[0-9]+$",
-      "description": "判断ポイントID（例: DP-03）"
+      "description": "判断ポイントID（T-007 判断ポイントカタログの DP IDs とリンク）"
     },
-    "title": { "type": "string", "description": "判断ポイントの要約" },
+    "name": { "type": "string", "maxLength": 100, "description": "判断ポイント名（人間が読んで決めるトリガー名）" },
     "phase": {
       "type": "string",
-      "enum": ["requirements", "design", "implementation", "test", "release", "cross-phase"],
-      "description": "発生フェーズ"
+      "enum": ["要件定義", "設計", "実装", "テスト", "リリース", "インフラ", "引き継ぎ"],
+      "description": "判断ポイントが属するフェーズ"
     },
-    "domain": { "type": "string", "description": "関連ドメイン（任意）" },
+    "modules": {
+      "type": "array",
+      "description": "適用モジュールタグ（T-007 関連モジュール）。",
+      "items": { "type": "string" }
+    },
+    "domains": {
+      "type": "array",
+      "description": "適用ドメインタグ（T-008 の10ドメイン、複数可）。",
+      "items": { "type": "string" }
+    },
     "options": {
       "type": "array",
-      "items": { "type": "string" },
-      "description": "選択肢の一覧"
+      "description": "選択肢リスト。各選択肢に name、when（任意、AI 推奨に利用）。1件以上。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name"],
+        "properties": {
+          "name": { "type": "string" },
+          "when": { "type": "object", "additionalProperties": true }
+        },
+        "additionalProperties": true
+      }
+    },
+    "decision_axes": {
+      "type": "array",
+      "description": "判断軸一覧。各軸に axis と options（1件以上）。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["axis", "options"],
+        "properties": {
+          "axis": { "type": "string" },
+          "options": { "type": "array", "minItems": 1, "items": { "type": "string" } }
+        },
+        "additionalProperties": true
+      }
     },
     "status": {
       "type": "string",
-      "enum": ["undecided", "decided"],
-      "description": "undecided の間は pending-watcher / 各 Hook が警告として可視化する"
+      "enum": ["decided", "undecided"],
+      "description": "判断状態。undecided は未決として docs/pending-decisions.md に明示し、フェーズ移行時に警告（ブロックなし, T-002）。"
+    },
+    "risk_if_wrong": {
+      "type": "string",
+      "description": "誤判断のリスク（任意、T-007 の誤判断のリスクを参照）。"
     },
     "decision_record": {
       "type": "object",
-      "description": "決定の記録。status=decided では3要素すべて必須（T-002 decision_record トリオ）。",
+      "description": "判断記録。status=decided では decided_by / decided_at / rationale が必須（トリオ）。adr_ref は任意。",
       "required": ["decided_by", "decided_at", "rationale"],
       "properties": {
-        "decided_by": { "type": "string", "description": "決定者" },
-        "decided_at": { "type": "string", "format": "date-time", "description": "決定日時" },
-        "rationale": { "type": "string", "description": "決定理由" },
-        "adr_ref": { "type": "string", "description": "対応する ADR ファイルパス（任意）" }
-      }
+        "decided_by": { "type": "string" },
+        "decided_at": { "type": "string", "format": "date-time" },
+        "rationale": { "type": "string" },
+        "adr_ref": { "type": "string" }
+      },
+      "additionalProperties": true
     }
   },
+  "if": { "properties": { "status": { "const": "decided" } }, "required": ["status"] },
+  "then": { "required": ["decision_record"] },
   "additionalProperties": true
 }

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/design.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/design.schema.json
@@ -1,25 +1,112 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/design.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式な8フィールド定義は Notion I/O契約スキーマDB（FLD-, data_source_id: 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする。",
+  "$comment": "T-011 I/O契約スキーマDB（FLD-, 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする本実装（#126 / B-01）。warn_and_document のため decision_record / undecided を追加保持（T-002）。",
   "title": "Design",
-  "description": "設計フェーズの成果物（T-011 の8フィールド）。designer Subagent が生成する。",
+  "description": "設計フェーズの成果物。designer / authentication-architect Subagent が生成する。",
   "type": "object",
-  "required": ["tech_stack", "undecided"],
+  "required": ["architecture", "db_schema", "authentication", "adr_list", "design_review_completed"],
   "properties": {
-    "tech_stack": { "type": "array", "items": { "type": "string" } },
-    "architecture": { "type": "string" },
-    "modules": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
-    "data_model": { "type": "object", "additionalProperties": true },
-    "api_design": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "architecture": {
+      "type": "object",
+      "description": "アーキテクチャ選定（DP-004）。stack/cloud/db_type/rationale が必須。",
+      "required": ["stack", "cloud", "db_type", "rationale"],
+      "properties": {
+        "stack": { "type": "string" },
+        "cloud": { "type": "string" },
+        "db_type": { "type": "string" },
+        "rationale": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "db_schema": {
+      "type": "object",
+      "description": "DBスキーマ設計（DP-005）。ER図とテーブル定義。",
+      "required": ["er_diagram_url", "tables"],
+      "properties": {
+        "er_diagram_url": { "type": "string" },
+        "tables": { "type": "array", "minItems": 1, "items": { "type": "object", "additionalProperties": true } },
+        "normalization_level": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "api_spec": {
+      "type": "object",
+      "description": "API設計（DP-006、条件付き必須）。OpenAPI パスとスタイル。",
+      "required": ["openapi_path", "style"],
+      "properties": {
+        "openapi_path": { "type": "string" },
+        "style": { "type": "string", "enum": ["REST", "GraphQL", "tRPC", "gRPC"] }
+      },
+      "additionalProperties": true
+    },
+    "authentication": {
+      "type": "object",
+      "description": "認証設計（DP-007 スタック選択 / DP-008 MFA）。",
+      "required": ["stack", "mfa_requirement"],
+      "properties": {
+        "stack": {
+          "type": "string",
+          "enum": ["Firebase Auth", "Devise", "Cognito", "dAccount", "NextAuth.js", "Laravel Sanctum"]
+        },
+        "mfa_requirement": {
+          "type": "string",
+          "enum": ["required", "optional", "admin_only", "none"]
+        }
+      },
+      "additionalProperties": true
+    },
+    "ui_design": {
+      "type": "object",
+      "description": "UI設計（条件付き必須。UI不要ユースケースではスキップ可）。",
+      "required": ["figma_url", "screen_count"],
+      "properties": {
+        "figma_url": { "type": "string" },
+        "screen_count": { "type": "integer", "minimum": 1 },
+        "key_screens": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "adr_list": {
+      "type": "array",
+      "description": "ADR一覧。各ADRに id/title/status/path が必須。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "title", "status", "path"],
+        "properties": {
+          "id": { "type": "string" },
+          "title": { "type": "string" },
+          "status": { "type": "string", "enum": ["proposed", "accepted", "superseded"] },
+          "path": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "design_review_completed": {
+      "type": "object",
+      "description": "設計レビュー状態。approved=false の間は実装フェーズに進めない（warn_and_document）。",
+      "required": ["approved"],
+      "properties": {
+        "approved": { "type": "boolean" },
+        "approved_by": { "type": ["string", "null"] },
+        "approved_at": { "type": ["string", "null"], "format": "date-time" }
+      },
+      "additionalProperties": true
+    },
+    "domain_specific_checks": {
+      "type": "object",
+      "description": "ドメイン特有チェック（条件付き必須）。docomo規約(DP-015)/PCI-DSS(DP-016)/コミュニティ規約(DP-018) 等を true/false で明示。",
+      "additionalProperties": true
+    },
     "decision_record": {
       "type": "array",
-      "description": "本フェーズで下した判断の記録（decision-point.schema.json の decision_record に準拠）。",
+      "description": "本フェーズで下した判断の記録（追加保持）。各要素は decision-point.schema.json の decision_record に準拠。",
       "items": { "type": "object", "additionalProperties": true }
     },
-    "adr_refs": { "type": "array", "items": { "type": "string" } },
     "undecided": {
       "type": "array",
+      "description": "未決の判断ポイントID（DP-XXX）。warn_and_document の検出対象（追加保持, T-002）。",
       "items": { "type": "string", "pattern": "^DP-[0-9]+$" }
     }
   },

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/implementation-plan.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/implementation-plan.schema.json
@@ -1,18 +1,69 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/implementation-plan.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式な5フィールド定義は Notion I/O契約スキーマDB（FLD-, data_source_id: 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする。",
+  "$comment": "T-011 I/O契約スキーマDB（FLD-, 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする本実装（#126 / B-01）。tasks/milestones/dependencies/test_plan は implementer 用の補助フィールドとして任意で許容。undecided を追加保持（T-002）。",
   "title": "ImplementationPlan",
-  "description": "実装フェーズの計画（T-011 の5フィールド）。implementer Subagent が生成する。",
+  "description": "実装フェーズの計画。implementer Subagent が生成する。",
   "type": "object",
-  "required": ["tasks", "undecided"],
+  "required": ["modules", "tdd_strategy", "ci_cd_config", "pr_strategy"],
   "properties": {
-    "tasks": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+    "modules": {
+      "type": "array",
+      "description": "採用モジュール一覧。module_ref が modules.schema.json に存在すること。priority は整数。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["module_ref"],
+        "properties": {
+          "module_ref": { "type": "string", "pattern": "^MOD-[0-9]+$" },
+          "priority": { "type": "integer" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "tdd_strategy": {
+      "type": "string",
+      "description": "テスト計画スタンス。NoTest はローリスクケースに限る。",
+      "enum": ["TDD", "TestAfter", "NoTest"]
+    },
+    "test_coverage_target": {
+      "type": "number",
+      "description": "テストカバレッジ目標 0-100（DP-010）。CI でこの値を下回ると警告。",
+      "minimum": 0,
+      "maximum": 100
+    },
+    "ci_cd_config": {
+      "type": "object",
+      "description": "CI/CD設定。type と hooks（lint/test/build を含む）。",
+      "required": ["type", "hooks"],
+      "properties": {
+        "type": { "type": "string", "enum": ["GitHub Actions", "GitLab CI", "CircleCI", "Jenkins"] },
+        "hooks": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": true
+    },
+    "pr_strategy": {
+      "type": "object",
+      "description": "PR戦略。サイズ・命名・マージストラテジー。",
+      "required": ["pr_max_size_lines", "merge_strategy"],
+      "properties": {
+        "pr_max_size_lines": { "type": "integer", "minimum": 1 },
+        "branch_naming": { "type": "string" },
+        "merge_strategy": { "type": "string", "enum": ["squash", "merge", "rebase"] }
+      },
+      "additionalProperties": true
+    },
+    "tasks": {
+      "type": "array",
+      "description": "実装タスク（補助・任意）。implementer が分解する作業単位。",
+      "items": { "type": "object", "additionalProperties": true }
+    },
     "milestones": { "type": "array", "items": { "type": "string" } },
     "dependencies": { "type": "array", "items": { "type": "string" } },
     "test_plan": { "type": "string" },
     "undecided": {
       "type": "array",
+      "description": "未決の判断ポイントID（DP-XXX）。warn_and_document の検出対象（追加保持, T-002）。",
       "items": { "type": "string", "pattern": "^DP-[0-9]+$" }
     }
   },

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/module.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/module.schema.json
@@ -1,21 +1,81 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/module.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式定義は Notion モジュールカタログスキーマDB（MCS-, data_source_id: a983ee9b-9f4c-4e76-810e-3ed7b1bb1462）を真実の源とする。",
+  "$comment": "T-013 モジュールカタログスキーマDB（MCS-, a983ee9b-9f4c-4e76-810e-3ed7b1bb1462）を真実の源とする本実装（#126 / B-01）。モジュールカタログの1エントリ（MOD-XXX）。",
   "title": "Module",
-  "description": "モジュール1件。designer が tech_options を参照してスタックを推奨する単位（MOD-XXX）。",
+  "description": "モジュールカタログの1件。designer / authentication-architect が tech_options を参照してスタックを推奨する単位。",
   "type": "object",
-  "required": ["id", "name"],
+  "required": ["id", "name", "description", "applicable_domains", "typical_requirements", "tech_options", "decision_points", "skill_structure_hint"],
   "properties": {
-    "id": { "type": "string", "pattern": "^MOD-[0-9]+$", "description": "モジュールID（例: MOD-01）" },
-    "name": { "type": "string" },
-    "description": { "type": "string" },
-    "tech_options": {
+    "id": { "type": "string", "pattern": "^MOD-[0-9]+$", "description": "モジュールの一意識別子（例: MOD-001）" },
+    "name": { "type": "string", "maxLength": 50 },
+    "description": { "type": "string", "maxLength": 500 },
+    "applicable_domains": {
       "type": "array",
-      "description": "技術選択肢。designer が推奨を提示し、最終決定は人間が行う（T-002）。",
+      "description": "適用ドメインタグ（T-008 の10ドメインから選択）。",
+      "minItems": 1,
       "items": { "type": "string" }
     },
-    "selected": { "type": "string", "description": "選定された技術（未決の間は空）" }
+    "typical_requirements": {
+      "type": "array",
+      "description": "典型要件チェック項目。モジュールが提供すべき機能リスト。",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "tech_options": {
+      "type": "array",
+      "description": "技術選定肢と適用条件。各選択肢に name/pros/cons が必須、when は任意（AI 推奨に利用）。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["name", "pros", "cons"],
+        "properties": {
+          "name": { "type": "string" },
+          "when": { "type": "object", "additionalProperties": true },
+          "pros": { "type": "array", "items": { "type": "string" } },
+          "cons": { "type": "array", "items": { "type": "string" } }
+        },
+        "additionalProperties": true
+      }
+    },
+    "decision_points": {
+      "type": "array",
+      "description": "属する判断ポイントID（T-007 判断ポイントカタログのDP-XXX）。1件以上。",
+      "minItems": 1,
+      "items": { "type": "string", "pattern": "^DP-[0-9]+$" }
+    },
+    "common_pitfalls": {
+      "type": "array",
+      "description": "落とし穴リスト（任意）。過去案件で踏んだ落とし穴。",
+      "items": { "type": "string" }
+    },
+    "past_implementations": {
+      "type": "array",
+      "description": "過去実装リポジトリ参照（任意、T-009 型化資産インベントリとリンク）。",
+      "items": {
+        "type": "object",
+        "properties": {
+          "repo": { "type": "string" },
+          "commit": { "type": "string" },
+          "year": { "type": "integer" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "dependencies": {
+      "type": "array",
+      "description": "依存する他モジュール（任意）。MOD-XXX を参照。",
+      "items": { "type": "string" }
+    },
+    "skill_structure_hint": {
+      "type": "object",
+      "description": "推奨Skill構造ヒント（T-018 と連携）。skill_md_files と typical_section_count。",
+      "properties": {
+        "skill_md_files": { "type": "array", "items": { "type": "string" } },
+        "typical_section_count": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": true
+    }
   },
   "additionalProperties": true
 }

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/modules.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/modules.schema.json
@@ -1,15 +1,45 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/modules.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式定義は Notion I/O契約スキーマDB（FLD-）/ モジュールカタログスキーマDB（MCS-, data_source_id: a983ee9b-9f4c-4e76-810e-3ed7b1bb1462）を真実の源とする。",
+  "$comment": "T-011 I/O契約スキーマDB（FLD-, 0f997761-9259-4f76-9056-3f209e3a3afc）の modules.schema.json を真実の源とする本実装（#126 / B-01）。設計で採用したモジュールの一覧。各 module_id は module.schema.json（カタログ）に対応する。",
   "title": "Modules",
-  "description": "設計で選定したモジュールの一覧。各要素は module.schema.json に準拠する。",
+  "description": "採用モジュール一覧。implementation-plan.schema.json の modules[].module_ref から参照される。",
   "type": "object",
   "required": ["modules"],
   "properties": {
     "modules": {
       "type": "array",
-      "items": { "$ref": "module.schema.json" }
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["module_id", "domain_tags", "decision_points", "tech_stack", "skills"],
+        "properties": {
+          "module_id": { "type": "string", "pattern": "^MOD-[0-9]+$" },
+          "domain_tags": {
+            "type": "array",
+            "description": "T-008 の10ドメインから選択。",
+            "items": { "type": "string" }
+          },
+          "decision_points": {
+            "type": "array",
+            "description": "T-007 判断ポイントカタログの DP-XXX。1件以上。",
+            "minItems": 1,
+            "items": { "type": "string", "pattern": "^DP-[0-9]+$" }
+          },
+          "tech_stack": {
+            "type": "array",
+            "description": "T-008 技術スタック軸から選択。",
+            "items": { "type": "string" }
+          },
+          "skills": {
+            "type": "array",
+            "description": "skills/ ディレクトリ下の MD ファイル参照。1件以上。",
+            "minItems": 1,
+            "items": { "type": "string" }
+          }
+        },
+        "additionalProperties": true
+      }
     }
   },
   "additionalProperties": true

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/requirements.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/requirements.schema.json
@@ -1,21 +1,112 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/requirements.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式な7フィールド定義は Notion I/O契約スキーマDB（FLD-, data_source_id: 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする。",
+  "$comment": "T-011 I/O契約スキーマDB（FLD-, data_source_id: 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする本実装（#126 / B-01）。warn_and_document のため undecided を追加保持（T-002）。project_name / overview は実務上の補助フィールドとして任意で許容。",
   "title": "Requirements",
-  "description": "要件定義フェーズの成果物（T-011 の7フィールド）。requirements-analyst Subagent が生成する。",
+  "description": "要件定義フェーズの成果物。requirements-analyst Subagent が生成する。",
   "type": "object",
-  "required": ["project_name", "overview", "undecided"],
+  "required": [
+    "scope",
+    "representative_use_cases",
+    "functional_requirements",
+    "non_functional_requirements",
+    "domain_tags",
+    "stakeholders",
+    "client_approval"
+  ],
   "properties": {
-    "project_name": { "type": "string" },
-    "overview": { "type": "string", "description": "何を/なぜ" },
-    "actors": { "type": "array", "items": { "type": "string" } },
-    "use_cases": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
-    "functional_requirements": { "type": "array", "items": { "type": "string" } },
-    "non_functional_requirements": { "type": "array", "items": { "type": "string" } },
+    "project_name": { "type": "string", "description": "案件名（補助・任意）" },
+    "overview": { "type": "string", "description": "何を/なぜ（補助・任意）" },
+    "scope": {
+      "type": "object",
+      "description": "MVPスコープの区切り（DP-001 / DP-003）。Must/Should/Could を振り分ける。must は1件以上、各要件に一意ID。",
+      "required": ["must"],
+      "properties": {
+        "must": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "required": ["id"],
+            "properties": { "id": { "type": "string" }, "title": { "type": "string" } },
+            "additionalProperties": true
+          }
+        },
+        "should": { "type": "array", "items": { "type": "object", "additionalProperties": true } },
+        "could": { "type": "array", "items": { "type": "object", "additionalProperties": true } }
+      },
+      "additionalProperties": true
+    },
+    "representative_use_cases": {
+      "type": "array",
+      "description": "代表ユースケース（DP-002）。各要素に id と name。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["id", "name"],
+        "properties": {
+          "id": { "type": "string" },
+          "name": { "type": "string" },
+          "kind": { "type": "string", "enum": ["core", "sub"] }
+        },
+        "additionalProperties": true
+      }
+    },
+    "functional_requirements": {
+      "type": "array",
+      "description": "機能要件。各要件に description。",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["description"],
+        "properties": { "id": { "type": "string" }, "description": { "type": "string" } },
+        "additionalProperties": true
+      }
+    },
+    "non_functional_requirements": {
+      "type": "array",
+      "description": "非機能要件（DP-008 セキュリティ/MFA 等）。performance/security/availability などでグループ化。",
+      "items": {
+        "type": "object",
+        "required": ["category", "description"],
+        "properties": {
+          "category": { "type": "string", "enum": ["performance", "security", "availability", "maintainability", "other"] },
+          "description": { "type": "string" }
+        },
+        "additionalProperties": true
+      }
+    },
+    "domain_tags": {
+      "type": "array",
+      "description": "案件が属するドメインタグ（T-008 業界軸10ドメインから選択、複数可）。",
+      "minItems": 1,
+      "items": { "type": "string" }
+    },
+    "stakeholders": {
+      "type": "object",
+      "description": "ステークホルダー（T-005）。client + pm + lead が必須。",
+      "required": ["client", "pm", "lead"],
+      "properties": {
+        "client": { "type": "string" },
+        "pm": { "type": "string" },
+        "lead": { "type": "string" }
+      },
+      "additionalProperties": true
+    },
+    "client_approval": {
+      "type": "object",
+      "description": "クライアント承認。approved=false の間は設計フェーズに進めない（warn_and_document で可視化）。",
+      "required": ["approved"],
+      "properties": {
+        "approved": { "type": "boolean" },
+        "approved_by": { "type": ["string", "null"] },
+        "approved_at": { "type": ["string", "null"], "format": "date-time" }
+      },
+      "additionalProperties": true
+    },
     "undecided": {
       "type": "array",
-      "description": "未決の判断ポイントID（DP-XXX）の一覧。空でないままフェーズ進行すると warn_and_document が発動する。",
+      "description": "未決の判断ポイントID（DP-XXX）。warn_and_document の検出対象（追加保持フィールド, T-002）。",
       "items": { "type": "string", "pattern": "^DP-[0-9]+$" }
     }
   },

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/risks.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/risks.schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://xtone.dev/ai-delivery/schemas/v1/risks.schema.json",
-  "$comment": "T-020 検証用の最小スタブ。正式定義は Notion I/O契約スキーマDB（FLD-, data_source_id: 0f997761-9259-4f76-9056-3f209e3a3afc）を真実の源とする。",
+  "$comment": "T-011 I/O契約スキーマDB（FLD-, 0f997761-9259-4f76-9056-3f209e3a3afc）の risks.schema.json を真実の源とする本実装（#126 / B-01）。",
   "title": "Risks",
   "description": "各フェーズで識別したリスクの一覧。",
   "type": "object",
@@ -11,12 +11,44 @@
       "type": "array",
       "items": {
         "type": "object",
-        "required": ["summary"],
+        "required": ["risk_id", "description", "impact_probability", "mitigation", "decision_record"],
         "properties": {
-          "summary": { "type": "string" },
-          "severity": { "type": "string", "enum": ["low", "medium", "high"] },
-          "mitigation": { "type": "string" },
-          "related_decision": { "type": "string", "pattern": "^DP-[0-9]+$" }
+          "risk_id": {
+            "type": "string",
+            "pattern": "^RISK-[0-9]+$",
+            "description": "リスクの一意識別子（例: RISK-001）"
+          },
+          "description": {
+            "type": "string",
+            "minLength": 20,
+            "description": "リスクの内容・説明（最低20文字）"
+          },
+          "impact_probability": {
+            "type": "object",
+            "description": "影響度と発生確率の評価。",
+            "required": ["impact", "probability"],
+            "properties": {
+              "impact": { "type": "string", "enum": ["low", "medium", "high", "critical"] },
+              "probability": { "type": "string", "enum": ["low", "medium", "high"] }
+            },
+            "additionalProperties": true
+          },
+          "mitigation": {
+            "type": "string",
+            "minLength": 1,
+            "description": "リスク軽減策。空文字不可（「未検討」も明示的に記載する）。"
+          },
+          "decision_record": {
+            "type": "object",
+            "description": "判断記録。adr_ref は design.schema.json の adr_list に存在。decided_by/decided_at が必須。",
+            "required": ["decided_by", "decided_at"],
+            "properties": {
+              "decided_by": { "type": "string" },
+              "decided_at": { "type": "string", "format": "date-time" },
+              "adr_ref": { "type": "string" }
+            },
+            "additionalProperties": true
+          }
         },
         "additionalProperties": true
       }


### PR DESCRIPTION
## 概要

訂正バックログ **B-01 / Issue #126** に対応。`xtone-shared-plugin/schemas/v1/` の検証用スタブを、Notion の真実の源（I/O契約スキーマDB=T-011 / 判断ポイントスキーマDB=T-012 / モジュールカタログスキーマDB=T-013）に基づく**本実装**に置き換える。

T-022 パイロットの発見 F-2「スキーマがスタブで検証が効かない」の解消。**(A) 追加方式**（正式フィールドを実装しつつ `undecided`/`decision_record` を保持）で、T-021 プラグインの warn_and_document フローを壊さない。

Closes #126

## 変更内容

### `feat(B-01)` スキーマ本実装（7ファイル）
| スキーマ | 由来 | 主な内容 |
|---|---|---|
| requirements | T-011/FLD | scope(DP-001/003) / representative_use_cases(DP-002) / functional / non_functional / domain_tags / stakeholders / client_approval ＋ undecided |
| design | T-011/FLD | architecture(DP-004) / db_schema(DP-005) / api_spec(DP-006) / **authentication(DP-007 stack enum・DP-008 mfa enum)** / adr_list / design_review_completed / domain_specific_checks(DP-015/016/018) ＋ decision_record・undecided |
| implementation-plan | T-011/FLD | modules / tdd_strategy / test_coverage_target(DP-010) / ci_cd_config / pr_strategy ＋ tasks(補助)・undecided |
| modules / module | T-011・T-013/MCS | 採用モジュール一覧 / カタログエントリ（tech_options・pitfalls 等） |
| decision-point | T-012/DPS | id/name/phase/options/decision_axes/status/decision_record（**status=decided なら record 必須**を if/then で強制）/ risk_if_wrong |
| risks | T-011/FLD | risk_id / impact_probability / mitigation / decision_record |

- `additionalProperties: true`、検証ルール（enum/pattern/minItems/minLength 等）を各フィールドに反映。
- `quality-gate-rules.yaml`（T-014）は本 Issue スコープ外のため変更なし。

### `docs(B-01)` プラグイン整合（7ファイル）
- sample-outputs（requirements.json / design.yaml / implementation-plan.json）を新スキーマ準拠に更新
- skills（auth-requirements-extraction / firebase-auth-design）・agents（requirements-analyst / authentication-architect）のフィールド名を新スキーマに整合

## 検証（実測）

- **draft-07 メタ検証**: 7スキーマすべて valid ✅
- **サンプル準拠**: 3サンプルを jsonschema で全件準拠 ✅（design.yaml は YAML ロードで検証）
- **ネガティブテスト**: 「decided なのに decision_record 欠落」「必須 client_approval 欠落」「未知の認証スタック(enum外)」を**正しく検出** ✅
- **プラグイン `claude plugin validate --strict`**: 回帰なし ✅
- サンプルアプリ `~/RubymineProjects/t-021-sample/delivery/` も新スキーマに同期済み（別リポジトリ）

## 補足

- 検証は ad-hoc（Python jsonschema）で実施。**コミット済みの検証ハーネス**（validate-plugin.sh）は #132（TPL-27）の範囲。
- Rollout は引き続き No-go 保留（残 High: #127 / #128 / #129）。

## 関連ID

- Issue #126（B-01）/ T-011 / T-012 / T-013 / FLD- / DPS- / MCS- / CONV-14 / DP-001〜010/015/016/018

🤖 Generated with [Claude Code](https://claude.com/claude-code)