### PR TITLE
feat(B-02 / #127): firebase-auth-setup の運用詳細追加＋言語非依存化

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: firebase-auth-setup
-description: Firebase Auth をプロジェクトにセットアップする手順とコードサンプルを提供するスキル。実装フェーズで、design.schema.json の認証設計に従って Firebase Admin SDK 設定・JWT 検証・差し替え可能な認証アダプタを実装したいときに使う。
+description: Firebase Auth を任意のバックエンドに統合するスキル。実装フェーズで、design.schema.json の認証設計に従い、差し替え可能な認証アダプタ・JWT 検証・退会時の Admin SDK 削除・公開鍵キャッシュ・トークン失効を実装したいときに使う。言語/FW 非依存の契約と手順を定義し、具体コードは references/ の言語別レシピに分離（現状 Rails、Node 等は追加可能）。
 ---
 
 # Firebase Auth Setup Skill
@@ -9,38 +9,68 @@ description: Firebase Auth をプロジェクトにセットアップする手�
 
 ## 概要
 
-`design.schema.json` の認証設計を実装に落とす。Firebase Admin SDK のセットアップ、JWT 認可、ログインセッション保持、そして **IaaS 差し替え可能な認証アダプタ層**の雛形を提供する。`implementation-plan.schema.json` のタスクに対応する。
+`design.schema.json` の認証設計を実装に落とす。本スキルは **言語・フレームワーク非依存の「契約」と「手順」**を定義し、具体的なコードは `references/<stack>.md`（言語別レシピ）に分離する。MVP は Firebase Auth、`AuthAdapter` で IaaS 差し替え可能（DP-007）。
+
+> 設計方針: 言語が変わっても **契約は不変**、実装手段（SDK/コード）だけがレシピごとに変わる。Rails 固定にせず、Node/Laravel 等へ展開できる構造にする。
 
 ## 入出力（スキーマ）
 
-- 入力: `schemas/design.schema.json`（採用スタック・アーキテクチャ・decision_record）
-- 出力: 実装コード + `schemas/implementation-plan.schema.json`（tasks / milestones / dependencies / test_plan / undecided）
+- 入力: `schemas/design.schema.json`（`authentication.stack` / `architecture.stack` / decision_record）
+- 出力: 実装コード + `schemas/implementation-plan.schema.json`
 
 スキーマは編集しない（CONV-14）。
 
-## 手順
+## 言語・フレームワーク別レシピ
 
-1. Firebase Console でプロジェクトを作成し、サービスアカウントキーを取得する（鍵は `.env` 管理、コミット禁止）。
-2. Admin SDK をインストールする（Rails: `firebase-auth-rails` 相当 / Node: `firebase-admin`）。
-3. `AuthAdapter` インターフェースを定義し、Firebase 実装（`FirebaseAuthAdapter`）を作る（差し替え可能設計, DP-007）。
-4. API ミドルウェアで JWT を検証し、ユーザーを解決する（バックエンドの JWT 認可）。
-5. フロント/アプリでセッション（IDトークン/リフレッシュトークン）を保持し、API リクエストに付与する。
-6. ダミーメールパターン等でローカル動作確認をする。
-7. 実装タスク・依存・テスト方針を `implementation-plan.schema.json` に記録する。
+design の `architecture.stack` / 採用言語を見て、該当レシピを参照する。レシピが無い言語は、下記「新しい言語・FW への展開」に従って追加してから実装する。
 
-## 認証アダプタ層（差し替え可能設計の核）
+| 言語 / FW | レシピ | 状態 |
+|---|---|---|
+| Ruby on Rails | [`references/rails.md`](./references/rails.md) | ✅ |
+| Node.js / Express | `references/node.md` | ⬜ 未作成（rails.md を雛形に追加） |
+| Laravel (PHP) | `references/laravel.md` | ⬜ 未作成 |
+| その他 | — | 追加可 |
 
-```
-AuthAdapter (interface)
-  ├─ verify_token(id_token) -> AuthUser
-  ├─ sign_in(...) / sign_out(...)
-  └─ get_user(uid) -> AuthUser
+## 実装契約（言語非依存）
 
-FirebaseAuthAdapter implements AuthAdapter   # MVP
-DeviseAuthAdapter   implements AuthAdapter   # 代替例（Rollout で実証）
-```
+すべてのレシピは以下の契約を満たす。
 
-アプリ本体は `AuthAdapter` にのみ依存する。Firebase 固有処理は `FirebaseAuthAdapter` に閉じ込める。
+### AuthAdapter（差し替え可能設計の核, DP-007）
+
+| メソッド | 契約 |
+|---|---|
+| `verify_token(id_token) → AuthUser` | ID トークン(JWT)を検証し uid/email/provider を返す。無効なら InvalidToken。失効済みも拒否。 |
+| `get_user(uid) → AuthUser` | ユーザー取得。 |
+| `delete_user(uid)` | IaaS 上のユーザー削除（退会）。**冪等**（既に無くても成功）。 |
+| `revoke(uid)` | リフレッシュトークン失効。 |
+
+アプリ本体は `AuthAdapter` にのみ依存する。Firebase 固有処理は `FirebaseAuthAdapter` に閉じ込め、別 IaaS は別実装（例: `DeviseAuthAdapter`）に差し替える。テストは同契約の `TestAdapter` で実 IaaS なしに回す。
+
+### 運用契約（本番必須・言語非依存）
+
+T-022 パイロット発見 F-3 / Issue #127 の解消。
+
+1. **退会時の IaaS ユーザー削除**: Admin SDK（サービスアカウント鍵、コミット禁止）で削除。冪等。
+2. **公開鍵（証明書）キャッシュ**: 検証鍵は HTTP の `Cache-Control: max-age` に従いキャッシュ。`kid` 不一致時は強制再取得（鍵ローテーション追従）。
+3. **トークン失効 / リフレッシュ**: ID トークン短命＋リフレッシュトークン。退会・パスワード変更・MFA 変更・不正検知時はサーバ側で失効し、以後 `auth_time` が失効時刻より前のトークンを拒否。
+
+## 手順（言語非依存）
+
+1. design の採用スタックを確認し、該当レシピ（`references/<stack>.md`）を開く。無ければ新レシピを追加。
+2. Firebase プロジェクト / サービスアカウント鍵を用意（`.env` / Secrets、コミット禁止）。
+3. `AuthAdapter` 契約を実装する（`FirebaseAuthAdapter`）。
+4. API で JWT を検証してユーザーを解決する。
+5. クライアントでセッション（ID/リフレッシュトークン）を保持し、API リクエストに付与する。
+6. **運用契約**（退会削除・証明書キャッシュ・トークン失効）を実装する。
+7. ローカル動作確認（テストは `TestAdapter` で実 Firebase 不要）。
+8. 実装タスク・依存・テスト方針を `implementation-plan.schema.json` に記録する。
+
+## 新しい言語・FW への展開
+
+1. `references/<stack>.md` を作成する（例: `node.md`, `laravel.md`）。[`references/rails.md`](./references/rails.md) を雛形にする。
+2. 上記 **実装契約**（AuthAdapter ＋ 運用契約）を、その言語の SDK / エコシステムで満たすコードを記述する。
+3. **契約は変えない**（差し替え可能設計を維持）。上のレシピ表に1行追加する。
+4. 言語特有の制約（例: Ruby に公式 Admin SDK が無く REST で代替）はレシピの「既知の制約」に明記する。
 
 ## 判断ポイント（人間判断をスルーさせない）
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -36,7 +36,7 @@ end
 
 ```ruby
 # app/adapters/auth/firebase_adapter.rb — Firebase 実装
-require "jwt"; require "net/http"; require "json"; require "openssl"
+require "jwt"; require "net/http"; require "json"; require "openssl"; require "stringio"
 
 module Auth
   class FirebaseAdapter < Adapter
@@ -51,8 +51,9 @@ module Auth
       decoded, _ = JWT.decode(id_token, nil, true,
         algorithms: ["RS256"],
         iss: "https://securetoken.google.com/#{@project_id}", verify_iss: true,
-        aud: @project_id, verify_aud: true, verify_expiration: true
+        aud: @project_id, verify_aud: true, verify_expiration: true, verify_iat: true
       ) { |h| public_key_for(h["kid"]) }
+      raise Auth::InvalidToken, "empty sub" if decoded["sub"].to_s.empty?  # Firebase 検証要件: uid 非空
       # 失効チェックは DB ベース（毎リクエスト HTTP を避ける）。下記「トークン失効」を参照。
       Auth::AuthUser.new(uid: decoded["sub"], email: decoded["email"],
                          provider: decoded.dig("firebase", "sign_in_provider"), claims: decoded)
@@ -194,7 +195,7 @@ private
 def access_token
   return @token[:value] if @token && Time.now < @token[:expires_at]
   cred = Google::Auth::ServiceAccountCredentials.make_creds(
-    json_key_io: File.open(ENV.fetch("GOOGLE_APPLICATION_CREDENTIALS")),
+    json_key_io: StringIO.new(File.read(ENV.fetch("GOOGLE_APPLICATION_CREDENTIALS"))),  # FD リーク回避
     scope: "https://www.googleapis.com/auth/identitytoolkit"
   )
   t = cred.fetch_access_token!

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -52,7 +52,7 @@ module Auth
         iss: "https://securetoken.google.com/#{@project_id}", verify_iss: true,
         aud: @project_id, verify_aud: true, verify_expiration: true
       ) { |h| public_key_for(h["kid"]) }
-      raise Auth::InvalidToken, "revoked" if revoked?(decoded["sub"], decoded["auth_time"])
+      # 失効チェックは DB ベース（毎リクエスト HTTP を避ける）。下記「トークン失効」を参照。
       Auth::AuthUser.new(uid: decoded["sub"], email: decoded["email"],
                          provider: decoded.dig("firebase", "sign_in_provider"), claims: decoded)
     rescue JWT::DecodeError, OpenSSL::X509::CertificateError => e
@@ -80,6 +80,9 @@ module Authenticatable
     return render(json: { error: "no token" }, status: :unauthorized) if token.blank?
     @current_auth_user = AppAuth.adapter.verify_token(token)
     @current_user = User.active.find_by(uid: @current_auth_user.uid)
+    if @current_user && !@current_user.token_valid?(@current_auth_user.claims["auth_time"])
+      return render(json: { error: "token revoked" }, status: :unauthorized)  # DB 参照のみ（HTTP なし）
+    end
   rescue Auth::InvalidToken => e
     render json: { error: e.message }, status: :unauthorized
   end
@@ -139,18 +142,70 @@ end
 
 ### トークン失効 / リフレッシュ
 
-```ruby
-def revoke(uid)
-  # Identity Toolkit: validSince を現在時刻に更新 → 以後の古い ID トークンを失効扱い
-  identitytoolkit_post("accounts:update", localId: uid, validSince: Time.now.to_i.to_s)
-end
+**毎リクエストで HTTP を叩かない**ため、失効判定は DB で行う。User に `tokens_valid_after`（datetime）カラムを持ち、失効時に更新。検証時はこの DB 値と ID トークンの `auth_time` を比較するだけ（HTTP 不要）。IaaS 側のリフレッシュトークン失効は失効アクション時のみ呼ぶ。
 
-def revoked?(uid, auth_time)
-  auth_time && valid_since(uid) && auth_time < valid_since(uid)
+```ruby
+# db/migrate: add_column :users, :tokens_valid_after, :datetime
+
+class User < ApplicationRecord
+  # 退会・パスワード変更・MFA 変更・不正検知時に呼ぶ
+  def revoke_tokens!
+    update!(tokens_valid_after: Time.current)
+    AppAuth.adapter.revoke(uid)   # IaaS 側のリフレッシュトークンも失効（ベストエフォート）
+  end
+
+  # 検証時の失効判定（DB のみ・HTTP なし）。auth_time が失効時刻以降なら有効。
+  def token_valid?(auth_time)
+    tokens_valid_after.nil? || (auth_time.present? && Time.at(auth_time.to_i) >= tokens_valid_after)
+  end
 end
 ```
 
-退会・パスワード変更・MFA 変更・不正検知時に `revoke(uid)` を呼ぶ。
+```ruby
+# FirebaseAdapter#revoke — IaaS 側のリフレッシュトークンを失効（失効アクション時のみ・冪等）
+def revoke(uid)
+  identitytoolkit_post("accounts:update", localId: uid, validSince: Time.now.to_i.to_s)
+  true
+rescue NotFoundError
+  true
+end
+```
+
+### Admin REST ヘルパー（FirebaseAdapter private）
+
+Ruby に公式 Admin SDK が無いため、Admin 操作（削除・失効）は Identity Toolkit REST ＋ サービスアカウントの OAuth2 アクセストークンで行う。`NotFoundError` も定義する。
+
+```ruby
+class NotFoundError < Auth::Error; end
+
+private
+
+# サービスアカウント鍵から OAuth2 アクセストークンを取得（googleauth gem）。短命なのでキャッシュ。
+def access_token
+  return @token[:value] if @token && Time.now < @token[:expires_at]
+  cred = Google::Auth::ServiceAccountCredentials.make_creds(
+    json_key_io: File.open(ENV.fetch("GOOGLE_APPLICATION_CREDENTIALS")),
+    scope: "https://www.googleapis.com/auth/identitytoolkit"
+  )
+  t = cred.fetch_access_token!
+  @token = { value: t["access_token"], expires_at: Time.now + t["expires_in"].to_i - 30 }
+  @token[:value]
+end
+
+def identitytoolkit_post(method, **body)
+  uri = URI("https://identitytoolkit.googleapis.com/v1/projects/#{@project_id}/#{method}")
+  req = Net::HTTP::Post.new(uri)
+  req["Authorization"] = "Bearer #{access_token}"
+  req["Content-Type"]  = "application/json"
+  req.body = JSON.dump(body)
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
+  raise NotFoundError if res.code == "404"
+  raise Auth::Error, "identitytoolkit #{method}: #{res.code}" unless res.is_a?(Net::HTTPSuccess)
+  res.body.to_s.empty? ? {} : JSON.parse(res.body)
+end
+```
+
+退会・パスワード変更・MFA 変更・不正検知時に `user.revoke_tokens!` を呼ぶ（DB 更新＋ IaaS 失効）。
 
 ## 4. テスト（実 Firebase 不要）
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -1,0 +1,149 @@
+# Firebase Auth レシピ: Ruby on Rails
+
+`firebase-auth-setup` スキルの **Rails 実装レシピ**。スキル本体（SKILL.md）の「実装契約（言語非依存）」を Rails/Ruby で満たす具体コード。契約（AuthAdapter ＋ 運用契約）は変えず、実装手段だけを示す。T-022 パイロット（`~/RubymineProjects/t-021-sample/`）で実証済み。
+
+- 対象: Rails 8（API モード）/ Ruby 3.1+（Rails 8 要件、環境前提は #129）
+- 依存: `jwt`（ID トークン検証）/ Admin 操作は Identity Toolkit REST API（Ruby 公式 Admin SDK は無いため REST で代替）
+
+## 1. セットアップ
+
+```ruby
+# Gemfile
+gem "jwt", "~> 3.2"
+```
+
+- Firebase プロジェクトを作成し、サービスアカウント鍵を取得。`GOOGLE_APPLICATION_CREDENTIALS`（または ENV）で渡す。**コミット禁止**（`.gitignore` / Secrets）。
+- `FIREBASE_PROJECT_ID` を ENV に設定（ID トークンの aud/iss 検証に使用）。
+
+## 2. AuthAdapter 契約の実装
+
+```ruby
+# app/adapters/auth/adapter.rb — 抽象（契約）
+module Auth
+  AuthUser = Struct.new(:uid, :email, :provider, :claims, keyword_init: true)
+  class Error < StandardError; end
+  class InvalidToken < Error; end
+
+  class Adapter
+    def verify_token(_id_token); raise NotImplementedError; end
+    def get_user(_uid);          raise NotImplementedError; end
+    def delete_user(_uid);       raise NotImplementedError; end  # 冪等
+    def revoke(_uid);            raise NotImplementedError; end
+  end
+end
+```
+
+```ruby
+# app/adapters/auth/firebase_adapter.rb — Firebase 実装
+require "jwt"; require "net/http"; require "json"; require "openssl"
+
+module Auth
+  class FirebaseAdapter < Adapter
+    CERTS_URI = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com".freeze
+
+    def initialize(project_id: ENV["FIREBASE_PROJECT_ID"])
+      @project_id = project_id.to_s
+      raise Auth::Error, "FIREBASE_PROJECT_ID が未設定です" if @project_id.empty?
+    end
+
+    def verify_token(id_token)
+      decoded, _ = JWT.decode(id_token, nil, true,
+        algorithms: ["RS256"],
+        iss: "https://securetoken.google.com/#{@project_id}", verify_iss: true,
+        aud: @project_id, verify_aud: true, verify_expiration: true
+      ) { |h| public_key_for(h["kid"]) }
+      raise Auth::InvalidToken, "revoked" if revoked?(decoded["sub"], decoded["auth_time"])
+      Auth::AuthUser.new(uid: decoded["sub"], email: decoded["email"],
+                         provider: decoded.dig("firebase", "sign_in_provider"), claims: decoded)
+    rescue JWT::DecodeError, OpenSSL::X509::CertificateError => e
+      raise Auth::InvalidToken, e.message
+    end
+
+    # ... delete_user / revoke / certs は下記「運用詳細」を参照
+  end
+end
+```
+
+JWT 認可ミドルウェア（コントローラ concern）:
+
+```ruby
+# app/controllers/concerns/authenticatable.rb
+module Authenticatable
+  extend ActiveSupport::Concern
+  included { before_action :authenticate!; attr_reader :current_user, :current_auth_user }
+  private
+  def authenticate!
+    token = request.headers["Authorization"].to_s.delete_prefix("Bearer ")
+    return render(json: { error: "no token" }, status: :unauthorized) if token.blank?
+    @current_auth_user = AppAuth.adapter.verify_token(token)
+    @current_user = User.active.find_by(uid: @current_auth_user.uid)
+  rescue Auth::InvalidToken => e
+    render json: { error: e.message }, status: :unauthorized
+  end
+end
+```
+
+アダプタの選択は ENV で切替（差し替え可能設計, DP-007）:
+
+```ruby
+# config 初期化（遅延）: ENV["AUTH_ADAPTER"]=firebase|test
+module AppAuth
+  def self.adapter = @adapter ||= (ENV.fetch("AUTH_ADAPTER", Rails.env.test? ? "test" : "firebase") == "test" ? Auth::TestAdapter.new : Auth::FirebaseAdapter.new)
+end
+```
+
+## 3. 運用詳細（本番必須）
+
+### 退会時の Admin SDK ユーザー削除（冪等）
+
+```ruby
+def delete_user(uid)
+  # Identity Toolkit REST: POST /v1/projects/{pid}/accounts:delete （要 OAuth2 アクセストークン）
+  identitytoolkit_post("accounts:delete", localId: uid)
+  true
+rescue NotFoundError
+  true  # 冪等: 既に存在しない
+end
+```
+
+### 公開鍵（証明書）キャッシュ（Cache-Control 準拠）
+
+```ruby
+def certs
+  return @cache[:pem] if @cache && Time.now < @cache[:expires_at]
+  res = Net::HTTP.get_response(URI(CERTS_URI))
+  ttl = res["cache-control"].to_s[/max-age=(\d+)/, 1]&.to_i || 3600
+  @cache = { pem: JSON.parse(res.body), expires_at: Time.now + ttl }
+  @cache[:pem]
+end
+
+def public_key_for(kid)
+  pem = certs[kid] || (@cache = nil; certs[kid])  # kid 不一致は強制再取得（ローテーション追従）
+  raise Auth::InvalidToken, "unknown kid" unless pem
+  OpenSSL::X509::Certificate.new(pem).public_key
+end
+```
+
+### トークン失効 / リフレッシュ
+
+```ruby
+def revoke(uid)
+  # Identity Toolkit: validSince を現在時刻に更新 → 以後の古い ID トークンを失効扱い
+  identitytoolkit_post("accounts:update", localId: uid, validSince: Time.now.to_i.to_s)
+end
+
+def revoked?(uid, auth_time)
+  auth_time && valid_since(uid) && auth_time < valid_since(uid)
+end
+```
+
+退会・パスワード変更・MFA 変更・不正検知時に `revoke(uid)` を呼ぶ。
+
+## 4. テスト（実 Firebase 不要）
+
+`TestAdapter`（同じ契約）でトークン形式 `test|<uid>|<email>|<provider>` を検証し、結合テストを実 Firebase なしで回す（パイロットは 8 tests / 0 failures）。
+
+## 5. 既知の制約
+
+- Ruby には公式 Firebase Admin SDK が無いため、Admin 操作（削除・失効）は Identity Toolkit REST API ＋ サービスアカウントの OAuth2 アクセストークンで実装する。
+- 本番鍵が無い環境では削除/失効はスタブ化し、検証（verify_token）と証明書キャッシュのみ動作確認する。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -72,6 +72,9 @@ module Authenticatable
   extend ActiveSupport::Concern
   included { before_action :authenticate!; attr_reader :current_user, :current_auth_user }
   private
+
+  # authn: トークン検証で current_auth_user を確立する。
+  # current_user は「ローカル DB に登録済みなら」設定される（初回ログインでは nil）。
   def authenticate!
     token = request.headers["Authorization"].to_s.delete_prefix("Bearer ")
     return render(json: { error: "no token" }, status: :unauthorized) if token.blank?
@@ -80,8 +83,18 @@ module Authenticatable
   rescue Auth::InvalidToken => e
     render json: { error: e.message }, status: :unauthorized
   end
+
+  # 登録済みユーザー必須のエンドポイントで使う before_action。
+  # Firebase 認証済みでもローカル DB 未登録（current_user=nil）なら 401 で弾く。
+  # ※ セッション確立（POST /auth/session）は current_auth_user から upsert するため本ガードは付けない。
+  def require_registered_user!
+    return if @current_user
+    render json: { error: "user not found" }, status: :unauthorized
+  end
 end
 ```
+
+登録済みユーザー必須のコントローラでは `before_action :require_registered_user!` を併用する（例: `AccountController`）。セッション確立コントローラ（`SessionsController#create`）は付けず、`current_auth_user` から `User.upsert_from_auth` で作成する。
 
 アダプタの選択は ENV で切替（差し替え可能設計, DP-007）:
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -3,13 +3,14 @@
 `firebase-auth-setup` スキルの **Rails 実装レシピ**。スキル本体（SKILL.md）の「実装契約（言語非依存）」を Rails/Ruby で満たす具体コード。契約（AuthAdapter ＋ 運用契約）は変えず、実装手段だけを示す。T-022 パイロット（`~/RubymineProjects/t-021-sample/`）で実証済み。
 
 - 対象: Rails 8（API モード）/ Ruby 3.1+（Rails 8 要件、環境前提は #129）
-- 依存: `jwt`（ID トークン検証）/ Admin 操作は Identity Toolkit REST API（Ruby 公式 Admin SDK は無いため REST で代替）
+- 依存: `jwt`（ID トークン検証）・`googleauth`（Admin REST の OAuth2 アクセストークン取得）/ Admin 操作は Identity Toolkit REST API（Ruby 公式 Admin SDK は無いため REST で代替）
 
 ## 1. セットアップ
 
 ```ruby
 # Gemfile
 gem "jwt", "~> 3.2"
+gem "googleauth"   # Admin REST の OAuth2 アクセストークン取得（退会削除・失効）
 ```
 
 - Firebase プロジェクトを作成し、サービスアカウント鍵を取得。`GOOGLE_APPLICATION_CREDENTIALS`（または ENV）で渡す。**コミット禁止**（`.gitignore` / Secrets）。
@@ -59,7 +60,16 @@ module Auth
       raise Auth::InvalidToken, e.message
     end
 
-    # ... delete_user / revoke / certs は下記「運用詳細」を参照
+    # ユーザー取得（Identity Toolkit REST accounts:lookup）
+    def get_user(uid)
+      res  = identitytoolkit_post("accounts:lookup", localId: [uid])
+      user = res.dig("users", 0)
+      raise Auth::Error, "user not found" unless user
+      Auth::AuthUser.new(uid: user["localId"], email: user["email"],
+                         provider: user.dig("providerUserInfo", 0, "providerId"), claims: user)
+    end
+
+    # delete_user / revoke / certs / identitytoolkit_post は下記「運用詳細」を参照
   end
 end
 ```


### PR DESCRIPTION
## 概要

訂正バックログ **B-02 / Issue #127** に対応。T-022 パイロット発見 F-3「firebase-auth-setup スキルが初期セットアップ止まりで運用詳細が薄い」を解消するとともに、**Rails 固定だった構造を言語非依存に再設計**した（レビュー指摘）。

Closes #127

## 変更内容

### スキルを「契約（言語非依存）＋ レシピ（言語別）」に分離

```
skills/implementation/firebase-auth-setup/
├── SKILL.md          # 言語非依存: 実装契約・運用契約・手順・レシピ表・新言語の追加手順
└── references/
    └── rails.md      # Rails の具体コード（ナレッジの1インスタンス）
```

- **SKILL.md（言語非依存）**:
  - 実装契約: `AuthAdapter`（verify_token / get_user / delete_user(冪等) / revoke）
  - **運用契約（本番必須, F-3 解消）**: ①退会時の Admin SDK ユーザー削除 ②公開鍵（証明書）キャッシュ（Cache-Control 準拠・kid ローテーション追従）③トークン失効/リフレッシュ
  - 言語別レシピ表（Rails ✅ / Node ⬜ / Laravel ⬜）と **新しい言語・FW への展開手順**
  - 「契約は不変、実装手段だけがレシピごとに変わる」方針を明記
- **references/rails.md**: Ruby/Rails の具体コード（gem・FirebaseAdapter・JWT ミドルウェア・退会削除・証明書キャッシュ・失効）。パイロット実証コードがベース。Ruby に公式 Admin SDK が無い等の言語特有制約も明記。

## これで得られること

- 将来 Node/Express・Laravel へ展開する際は `references/<stack>.md` を追加するだけ。SKILL.md（契約・手順）は共通で再利用。
- Rails のナレッジは1レシピとして保持（失わない）。
- 差し替え可能設計（DP-007）の思想を「IaaS の差し替え」だけでなく「実装言語の差し替え」にも一貫適用。

## 検証

- `claude plugin validate --strict` ✅（references/ サブディレクトリ含め問題なし）

## 関連ID

- Issue #127（B-02）/ F-3 / SCH- / SKL- / DP-007 / DP-008

🤖 Generated with [Claude Code](https://claude.com/claude-code)