### PR TITLE
feat(B-03 / #130): design に責務仕分け（responsibility_split）を追加

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
@@ -39,6 +39,15 @@ domain_specific_checks:
   dAccount: false       # DP-015 非該当（docomo 連携なし）
   pci_dss: false        # DP-016 非該当（決済なし）
 
+responsibility_split:   # F-4: 機能の責務を backend/client/iaas/shared に仕分け
+  - { item: "サインイン（メール+パスワード/パスワードレス/OIDC）", owner: "client" }
+  - { item: "ID トークン検証 / JWT 認可", owner: "backend" }
+  - { item: "セッション確立（アプリ側ユーザー作成）", owner: "backend" }
+  - { item: "パスワード変更・リセット", owner: "iaas" }      # Firebase クライアント SDK で完結＝BE 対象外
+  - { item: "メールアドレス変更", owner: "iaas" }
+  - { item: "認証方式の追加（アカウント連携）", owner: "client" }
+  - { item: "退会（IaaS 削除＋アプリ側論理削除）", owner: "shared" }
+
 decision_record:
   - dp_id: "DP-007"
     chosen: "Firebase Auth"

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
@@ -27,6 +27,23 @@
 
 - IDトークン TTL / リフレッシュ方針 / 失効条件
 
+## 責務仕分け（design.schema: responsibility_split / F-4）
+
+requirements に並ぶ各機能を **backend / client / iaas / shared** に仕分ける。クライアント SDK や IaaS 側で完結する機能（パスワード変更・リセット・メール変更など）を明示し、バックエンド実装対象と取り違えないようにする。
+
+| 機能 | 担当（owner） | 補足 |
+|---|---|---|
+| サインイン（メール+パスワード / パスワードレス / OIDC） | client + iaas | Firebase クライアント SDK ＋ Firebase Auth |
+| ID トークン検証 / JWT 認可 | backend | API ミドルウェア |
+| セッション確立（アプリ側ユーザー作成） | backend | POST /auth/session |
+| パスワード変更・リセット | client + iaas | Firebase クライアント SDK で完結（**バックエンド対象外**） |
+| メールアドレス変更 | client + iaas | 同上 |
+| 認証方式の追加（アカウント連携） | client + iaas | 同上 |
+| 退会（IaaS ユーザー削除 ＋ アプリ側論理削除） | shared | Admin SDK（backend）＋ アプリ DB |
+| MFA | iaas（設定）+ client（フロー） | DP-008 の方針に従う |
+
+> owner の値: **backend**=サーバ実装 / **client**=アプリ・フロント SDK / **iaas**=Firebase 等が提供 / **shared**=両方。
+
 ## 未決（undecided）
 
 - DP-XXX: <概要>（`docs/pending-decisions.md` に起票済み）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
@@ -31,16 +31,18 @@
 
 requirements に並ぶ各機能を **backend / client / iaas / shared** に仕分ける。クライアント SDK や IaaS 側で完結する機能（パスワード変更・リセット・メール変更など）を明示し、バックエンド実装対象と取り違えないようにする。
 
+owner は **単一の enum 値**（`backend` / `client` / `iaas` / `shared`）。複合的な場合は主担当を1つ選び、内訳は「補足」列に書く（design.schema.json の `responsibility_split[].owner` と一致させる）。
+
 | 機能 | 担当（owner） | 補足 |
 |---|---|---|
-| サインイン（メール+パスワード / パスワードレス / OIDC） | client + iaas | Firebase クライアント SDK ＋ Firebase Auth |
+| サインイン（メール+パスワード / パスワードレス / OIDC） | client | クライアント SDK 主体（認証自体は IaaS=Firebase Auth が提供） |
 | ID トークン検証 / JWT 認可 | backend | API ミドルウェア |
 | セッション確立（アプリ側ユーザー作成） | backend | POST /auth/session |
-| パスワード変更・リセット | client + iaas | Firebase クライアント SDK で完結（**バックエンド対象外**） |
-| メールアドレス変更 | client + iaas | 同上 |
-| 認証方式の追加（アカウント連携） | client + iaas | 同上 |
-| 退会（IaaS ユーザー削除 ＋ アプリ側論理削除） | shared | Admin SDK（backend）＋ アプリ DB |
-| MFA | iaas（設定）+ client（フロー） | DP-008 の方針に従う |
+| パスワード変更・リセット | iaas | Firebase が提供、クライアント SDK で完結（**バックエンド対象外**） |
+| メールアドレス変更 | iaas | 同上 |
+| 認証方式の追加（アカウント連携） | client | クライアント SDK 主体（**バックエンド対象外**） |
+| 退会（IaaS ユーザー削除 ＋ アプリ側論理削除） | shared | Admin SDK（backend）＋ アプリ DB 論理削除 |
+| MFA | shared | 設定は IaaS、フローは client（DP-008 の方針に従う） |
 
 > owner の値: **backend**=サーバ実装 / **client**=アプリ・フロント SDK / **iaas**=Firebase 等が提供 / **shared**=両方。
 

--- a/ai-delivery/xtone-shared-plugin/schemas/v1/design.schema.json
+++ b/ai-delivery/xtone-shared-plugin/schemas/v1/design.schema.json
@@ -99,6 +99,19 @@
       "description": "ドメイン特有チェック（条件付き必須）。docomo規約(DP-015)/PCI-DSS(DP-016)/コミュニティ規約(DP-018) 等を true/false で明示。",
       "additionalProperties": true
     },
