### PR TITLE
feat(B-10 / #141): フロントエンド認証実装スキル（Hotwire / Next.js）

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
@@ -15,6 +15,7 @@ T-022 内部パイロット（[pilot-report.md](./pilot-report.md)）で発見�
 | **B-07** | [#132](https://github.com/xtone/ai_development_tools/issues/132) | Tooling | Med | `validate-plugin.sh`（TPL-27）/ `generate-plugin.sh`（TPL-26）の整備。delivery 成果物の **スキーマ検証**を自動化 | TPL-26/27 | F-6 |
 | **B-08** | [#133](https://github.com/xtone/ai_development_tools/issues/133) | Decision | Low | 新規 DP「**退会済みアカウントの再登録ポリシー**」を判断ポイントカタログに起票（本実装は 403 拒否で仮対応）。pending-decisions に起票済み | DP（新規候補）| F-7 |
 | **B-09** | [#134](https://github.com/xtone/ai_development_tools/issues/134) | Plugin（任意） | Low | **言語別の実装テンプレ**（例: Rails 向け AuthAdapter コード雛形）をスキルに同梱し実装を加速 | SKL- | F-8 |
+| **B-10** | [#141](https://github.com/xtone/ai_development_tools/issues/141) | Architecture | Med | **フロントエンド認証実装スキル新設**（`firebase-auth-frontend` ＋ hotwire/nextjs レシピ）。#130 で責務分類した `client` 側の実装ガイドが欠落（firebase-auth-setup は backend 専用）。セッション戦略は判断ポイント扱い | SKL- / #130 | #130 レビュー後 |
 
 ## 優先度の考え方
 

--- a/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
@@ -38,10 +38,17 @@ claude plugin validate --strict plugins/xtone-auth-plugin
 | フェーズ | コマンド | 出力スキーマ |
 |---|---|---|
 | 要件定義 | `/req-collect` | `schemas/requirements.schema.json` |
-| 設計 | `/auth-design` | `schemas/design.schema.json`（+ `docs/adr/ADR-NNN.md`） |
+| 設計 | `/auth-design` | `schemas/design.schema.json`（+ `docs/adr/ADR-NNN.md`、`responsibility_split` で BE/FE 仕分け） |
 | 実装 | `/implement` | `schemas/implementation-plan.schema.json` + 実装コード |
 
 `schemas/` は xtone-shared-plugin への symlink（編集不可, CONV-14）。
+
+### 実装スキル（責務で使い分け）
+
+`design` の `responsibility_split` に応じて、バックエンド／フロントエンドの実装スキルを使い分ける:
+
+- **backend**: [`firebase-auth-setup`](../skills/implementation/firebase-auth-setup/SKILL.md) — ID トークン検証・JWT 認可・退会時 Admin SDK 削除（レシピ: Rails）
+- **client（フロント）**: [`firebase-auth-frontend`](../skills/implementation/firebase-auth-frontend/SKILL.md) — サインインUI・パスワード/メール変更・トークン保持・API への Bearer 付与（レシピ: Hotwire / Next.js）
 
 ## 4. 判断ポイント（人間判断をスルーさせない）
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: firebase-auth-frontend
+description: Firebase Auth をフロントエンド（クライアント）に統合するスキル。実装フェーズで、サインイン（メール/パスワードレス/OIDC）・パスワード変更/リセット・メール変更・トークン保持と API への Bearer 付与・セッション復元を実装したいときに使う。言語/FW 非依存の AuthClient 契約を定義し、具体コードは references/（Hotwire / Next.js）に分離。バックエンド側は firebase-auth-setup を参照。
+---
+
+# Firebase Auth Frontend Skill
+
+> SKL-12: `description` は Claude が Skill を選ぶための主要判断材料。3要素（何を / いつ / どんな条件で）を含む。
+
+## 概要
+
+`design.schema.json` の認証設計のうち、`responsibility_split` で **`client`** に仕分けた機能をフロントエンドに実装する。本スキルは **言語/FW 非依存の AuthClient 契約**を定義し、具体コードは `references/<stack>.md` に分離する（バックエンドの [`firebase-auth-setup`](../firebase-auth-setup/SKILL.md) と対の構造）。
+
+> 役割分担: **Firebase クライアント SDK** が認証フロー（サインイン・パスワード/メール変更等）を担い、**サーバ（firebase-auth-setup）** は ID トークンの検証のみ。フロントは取得した ID トークンを API に Bearer で渡す。
+
+## 入出力（スキーマ）
+
+- 入力: `schemas/design.schema.json`（`authentication` / `responsibility_split` の client 項目 / セッション戦略）
+- 出力: フロント実装コード + `schemas/implementation-plan.schema.json`
+
+スキーマは編集しない（CONV-14）。
+
+## 言語・フレームワーク別レシピ
+
+| FW | レシピ | 状態 |
+|---|---|---|
+| Ruby on Rails + Hotwire | [`references/hotwire.md`](./references/hotwire.md) | ✅ |
+| Next.js | [`references/nextjs.md`](./references/nextjs.md) | ✅ |
+| その他（Vue / Flutter 等） | — | 追加可（rails 同様に契約を満たす） |
+
+## 実装契約（FW 非依存）— AuthClient
+
+| メソッド | 契約 | responsibility |
+|---|---|---|
+| `signInWithPassword(email, pw)` | メール+パスワードでサインイン | client + iaas |
+| `signInWithEmailLink(email)` / `completeEmailLink()` | パスワードレス（メールリンク） | client + iaas |
+| `signInWithOIDC(provider)` | Google / Apple 等 | client + iaas |
+| `linkProvider(provider)` | 認証方式の追加（UC-A04） | client |
+| `sendPasswordReset(email)` / `updatePassword(new)` | パスワードリセット / 変更 | iaas（Firebase が完結） |
+| `updateEmail(new)` | メールアドレス変更 | iaas |
+| `signOut()` | サインアウト（ローカルのトークン破棄） | client |
+| `getIdToken({forceRefresh})` | API 呼び出し用 ID トークン取得（期限切れは自動リフレッシュ） | client |
+| `onAuthStateChanged(cb)` | セッション復元・認証状態の購読 | client |
+| `withdraw()` | 退会トリガ。サーバの `DELETE /account` を呼ぶ（IaaS 削除は backend） | shared |
+
+アプリは `AuthClient` 越しに Firebase を呼ぶ。API 呼び出しには `getIdToken()` の Bearer を付け、サーバ（firebase-auth-setup）が検証する。
+
+## バックエンド連携（firebase-auth-setup と対）
+
+- ログイン後: `getIdToken()` → `POST /auth/session`（サーバがユーザーを upsert）
+- API: `Authorization: Bearer <idToken>`（サーバが検証）
+- 退会: `DELETE /account`（サーバが論理削除 ＋ Admin SDK で IaaS 削除）
+- `responsibility_split`: **client = 本スキル / backend = firebase-auth-setup / iaas = Firebase が提供**
+
+## 判断ポイント（人間判断をスルーさせない / DP相当）
+
+セッション戦略は AI が決めず推奨だけ提示する:
+
+- **トークン保持**: メモリ保持＋自動リフレッシュ（推奨。XSS 配慮で `localStorage` を避ける）/ Rails のクッキーセッションに載せ替え（SSR 主体なら有力）
+- **Next.js の経路**: クライアントから Rails API へ直接 Bearer / BFF（Next.js Route Handler 経由でトークンを秘匿）
+
+決められない場合は `undecided` と `docs/pending-decisions.md` に残す（T-002 warn_and_document）。
+
+## 手順
+
+1. design の `responsibility_split` から `client` 項目を確認する。
+2. 採用 FW のレシピ（`references/<stack>.md`）を開く。無ければ追加。
+3. `AuthClient` 契約を実装する。
+4. ログイン → `POST /auth/session`、API への Bearer 付与、`onAuthStateChanged` でセッション復元を実装する。
+5. セッション戦略を人間に確認する（DP）。
+6. 実装タスク・依存・テスト方針を `implementation-plan.schema.json` に記録する。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -59,7 +59,7 @@ export const AuthClient = {
   getIdToken: (force = false) => auth.currentUser ? auth.currentUser.getIdToken(force) : Promise.resolve(null),  // 期限切れは自動リフレッシュ
   onAuthStateChanged: (cb) => onAuthStateChanged(auth, cb),
   withdraw: async () => {                                                // 退会（responsibility=shared）
-    const idToken = await auth.currentUser?.getIdToken(true)
+    const idToken = auth.currentUser ? await auth.currentUser.getIdToken(true) : null
     await fetch("/account", { method: "DELETE", headers: { Authorization: `Bearer ${idToken}` } })
     return signOut(auth)                                                 // サーバが論理削除＋Admin SDK 削除
   },

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -38,6 +38,15 @@ setPersistence(auth, inMemoryPersistence)
 
 export const AuthClient = {
   signInWithPassword: (email, pw) => signInWithEmailAndPassword(auth, email, pw),
+  signInWithEmailLink: (email) => sendSignInLinkToEmail(auth, email, {
+    url: window.location.origin + "/auth/email-link",   // ActionCodeSettings — 要件に合わせて変更
+    handleCodeInApp: true,
+  }),                                                    // 送信時に email を保存しておく（completeEmailLink で参照）
+  completeEmailLink: () => {
+    if (!isSignInWithEmailLink(auth, window.location.href)) return Promise.reject(new Error("invalid link"))
+    const email = window.localStorage.getItem("emailForSignIn")   // 送信時に保存した email
+    return signInWithEmailLink(auth, email, window.location.href)
+  },
   signInWithOIDC: (id) => signInWithPopup(auth, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
   linkProvider: (id) => linkWithPopup(auth.currentUser, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
   sendPasswordReset: (email) => sendPasswordResetEmail(auth, email),     // Firebase が完結（iaas）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -1,0 +1,98 @@
+# フロント認証レシピ: Rails + Hotwire
+
+`firebase-auth-frontend` スキルの **Rails + Hotwire 実装レシピ**。SKILL.md の AuthClient 契約を、Rails 内のフロント（Hotwire / Stimulus ＋ Firebase JS SDK）で満たす。バックエンド（ID トークン検証・/auth/session）は [`../../firebase-auth-setup/references/rails.md`](../../firebase-auth-setup/references/rails.md)。
+
+- 対象: Rails（Hotwire 同梱）/ Firebase JS SDK — **いずれも公式の最新安定版**（バージョン方針は `ai-delivery/docs/environment-setup.md`）
+- 構成: サーバ HTML（Turbo）＋ Stimulus コントローラで Firebase JS SDK を呼ぶ。認証フローはブラウザ（client）、トークン検証は Rails（backend）。
+
+## 1. Firebase JS SDK の導入
+
+importmap（Rails 標準）の例:
+
+```ruby
+# config/importmap.rb
+pin "firebase/app", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-app.js"
+pin "firebase/auth", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-auth.js"
+```
+
+> `<latest>` は固定値でなく公式の最新安定版を使う（environment-setup.md）。esbuild/jsbundling を使う場合は `npm i firebase`。Firebase の Web 設定値（apiKey 等）は公開前提の値だが、`config/credentials` か ENV から埋め込む。
+
+## 2. AuthClient（契約の実装）
+
+```javascript
+// app/javascript/auth/client.js
+import { initializeApp } from "firebase/app"
+import {
+  getAuth, signInWithEmailAndPassword, sendSignInLinkToEmail, isSignInWithEmailLink,
+  signInWithEmailLink, GoogleAuthProvider, OAuthProvider, signInWithPopup, linkWithPopup,
+  sendPasswordResetEmail, updatePassword, updateEmail, signOut, onAuthStateChanged
+} from "firebase/auth"
+
+const auth = getAuth(initializeApp(window.FIREBASE_CONFIG))
+
+export const AuthClient = {
+  signInWithPassword: (email, pw) => signInWithEmailAndPassword(auth, email, pw),
+  signInWithOIDC: (id) => signInWithPopup(auth, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
+  linkProvider: (id) => linkWithPopup(auth.currentUser, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
+  sendPasswordReset: (email) => sendPasswordResetEmail(auth, email),     // Firebase が完結（iaas）
+  updatePassword: (pw) => updatePassword(auth.currentUser, pw),
+  updateEmail: (email) => updateEmail(auth.currentUser, email),
+  signOut: () => signOut(auth),
+  getIdToken: (force = false) => auth.currentUser?.getIdToken(force),    // 期限切れは自動リフレッシュ
+  onAuthStateChanged: (cb) => onAuthStateChanged(auth, cb),
+}
+```
+
+## 3. Stimulus コントローラ（サインイン → /auth/session）
+
+```javascript
+// app/javascript/controllers/auth_controller.js
+import { Controller } from "@hotwired/stimulus"
+import { AuthClient } from "auth/client"
+
+export default class extends Controller {
+  static targets = ["email", "password"]
+
+  async signIn(e) {
+    e.preventDefault()
+    await AuthClient.signInWithPassword(this.emailTarget.value, this.passwordTarget.value)
+    await this.establishSession()
+  }
+
+  async establishSession() {
+    const idToken = await AuthClient.getIdToken(true)
+    await fetch("/auth/session", {
+      method: "POST",
+      headers: { "Authorization": `Bearer ${idToken}`, "X-CSRF-Token": this.csrf() },
+    })
+    Turbo.visit("/")   // ログイン後の遷移
+  }
+
+  csrf() { return document.querySelector("meta[name='csrf-token']")?.content }
+}
+```
+
+API を叩く場合は `getIdToken()` を取得して `Authorization: Bearer` を付ける。サーバ側の検証は firebase-auth-setup/rails.md。
+
+## 4. セッション戦略（判断ポイント）
+
+| 戦略 | 概要 | 向き |
+|---|---|---|
+| **A. Bearer 都度付与（推奨・SPA寄り）** | ID トークンをメモリ保持し、API 毎に `getIdToken()` で Bearer 付与。サーバはステートレス検証 | Turbo/Stimulus で API を叩く構成 |
+| **B. クッキーセッション（SSR寄り）** | `/auth/session` で ID トークン検証後、Rails のセッションクッキーにログイン状態を載せる。以後は Rails セッションで認可 | サーバ HTML 主体・Turbo Drive 中心 |
+
+SSR 主体の Hotwire では **B** が素直なことが多い。**どちらにするかは人間判断**（`firebase-auth-frontend` の判断ポイント参照）。B の場合、サーバ側は検証済み uid をセッションに保存し、ログアウトでセッション破棄。
+
+## 5. セッション復元
+
+```javascript
+AuthClient.onAuthStateChanged((user) => {
+  // リロード時: user があれば establishSession() 済み状態を反映、無ければログイン導線を表示
+})
+```
+
+## 6. 既知の制約 / 注意
+
+- Firebase JS SDK はブラウザ実行。`localStorage` ではなくメモリ保持 ＋ リフレッシュを既定にし、XSS リスクを下げる（戦略 A）。
+- パスワード変更・リセット・メール変更は Firebase JS SDK で完結し **Rails 実装不要**（responsibility=iaas）。
+- 退会はフロントから `DELETE /account` を呼び、サーバが論理削除＋Admin SDK 削除を行う（responsibility=shared）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -38,10 +38,13 @@ setPersistence(auth, inMemoryPersistence)
 
 export const AuthClient = {
   signInWithPassword: (email, pw) => signInWithEmailAndPassword(auth, email, pw),
-  signInWithEmailLink: (email) => sendSignInLinkToEmail(auth, email, {
-    url: window.location.origin + "/auth/email-link",   // ActionCodeSettings — 要件に合わせて変更
-    handleCodeInApp: true,
-  }),                                                    // 送信時に email を保存しておく（completeEmailLink で参照）
+  signInWithEmailLink: (email) => {
+    window.localStorage.setItem("emailForSignIn", email)  // completeEmailLink で参照
+    return sendSignInLinkToEmail(auth, email, {
+      url: window.location.origin + "/auth/email-link",   // ActionCodeSettings — 要件に合わせて変更
+      handleCodeInApp: true,
+    })
+  },
   completeEmailLink: () => {
     if (!isSignInWithEmailLink(auth, window.location.href)) return Promise.reject(new Error("invalid link"))
     const email = window.localStorage.getItem("emailForSignIn")   // 送信時に保存した email
@@ -53,7 +56,7 @@ export const AuthClient = {
   updatePassword: (pw) => updatePassword(auth.currentUser, pw),
   updateEmail: (email) => updateEmail(auth.currentUser, email),
   signOut: () => signOut(auth),
-  getIdToken: (force = false) => auth.currentUser?.getIdToken(force),    // 期限切れは自動リフレッシュ
+  getIdToken: (force = false) => auth.currentUser ? auth.currentUser.getIdToken(force) : Promise.resolve(null),  // 期限切れは自動リフレッシュ
   onAuthStateChanged: (cb) => onAuthStateChanged(auth, cb),
   withdraw: async () => {                                                // 退会（responsibility=shared）
     const idToken = await auth.currentUser?.getIdToken(true)

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -23,12 +23,18 @@ pin "firebase/auth", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-a
 // app/javascript/auth/client.js
 import { initializeApp } from "firebase/app"
 import {
-  getAuth, signInWithEmailAndPassword, sendSignInLinkToEmail, isSignInWithEmailLink,
+  getAuth, setPersistence, inMemoryPersistence,
+  signInWithEmailAndPassword, sendSignInLinkToEmail, isSignInWithEmailLink,
   signInWithEmailLink, GoogleAuthProvider, OAuthProvider, signInWithPopup, linkWithPopup,
   sendPasswordResetEmail, updatePassword, updateEmail, signOut, onAuthStateChanged
 } from "firebase/auth"
 
 const auth = getAuth(initializeApp(window.FIREBASE_CONFIG))
+
+// XSS 配慮: トークンをメモリのみに保持（Firebase 既定の localStorage/indexedDB を使わない）。
+// 注意: リロードでセッションが切れるため、戦略B（クッキーセッション）と併用するか SSR でログイン状態を保持する（下記「セッション戦略」）。
+// 戦略B 採用時は browserSessionPersistence も選択肢。
+setPersistence(auth, inMemoryPersistence)
 
 export const AuthClient = {
   signInWithPassword: (email, pw) => signInWithEmailAndPassword(auth, email, pw),
@@ -40,6 +46,11 @@ export const AuthClient = {
   signOut: () => signOut(auth),
   getIdToken: (force = false) => auth.currentUser?.getIdToken(force),    // 期限切れは自動リフレッシュ
   onAuthStateChanged: (cb) => onAuthStateChanged(auth, cb),
+  withdraw: async () => {                                                // 退会（responsibility=shared）
+    const idToken = await auth.currentUser?.getIdToken(true)
+    await fetch("/account", { method: "DELETE", headers: { Authorization: `Bearer ${idToken}` } })
+    return signOut(auth)                                                 // サーバが論理削除＋Admin SDK 削除
+  },
 }
 ```
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
@@ -1,0 +1,88 @@
+# フロント認証レシピ: Next.js
+
+`firebase-auth-frontend` スキルの **Next.js 実装レシピ**。SKILL.md の AuthClient 契約を Next.js（App Router）＋ Firebase JS SDK で満たす。バックエンド（ID トークン検証・/auth/session）は Rails の [`../../firebase-auth-setup/references/rails.md`](../../firebase-auth-setup/references/rails.md)（または同契約の任意 backend）。
+
+- 対象: Next.js（App Router）/ Firebase JS SDK — **いずれも公式の最新安定版**（バージョン方針は `ai-delivery/docs/environment-setup.md`）
+- 構成: Firebase JS SDK で認証（client）、ID トークンを Rails API へ Bearer。Rails API のオリジンは `NEXT_PUBLIC_API_BASE`。
+
+## 1. セットアップ
+
+```bash
+npm i firebase
+```
+
+```ts
+// lib/firebase.ts  ('use client' から利用)
+import { initializeApp, getApps } from "firebase/app"
+import { getAuth } from "firebase/auth"
+const app = getApps()[0] ?? initializeApp({ /* NEXT_PUBLIC_FIREBASE_* から */ })
+export const auth = getAuth(app)
+```
+
+> Firebase の Web 設定（apiKey 等）は `NEXT_PUBLIC_FIREBASE_*` で渡す（公開前提値）。サービスアカウント鍵は **フロントに置かない**（backend のみ）。
+
+## 2. AuthClient（契約の実装）
+
+```ts
+// lib/auth-client.ts  ('use client')
+import { auth } from "./firebase"
+import {
+  signInWithEmailAndPassword, GoogleAuthProvider, OAuthProvider, signInWithPopup, linkWithPopup,
+  sendPasswordResetEmail, updatePassword, updateEmail, signOut, onAuthStateChanged, getIdToken
+} from "firebase/auth"
+
+export const AuthClient = {
+  signInWithPassword: (e: string, p: string) => signInWithEmailAndPassword(auth, e, p),
+  signInWithOIDC: (id: "google" | "apple") =>
+    signInWithPopup(auth, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
+  linkProvider: (id: "google" | "apple") =>
+    linkWithPopup(auth.currentUser!, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
+  sendPasswordReset: (e: string) => sendPasswordResetEmail(auth, e),   // Firebase が完結（iaas）
+  updatePassword: (p: string) => updatePassword(auth.currentUser!, p),
+  updateEmail: (e: string) => updateEmail(auth.currentUser!, e),
+  signOut: () => signOut(auth),
+  getIdToken: (force = false) => (auth.currentUser ? getIdToken(auth.currentUser, force) : Promise.resolve(null)),
+  onAuthStateChanged: (cb: Parameters<typeof onAuthStateChanged>[1]) => onAuthStateChanged(auth, cb),
+}
+```
+
+## 3. ログイン → バックエンド連携
+
+```tsx
+// app/(auth)/login/page.tsx  ('use client')
+"use client"
+import { AuthClient } from "@/lib/auth-client"
+
+async function establishSession() {
+  const idToken = await AuthClient.getIdToken(true)
+  await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/session`, {
+    method: "POST",
+    headers: { Authorization: `Bearer ${idToken}` },
+  })
+}
+```
+
+API 呼び出しは `getIdToken()` の Bearer を付ける（サーバが検証）。`onAuthStateChanged` でリロード時のセッション復元を行う。
+
+## 4. 経路の選択（判断ポイント）
+
+| 経路 | 概要 | トレードオフ |
+|---|---|---|
+| **A. クライアント → Rails API 直接 Bearer（推奨・シンプル）** | ブラウザの Firebase JS SDK で取得した ID トークンを Rails API に Bearer 送信 | CORS 設定が要る。トークンはブラウザが保持 |
+| **B. BFF（Next.js Route Handler 経由）** | `app/api/*/route.ts` をプロキシにし、トークンを HttpOnly クッキー等でサーバ側に秘匿 | トークン秘匿性が上がるが実装増。SSR/RSC で認可したい場合に有力 |
+
+**どちらにするかは人間判断**（`firebase-auth-frontend` の判断ポイント）。SSR/RSC で保護ページを出すなら B（ミドルウェアでクッキー検証）が向く。
+
+```ts
+// 例: B の保護（middleware.ts）— BFF が設定した検証済みクッキーを確認
+export function middleware(req: NextRequest) {
+  if (!req.cookies.get("session")) return NextResponse.redirect(new URL("/login", req.url))
+}
+```
+
+## 5. 既知の制約 / 注意
+
+- ID トークンはメモリ保持＋リフレッシュを既定にし、`localStorage` を避ける（XSS 配慮）。BFF 採用時は HttpOnly クッキー。
+- パスワード変更・リセット・メール変更は Firebase JS SDK で完結し **backend 実装不要**（responsibility=iaas）。
+- 退会はフロントから `DELETE /account` を呼び、backend が論理削除＋Admin SDK 削除（responsibility=shared）。
+- サービスアカウント鍵・Admin 操作は **フロントに置かない**（backend のみ）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
@@ -14,9 +14,13 @@ npm i firebase
 ```ts
 // lib/firebase.ts  ('use client' から利用)
 import { initializeApp, getApps } from "firebase/app"
-import { getAuth } from "firebase/auth"
+import { getAuth, setPersistence, inMemoryPersistence } from "firebase/auth"
 const app = getApps()[0] ?? initializeApp({ /* NEXT_PUBLIC_FIREBASE_* から */ })
 export const auth = getAuth(app)
+
+// XSS 配慮: トークンをメモリのみに保持（Firebase 既定の localStorage/indexedDB を使わない）。
+// 注意: リロードでセッションが切れる。BFF（経路B）で HttpOnly クッキーを使う場合は browserSessionPersistence も検討。
+setPersistence(auth, inMemoryPersistence)
 ```
 
 > Firebase の Web 設定（apiKey 等）は `NEXT_PUBLIC_FIREBASE_*` で渡す（公開前提値）。サービスアカウント鍵は **フロントに置かない**（backend のみ）。
@@ -43,6 +47,13 @@ export const AuthClient = {
   signOut: () => signOut(auth),
   getIdToken: (force = false) => (auth.currentUser ? getIdToken(auth.currentUser, force) : Promise.resolve(null)),
   onAuthStateChanged: (cb: Parameters<typeof onAuthStateChanged>[1]) => onAuthStateChanged(auth, cb),
+  withdraw: async () => {                                              // 退会（responsibility=shared）
+    const idToken = auth.currentUser ? await getIdToken(auth.currentUser, true) : null
+    await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/account`, {
+      method: "DELETE", headers: { Authorization: `Bearer ${idToken}` },
+    })
+    return signOut(auth)                                              // サーバが論理削除＋Admin SDK 削除
+  },
 }
 ```
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
@@ -25,18 +25,37 @@ setPersistence(auth, inMemoryPersistence)
 
 > Firebase の Web 設定（apiKey 等）は `NEXT_PUBLIC_FIREBASE_*` で渡す（公開前提値）。サービスアカウント鍵は **フロントに置かない**（backend のみ）。
 
+```bash
+# .env.local（例。値は Firebase コンソールの Web アプリ設定から）
+NEXT_PUBLIC_FIREBASE_API_KEY=...
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=<project>.firebaseapp.com
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=<project>
+NEXT_PUBLIC_FIREBASE_APP_ID=...
+NEXT_PUBLIC_API_BASE=http://localhost:3000   # Rails API のオリジン
+```
+
 ## 2. AuthClient（契約の実装）
 
 ```ts
 // lib/auth-client.ts  ('use client')
 import { auth } from "./firebase"
 import {
-  signInWithEmailAndPassword, GoogleAuthProvider, OAuthProvider, signInWithPopup, linkWithPopup,
+  signInWithEmailAndPassword, sendSignInLinkToEmail, isSignInWithEmailLink, signInWithEmailLink,
+  GoogleAuthProvider, OAuthProvider, signInWithPopup, linkWithPopup,
   sendPasswordResetEmail, updatePassword, updateEmail, signOut, onAuthStateChanged, getIdToken
 } from "firebase/auth"
 
 export const AuthClient = {
   signInWithPassword: (e: string, p: string) => signInWithEmailAndPassword(auth, e, p),
+  signInWithEmailLink: (email: string) => sendSignInLinkToEmail(auth, email, {
+    url: `${window.location.origin}/auth/email-link`,   // ActionCodeSettings — 要件に合わせて変更
+    handleCodeInApp: true,
+  }),
+  completeEmailLink: () => {
+    if (!isSignInWithEmailLink(auth, window.location.href)) return Promise.reject(new Error("invalid link"))
+    const email = window.localStorage.getItem("emailForSignIn")   // 送信時に保存した email
+    return signInWithEmailLink(auth, email!, window.location.href)
+  },
   signInWithOIDC: (id: "google" | "apple") =>
     signInWithPopup(auth, id === "apple" ? new OAuthProvider("apple.com") : new GoogleAuthProvider()),
   linkProvider: (id: "google" | "apple") =>

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
@@ -47,10 +47,13 @@ import {
 
 export const AuthClient = {
   signInWithPassword: (e: string, p: string) => signInWithEmailAndPassword(auth, e, p),
-  signInWithEmailLink: (email: string) => sendSignInLinkToEmail(auth, email, {
-    url: `${window.location.origin}/auth/email-link`,   // ActionCodeSettings — 要件に合わせて変更
-    handleCodeInApp: true,
-  }),
+  signInWithEmailLink: (email: string) => {
+    window.localStorage.setItem("emailForSignIn", email)  // completeEmailLink で参照
+    return sendSignInLinkToEmail(auth, email, {
+      url: `${window.location.origin}/auth/email-link`,   // ActionCodeSettings — 要件に合わせて変更
+      handleCodeInApp: true,
+    })
+  },
   completeEmailLink: () => {
     if (!isSignInWithEmailLink(auth, window.location.href)) return Promise.reject(new Error("invalid link"))
     const email = window.localStorage.getItem("emailForSignIn")   // 送信時に保存した email

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
@@ -13,6 +13,8 @@ description: Firebase Auth を任意のバックエンドに統合するスキ�
 
 > 設計方針: 言語が変わっても **契約は不変**、実装手段（SDK/コード）だけがレシピごとに変わる。Rails 固定にせず、Node/Laravel 等へ展開できる構造にする。
 
+> **スコープ: バックエンド（サーバ）専用。** ID トークン検証・JWT 認可・退会時の Admin SDK 削除・トークン失効など。フロントエンド（サインインUI・パスワード/メール変更・トークン保持・API への Bearer 付与）は対の [`firebase-auth-frontend`](../firebase-auth-frontend/SKILL.md) を参照。`responsibility_split` の **backend = 本スキル / client = firebase-auth-frontend / iaas = Firebase が提供**。
+
 ## 入出力（スキーマ）
 
 - 入力: `schemas/design.schema.json`（`authentication.stack` / `architecture.stack` / decision_record）


### PR DESCRIPTION
## 概要

訂正バックログ **B-10 / Issue #141** に対応。#130 で design に `responsibility_split`（backend/client/iaas）を追加したが、**client（フロントエンド）担当の実装スキルが存在しなかった**（firebase-auth-setup は backend 専用）。責務を分類したのにフロント側のガイドが欠落していた問題を解消する。

backend スキルと同じ「**言語/FW 非依存の契約 ＋ 言語別レシピ**」構造で、フロント実装スキルを新設。フロントのパターンとして **Rails + Hotwire** と **Next.js** をカバー。

Closes #141

## 変更内容

### 新規スキル `firebase-auth-frontend`
```
skills/implementation/firebase-auth-frontend/
├── SKILL.md          # 言語非依存の AuthClient 契約
└── references/
    ├── hotwire.md    # Rails + Hotwire（Firebase JS SDK + Stimulus）
    └── nextjs.md     # Next.js（Firebase JS SDK + App Router）
```
- **SKILL.md**: `AuthClient` 契約（signIn 各種 / linkProvider / パスワード・メール変更 / getIdToken / onAuthStateChanged / withdraw）、バックエンド連携（`POST /auth/session`・`Bearer`）、`responsibility_split` との対応（client=本スキル / backend=firebase-auth-setup / iaas=Firebase）
- **hotwire.md**: importmap で Firebase JS SDK、Stimulus で サインイン→`/auth/session`
- **nextjs.md**: App Router で Firebase JS SDK、Rails API へ Bearer

### 判断ポイント（DP相当）として明示
- **トークン保持**: メモリ＋リフレッシュ（推奨, XSS 配慮）vs Rails クッキーセッション
- **Next.js 経路**: クライアント→Rails API へ直接 Bearer vs BFF（Route Handler 経由）
- → 各レシピで「推奨提示・最終決定は人間」（warn_and_document）

### 既存への反映
- `firebase-auth-setup` を **backend 専用**と明確化し、フロント↔バックエンドを相互リンク
- `usage-guide.md` に「実装スキルを責務（backend / client）で使い分け」を追記
- `backlog.md` に B-10 を追記

## 検証

- `claude plugin validate --strict` ✅（references/ 含め問題なし）

## 関連ID

- Issue #141（B-10）/ #130（responsibility_split）/ DP-007 / DP-008 / SKL-

🤖 Generated with [Claude Code](https://claude.com/claude-code)