+    "responsibility_split": {
+      "type": "array",
+      "description": "責務仕分け（条件付き必須・F-4）。各機能を backend/client/iaas/shared に仕分ける。クライアント SDK や IaaS 側で完結する機能（例: パスワード変更・リセット・メール変更）を明示し、実装者の混乱を防ぐ。",
+      "items": {
+        "type": "object",
+        "required": ["item", "owner"],
+        "properties": {
+          "item": { "type": "string" },
+          "owner": { "type": "string", "enum": ["backend", "client", "iaas", "shared"] }
+        },
+        "additionalProperties": true
+      }
+    },
     "decision_record": {
       "type": "array",
       "description": "本フェーズで下した判断の記録（追加保持）。各要素は decision-point.schema.json の decision_record に準拠。",


### PR DESCRIPTION
## 概要

訂正バックログ **B-03 / Issue #130** に対応。T-022 パイロット発見 F-4「パスワード変更・リセット・メール変更は Firebase クライアント SDK 側で完結＝バックエンド対象外だが、requirements には機能として並ぶ。design で仕分けが明示されないと実装者が混乱」を解消する。

Single Source of Truth を保ち、**FLD DB → design.schema → テンプレ → サンプル**の順で整合させた。

Closes #130

## 変更内容

- **FLD DB（Notion, 本PRと同時）**: design.schema 用に `responsibility_split` フィールドを新規追加（条件付き必須・owner enum: backend/client/iaas/shared、F-4 由来）
- **`design.schema.json`**: `responsibility_split`（array of `{item, owner}`、owner enum）を実装
- **`auth-section.template.md`**: 「責務仕分け」表を追加（各認証機能 → backend/client/iaas/shared。パスワード変更等は「バックエンド対象外」と明記）
- **`sample-outputs/design.yaml`**: 「みんなの読書会」の responsibility_split 例を追加

## 責務 owner の定義

- **backend** = サーバ実装（Rails API） / **client** = アプリ・フロント SDK / **iaas** = Firebase 等が提供 / **shared** = 両方

## 検証（実測）

- `design.schema.json` draft-07 メタ検証 ✅
- `design.yaml`（responsibility_split 含む）スキーマ準拠 ✅
- ネガティブテスト: 不正 owner（`frontend`）・owner 欠落を正しく検出 ✅
- `claude plugin validate --strict` 回帰なし ✅

## 関連ID

- Issue #130（B-03）/ F-4 / FLD- / SKL- / T-022

🤖 Generated with [Claude Code](https://claude.com/claude-code)