### PR TITLE
feat(T-021): ローカル検証スキル firebase-auth-emulator を新設

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/auth-plugin-guide/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/auth-plugin-guide/SKILL.md
@@ -51,6 +51,8 @@ AI はこれらを **勝手に決めず推奨だけ提示**し、未決は `unde
 
 > DP-008 で MFA 方針が決まったら、実装は専用スキル `firebase-auth-mfa`（TOTP/SMS の登録・追加認証＝client、クレーム検証・管理者強制・失効＝backend）に従う。
 
+> **ローカル検証**（実 Firebase 無しで E2E）は `firebase-auth-emulator` を使う。Docker で Auth Emulator を起動し、署名検証スキップ・`connectAuthEmulator`・SMS MFA で E2E まで可能。**TOTP はエミュレーター非対応**のため、TOTP の E2E は実 Identity Platform で行う前提を案件 ADR に明記する。
+
 ## 構成
 
 | ディレクトリ | 内容 |

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: firebase-auth-emulator
+description: Firebase Auth Emulator を Docker で起動し、認証フローをローカルで E2E 検証するスキル。実装フェーズで、firebase-auth-setup(backend) / firebase-auth-frontend(client) / firebase-auth-mfa(横断) の実装を実 Firebase 無しで起動・確認したいときに使う。基本フロー（メール+PW / パスワードレス / 退会 / ロール認可）と **SMS(phone) MFA** は対応、**TOTP MFA は非対応**（firebase-tools #6224）。署名検証スキップ・Admin REST のエミュレーター切替・connectAuthEmulator・SMS コード取得 REST を言語非依存の契約として定義し、具体コードは references/（docker-compose / rails / nextjs）に分離。
+---
+
+# Firebase Auth Emulator Skill
+
+> SKL-12: `description` は Claude が Skill を選ぶための主要判断材料。3要素（何を / いつ / どんな条件で）を含む。
+
+## 概要
+
+Firebase Auth Emulator を Docker で起動して、`firebase-auth-setup`（backend）／`firebase-auth-frontend`（client）／`firebase-auth-mfa`（横断）の実装を **実 Firebase / Identity Platform 無しで E2E 検証**するためのスキル。backend/client/emulator にまたがる横断トピックなので、既存スキルの片方には収まらず本スキルに集約する（`firebase-auth-mfa` と同じ論理）。
+
+> **本番ではない**: 本スキルは「ローカル検証専用」。本番は実 Firebase Auth（MFA は Identity Platform）を使う。スキルが定義する署名検証スキップや `Bearer owner` は **本番経路では絶対に有効化しない**。
+
+## スコープと既知の制約
+
+| 項目 | エミュレーター対応 | 検証方針 |
+|---|---|---|
+| メール+PW サインイン / パスワードレス | ✅ | エミュレーターで E2E |
+| 退会（Admin 削除）/ トークン失効 / Bearer 認可 | ✅ | エミュレーターで E2E |
+| **SMS(phone) MFA**（enrollment / challenge） | ✅ | エミュレーターで E2E。SMS コードはターミナル / REST で取得 |
+| **TOTP MFA** | ❌ **非対応**（[firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)） | **実 Identity Platform** で検証。設計が TOTP 主体でも、ローカル検証は SMS で代替する |
+| Phone Auth の reCAPTCHA / APN / Console のテスト電話番号 | ❌ | エミュレーター内ではスキップ可能（コードはターミナル出力） |
+| ID トークンの署名 | **unsigned**（alg=none 相当） | backend は **EMULATOR_HOST 検出時に署名検証をスキップ**（iss/aud/exp/sub は手動検証） |
+
+> design の `authentication.mfa_requirement` が `required` でも、ローカル検証は **SMS MFA で E2E** ／ TOTP は実 Identity Platform、という前提を案件のドキュメント（ADR・pilot-report 等）に明記する。
+
+## 入出力（スキーマ）
+
+- 入力: `schemas/design.schema.json`（`authentication.stack=Firebase Auth` を前提）、案件の `responsibility_split`
+- 出力: `docker-compose.yml` / `firebase.json` / backend 起動 ENV / frontend `connectAuthEmulator` 初期化コード + `schemas/implementation-plan.schema.json`
+
+スキーマは編集しない（CONV-14）。
+
+## 実装契約（言語非依存）
+
+### emulator 接続パラメータ
+
+| 名前 | 値 | 用途 |
+|---|---|---|
+| `FIREBASE_AUTH_EMULATOR_HOST` | `host:port`（プロトコル**無し**、例 `auth-emulator:9099`） | backend / client / Admin SDK 共通の検出フラグ |
+| Auth Emulator port | `9099` | REST / SDK 接続先 |
+| Emulator UI port | `4000` | ブラウザ UI（mock user 管理） |
+| project id | 任意（例 `demo-project`） | エミュレーター内で完結する識別子 |
+
+### backend 契約（firebase-auth-setup / mfa の差分）
+
+| 操作 | エミュレーター時の振る舞い |
+|---|---|
+| `verify_token(id_token)` | ID トークンは **unsigned**。EMULATOR_HOST 設定時は **署名検証をスキップ**してデコードし、`iss=https://securetoken.google.com/<project>` / `aud=<project>` / `exp` / `sub` を手動検証する。`firebase.sign_in_second_factor`（SMS の場合 `"phone"`）も従来どおり読む（`firebase-auth-mfa`）。 |
+| `delete_user(uid)` / `revoke(uid)` / `mfa_enrolled?(uid)` | Admin REST のホストを `http://${EMULATOR_HOST}/identitytoolkit.googleapis.com` に切替、`Authorization: Bearer owner`。サービスアカウント鍵は不要。 |
+| `require_mfa!` | クレーム読みは本番と同じ。**SMS MFA で第2要素を満たすトークン** が入ってくれば `mfa_satisfied?=true`。 |
+
+### client 契約（firebase-auth-frontend / mfa の差分）
+
+| 操作 | エミュレーター時の振る舞い |
+|---|---|
+| 初期化 | `connectAuthEmulator(auth, http://${EMULATOR_HOST}, { disableWarnings: true })` を初回に1回呼ぶ。 |
+| SMS enrollment | 本番と同じ API。reCAPTCHA は `RecaptchaVerifier` の代わりに **テスト用の verifier** を使う（実コードは `references/nextjs.md`）。SMS コードはサーバ送信されず、エミュレーターのコンソール出力か REST で取得。 |
+| TOTP enrollment | **エミュレーターでは失敗する**（#6224）。コードを残す場合は `if (!EMULATOR) await MfaClient.enrollTotp(...)` で分岐し、実 Identity Platform でのみ実行する。 |
+| SMS コード自動取得（テスト） | `GET http://${EMULATOR_HOST}/emulator/v1/projects/{project}/verificationCodes` → `verificationCodes[]` から最新コードを取り、`confirmSms` に渡す。 |
+
+## 手順（言語非依存）
+
+1. `firebase.json` の `emulators.auth.port=9099` を設定（ポートはデフォルト推奨）。
+2. `docker-compose.yml` で Auth Emulator サービス（`firebase-tools` 入り Node + JRE のイメージ）を起動。`FIREBASE_AUTH_EMULATOR_HOST` を backend / frontend サービスに渡す。
+3. backend は EMULATOR_HOST を検出して、`verify_token` の **署名検証スキップ** と Admin REST の **ホスト切替**を有効化する。
+4. frontend は `connectAuthEmulator(auth, http://${EMULATOR_HOST})` を呼ぶ。
+5. mock user を Emulator UI（`http://localhost:4000`）か REST で作成（MFA 用に電話番号を設定可能）。
+6. 基本フローを E2E：メール+PW サインイン → `POST /auth/session` → 保護リソース → 退会。
+7. SMS MFA を E2E：enrollment（電話番号入力 → SMS コード取得 REST → 確定）→ challenge（再ログイン時の第2要素）→ 保護リソース。
+8. TOTP MFA は **エミュレーターをバイパス**して実 Identity Platform で検証することを案件ドキュメントに明記。
+
+## 言語・フレームワーク別レシピ
+
+| 層 | 言語 / FW | レシピ | 状態 |
+|---|---|---|---|
+| 環境 | Docker | [`references/docker-compose.md`](./references/docker-compose.md) | ✅ |
+| backend | Ruby on Rails | [`references/rails.md`](./references/rails.md) | ✅ |
+| client | Next.js | [`references/nextjs.md`](./references/nextjs.md) | ✅ |
+| その他 | — | — | 追加可（契約を満たす形で追加） |
+
+## 既知の制約（くりかえし）
+
+- **TOTP MFA は不可**（#6224）。設計が TOTP 主体でも、ローカル検証は SMS で代替する。
+- ID トークンは **unsigned**。本番経路で署名検証スキップを誤って有効化すると重大なセキュリティ事故になる。**EMULATOR_HOST が立っているときのみ**スキップする条件分岐を必ず置く。
+- Admin REST の `Bearer owner` は **エミュレーター専用**。本番は OAuth2 アクセストークン（サービスアカウント）。
+- Phone Auth の reCAPTCHA / APN / Console のテスト電話番号機能はエミュレーター内では使えない。
+
+## 判断ポイント（人間判断をスルーさせない）
+
+- **TOTP 検証の代替方針**: ローカル E2E では SMS MFA で代替し、TOTP の実 E2E は staging / 実 Identity Platform で行う、という分担を案件 ADR に明記するか。
+- **エミュレーター用 mock user の管理**: 初期データを `auth_export/` から自動インポートするか、起動ごとに手動作成するか。
+- **本番 / emulator の切替戦略**: ENV だけで切るか、Docker profile で切るか。誤って本番に EMULATOR_HOST が漏れない構成にする（プロダクションビルドで参照しない、CI のシークレットに含めない）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
@@ -1,0 +1,115 @@
+# レシピ: Docker Compose で Auth Emulator を起動
+
+`firebase-auth-emulator` スキルの **環境構築レシピ**。SKILL.md の接続パラメータ（`FIREBASE_AUTH_EMULATOR_HOST=host:port`、port 9099）を満たす最小構成を Docker で作る。
+
+- 対象: Docker / docker-compose / firebase-tools — **いずれも公式の最新安定版**（バージョン方針は `ai-delivery/docs/environment-setup.md`）
+- 構成: emulator サービス（`firebase-tools` 入り）＋ backend ＋ frontend を1つの compose で起動。
+
+## 1. firebase.json（最小）
+
+emulator のポートだけ指定。auth と UI のみ。
+
+```json
+{
+  "emulators": {
+    "auth": { "host": "0.0.0.0", "port": 9099 },
+    "ui":   { "enabled": true, "port": 4000 }
+  }
+}
+```
+
+> `host: 0.0.0.0` にしておかないと、Docker コンテナ外から接続できない。
+
+## 2. emulator サービスの Dockerfile
+
+`firebase-tools` の公式 Docker イメージは無いため、自前で組む（Node + JRE）。最小：
+
+```dockerfile
+# emulator/Dockerfile
+FROM node:22-bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends openjdk-17-jre-headless ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+RUN npm install -g firebase-tools
+WORKDIR /app
+COPY firebase.json ./
+EXPOSE 9099 4000
+# project は何でも良い（emulator 内で完結）。auth のみ起動。
+CMD ["firebase", "emulators:start", "--only", "auth", "--project", "demo-telemed"]
+```
+
+## 3. docker-compose.yml
+
+```yaml
+services:
+  auth-emulator:
+    build: ./emulator
+    ports:
+      - "9099:9099"   # Auth REST / SDK
+      - "4000:4000"   # Emulator UI（http://localhost:4000）
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9099"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  backend:
+    build: ./backend
+    environment:
+      AUTH_ADAPTER: "firebase"
+      FIREBASE_PROJECT_ID: "demo-telemed"
+      FIREBASE_AUTH_EMULATOR_HOST: "auth-emulator:9099"   # ★ プロトコル無しで host:port
+      MFA_REQUIREMENT: "required"
+    ports: ["3000:3000"]
+    depends_on:
+      auth-emulator:
+        condition: service_healthy
+
+  frontend:
+    build: ./frontend
+    environment:
+      NEXT_PUBLIC_FIREBASE_PROJECT_ID: "demo-telemed"
+      NEXT_PUBLIC_FIREBASE_API_KEY: "demo-key"          # emulator は任意値で OK
+      NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST: "localhost:9099"  # ブラウザは localhost:9099 へ接続
+      NEXT_PUBLIC_API_BASE: "http://localhost:3000"
+    ports: ["3001:3000"]
+    depends_on:
+      auth-emulator:
+        condition: service_healthy
+```
+
+> **host の使い分け**: backend は Docker ネットワーク内なので `auth-emulator:9099`。frontend のブラウザ側コードは **ホスト OS のブラウザから** emulator に繋ぐので `localhost:9099`（コンテナ間 DNS は使えない）。NEXT_PUBLIC_ で分けるのが安全。
+
+## 4. 起動と確認
+
+```bash
+docker compose up --build
+# 別ターミナルで:
+curl -fsS http://localhost:9099    # emulator が起きていれば 200 系
+open http://localhost:4000          # Emulator UI（mock user 管理）
+```
+
+UI の `Auth > Add User` で mock user を作成し、必要なら電話番号を設定する（SMS MFA enrollment 用）。
+
+## 5. データの永続化（任意）
+
+開発中は emulator を毎回作り直すと user が消える。`--import` / `--export-on-exit` で永続化できる：
+
+```yaml
+    volumes:
+      - ./emulator/auth_export:/app/auth_export
+    command:
+      - firebase
+      - emulators:start
+      - --only=auth
+      - --project=demo-telemed
+      - --import=./auth_export
+      - --export-on-exit=./auth_export
+```
+
+## 6. 既知の制約 / 注意
+
+- `firebase-tools` 公式 Docker イメージは無い。コミュニティ製を使うこともできるが、本レシピでは自前 Dockerfile を推奨（依存が明示できる）。
+- emulator は JVM ベース。JRE が必須（Dockerfile の `openjdk-17-jre-headless`）。
+- emulator UI（4000）は **開発用**。プロダクションには公開しない。
+- `FIREBASE_AUTH_EMULATOR_HOST` を **本番ビルドに混入させない**（プロダクションの Next.js では `NEXT_PUBLIC_*` を未設定にする）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
@@ -30,13 +30,21 @@ FROM node:22-bookworm-slim
 RUN apt-get update \
  && apt-get install -y --no-install-recommends openjdk-17-jre-headless ca-certificates curl \
  && rm -rf /var/lib/apt/lists/*
-RUN npm install -g firebase-tools
+
+# firebase-tools: バージョン固定（再現性のため）。
+# 採用時点の最新安定版を ARG のデフォルトに置く。更新は公式リリースで確認:
+#   https://github.com/firebase/firebase-tools/releases （B-06: 数値ハードコードは避け公式最新を採る）
+ARG FIREBASE_TOOLS_VERSION=14.4.0
+RUN npm install -g "firebase-tools@${FIREBASE_TOOLS_VERSION}"
+
 WORKDIR /app
 COPY firebase.json ./
 EXPOSE 9099 4000
 # project は何でも良い（emulator 内で完結）。auth のみ起動。
 CMD ["firebase", "emulators:start", "--only", "auth", "--project", "demo-telemed"]
 ```
+
+> ピン留めは `docker compose build` の再現性のため。**バージョン更新は B-06 の手順に従い公式リリースを確認**して `--build-arg FIREBASE_TOOLS_VERSION=...` または ARG のデフォルトを更新する。固定値の陳腐化を避けるため、定期的に最新安定版へ追従する判断ポイント。
 
 ## 3. docker-compose.yml
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/nextjs.md
@@ -1,0 +1,102 @@
+# レシピ: Next.js frontend のエミュレーター対応
+
+`firebase-auth-emulator` スキルの **client(Next.js) 実装レシピ**。SKILL.md の client 契約（`connectAuthEmulator`・SMS MFA・SMS コード REST 取得）を実装する。土台は [`firebase-auth-frontend/references/nextjs.md`](../../firebase-auth-frontend/references/nextjs.md) と [`firebase-auth-mfa/references/nextjs.md`](../../firebase-auth-mfa/references/nextjs.md)。本レシピはその**差分のみ**を示す。
+
+- 対象: Next.js（App Router）/ Firebase JS SDK — 公式の最新安定版
+
+## 1. connectAuthEmulator（初期化の差分）
+
+`NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST` を見て、設定されていれば emulator に接続する。一度だけ呼ぶ（HMR で複数回呼ばないよう注意）。
+
+```ts
+// lib/firebase.ts（差分）
+import { initializeApp, getApps } from "firebase/app";
+import { getAuth, setPersistence, inMemoryPersistence, connectAuthEmulator } from "firebase/auth";
+
+const app =
+  getApps()[0] ??
+  initializeApp({
+    apiKey: process.env.NEXT_PUBLIC_FIREBASE_API_KEY,
+    authDomain: process.env.NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID,
+    appId: process.env.NEXT_PUBLIC_FIREBASE_APP_ID,
+  });
+
+export const auth = getAuth(app);
+setPersistence(auth, inMemoryPersistence);
+
+// ★ EMULATOR_HOST が設定されている場合のみエミュレーターに接続。本番ビルドでは未設定にする。
+const EMU = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST;
+if (EMU && typeof window !== "undefined" && !(auth as unknown as { _canInitEmulator: boolean })._canInitEmulator === false) {
+  // disableWarnings: コンソール赤帯の警告を抑制（本番ビルドではこのコードに来ない前提）
+  connectAuthEmulator(auth, `http://${EMU}`, { disableWarnings: true });
+}
+```
+
+> 本番ビルドでは `NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST` を **未設定**にする（`.env.production` に書かない）。`NEXT_PUBLIC_*` はビルド時に埋め込まれるため、誤って production に混入させない。
+
+## 2. SMS MFA（エミュレーターで E2E できる唯一の MFA）
+
+本番では TOTP 主体／SMS 補助でも、ローカル検証は **SMS MFA で第2要素を満たす**。`firebase-auth-mfa/references/nextjs.md` の `enrollSms` / `startSmsChallenge` / `completeSmsChallenge` をそのまま使える（emulator 側で reCAPTCHA はスキップされる扱いだが、API としては `RecaptchaVerifier` を渡す）。
+
+```ts
+// 例: SMS MFA enrollment（mfa-client.ts の enrollSms をそのまま呼ぶ）
+const verificationId = await MfaClient.enrollSms("+81-90-XXXX-XXXX", "recaptcha-container");
+// → ターミナル（emulator 出力）または REST でコードを取得して確定
+const code = await fetchEmulatorSmsCode(); // 下記
+await MfaClient.confirmSms(verificationId, code, "SMS");
+```
+
+## 3. SMS コードの自動取得（テスト用 REST）
+
+E2E スクリプトでは、エミュレーターの REST から最新の SMS コードを取得して `confirmSms` / `completeSmsChallenge` に渡す。
+
+```ts
+// E2E ヘルパー（テスト用、本番には含めない）
+export async function fetchEmulatorSmsCode(): Promise<string> {
+  const EMU = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST!;
+  const project = process.env.NEXT_PUBLIC_FIREBASE_PROJECT_ID!;
+  const res = await fetch(`http://${EMU}/emulator/v1/projects/${project}/verificationCodes`, {
+    headers: { Authorization: "Bearer owner" },
+  });
+  if (!res.ok) throw new Error(`emulator verificationCodes: ${res.status}`);
+  const { verificationCodes } = (await res.json()) as { verificationCodes: { code: string }[] };
+  if (!verificationCodes?.length) throw new Error("no SMS code in emulator");
+  return verificationCodes[verificationCodes.length - 1].code;
+}
+```
+
+> 本番では当然このエンドポイントは存在しない。**テストコードを `lib/` 直下ではなく `test/` 系に置く**、または `process.env.NODE_ENV !== "production"` でガードする。
+
+## 4. TOTP のバイパス（エミュレーター時のみ）
+
+`firebase-auth-mfa/references/nextjs.md` の `MfaClient.enrollTotp` はエミュレーターでは **失敗する**（#6224、`Missing phoneEnrollmentInfo`）。UI から enrollment 種別を選ぶ場合、emulator 環境では TOTP を非表示／非活性にしておくと開発体験が良い。
+
+```ts
+// 設定画面の例: 環境で TOTP の出し分け
+const isEmulator = !!process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST;
+{!isEmulator && <button onClick={() => MfaClient.enrollTotp()}>TOTP で登録</button>}
+<button onClick={() => MfaClient.enrollSms(phone, "recaptcha-container")}>SMS で登録</button>
+```
+
+> 設計（ADR）で「TOTP の E2E は実 Identity Platform」と決めておくこと。
+
+## 5. 起動
+
+`docker-compose.yml` から（[`docker-compose.md`](./docker-compose.md) 参照）：
+
+```env
+NEXT_PUBLIC_FIREBASE_PROJECT_ID=demo-telemed
+NEXT_PUBLIC_FIREBASE_API_KEY=demo-key
+NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST=localhost:9099
+NEXT_PUBLIC_API_BASE=http://localhost:3000
+```
+
+ブラウザ側コードは `localhost:9099` で emulator に直接アクセスする（コンテナ間 DNS は使えない）。
+
+## 6. 既知の制約
+
+- TOTP はエミュレーターで失敗する（#6224）。ローカルは SMS、本番／staging で TOTP。
+- Emulator UI（`http://localhost:4000`）で mock user 作成・電話番号設定が手軽。
+- `connectAuthEmulator` は **一度だけ**呼ぶ。HMR で再評価されると `auth/emulator-config-failed` が出ることがある。`getAuth(app)` の app 単一インスタンスを保つ（`getApps()[0] ?? initializeApp(...)` の慣習を守る）。
+- `NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST` を本番ビルドに混入させない（`.env.production` に書かない）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/nextjs.md
@@ -27,9 +27,14 @@ setPersistence(auth, inMemoryPersistence);
 
 // ★ EMULATOR_HOST が設定されている場合のみエミュレーターに接続。本番ビルドでは未設定にする。
 const EMU = process.env.NEXT_PUBLIC_FIREBASE_AUTH_EMULATOR_HOST;
-if (EMU && typeof window !== "undefined" && !(auth as unknown as { _canInitEmulator: boolean })._canInitEmulator === false) {
-  // disableWarnings: コンソール赤帯の警告を抑制（本番ビルドではこのコードに来ない前提）
-  connectAuthEmulator(auth, `http://${EMU}`, { disableWarnings: true });
+if (EMU && typeof window !== "undefined") {
+  try {
+    // disableWarnings: コンソール赤帯の警告を抑制（本番ビルドではこのコードに来ない前提）
+    connectAuthEmulator(auth, `http://${EMU}`, { disableWarnings: true });
+  } catch {
+    // HMR で本ファイルが再評価された場合、connectAuthEmulator は2回目以降エラーを投げる。
+    // 既に接続済みの状態なので握りつぶしてよい。
+  }
 }
 ```
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/rails.md
@@ -20,6 +20,12 @@ module AppAuth
   def self.emulator?       = !emulator_host.nil?
   def self.reset!          = (@adapter = nil)
 end
+
+# ★ 本番混入ガード（テンプレートに含める / 推奨止まりにしない）。
+# production で FIREBASE_AUTH_EMULATOR_HOST が設定されていたら、認証無効化の重大事故を防ぐため起動を止める。
+if defined?(Rails) && Rails.env.production? && AppAuth.emulator?
+  abort "FATAL: FIREBASE_AUTH_EMULATOR_HOST is set in production. Refusing to start (firebase-auth-emulator)."
+end
 ```
 
 ## 2. verify_token: 署名検証スキップ + 手動 iss/aud/exp 検証

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/rails.md
@@ -1,0 +1,130 @@
+# レシピ: Rails backend のエミュレーター対応
+
+`firebase-auth-emulator` スキルの **backend(Rails) 実装レシピ**。SKILL.md の backend 契約（署名検証スキップ・Admin REST 切替）を実装する。土台は [`firebase-auth-setup/references/rails.md`](../../firebase-auth-setup/references/rails.md) と [`firebase-auth-mfa/references/rails.md`](../../firebase-auth-mfa/references/rails.md)。本レシピはその**差分のみ**を示す。
+
+- 対象: Rails（API モード）/ Ruby — 公式の最新安定版
+- 依存: 追加なし（jwt / googleauth のまま）
+
+## 1. EMULATOR_HOST の検出
+
+`AppAuth` で一元管理する。`FIREBASE_AUTH_EMULATOR_HOST` が設定されているかどうかで分岐する。
+
+```ruby
+# config/initializers/app_auth.rb（差分）
+module AppAuth
+  def self.adapter
+    @adapter ||= (ENV.fetch("AUTH_ADAPTER", Rails.env.test? ? "test" : "firebase") == "test" ? Auth::TestAdapter.new : Auth::FirebaseAdapter.new)
+  end
+  def self.mfa_requirement = ENV.fetch("MFA_REQUIREMENT", "required")
+  def self.emulator_host   = ENV["FIREBASE_AUTH_EMULATOR_HOST"].presence   # host:port（プロトコル無し）
+  def self.emulator?       = !emulator_host.nil?
+  def self.reset!          = (@adapter = nil)
+end
+```
+
+## 2. verify_token: 署名検証スキップ + 手動 iss/aud/exp 検証
+
+エミュレーターの ID トークンは **unsigned**（alg=none 相当）。jwt gem の署名検証はスキップし、iss/aud/exp/sub と `auth_time` は手動で確認する。
+
+```ruby
+# app/adapters/auth/firebase_adapter.rb（差分: verify_token）
+def verify_token(id_token)
+  decoded =
+    if AppAuth.emulator?
+      decode_unsigned(id_token)              # 署名スキップ ＋ 手動検証
+    else
+      decode_signed(id_token)                # 本番: RS256 + 公開鍵
+    end
+  raise Auth::InvalidToken, "empty sub" if decoded["sub"].to_s.empty?
+  Auth::AuthUser.new(
+    uid:           decoded["sub"],
+    email:         decoded["email"],
+    provider:      decoded.dig("firebase", "sign_in_provider"),
+    second_factor: decoded.dig("firebase", "sign_in_second_factor"),
+    claims:        decoded
+  )
+rescue JWT::DecodeError, OpenSSL::X509::CertificateError => e
+  raise Auth::InvalidToken, e.message
+end
+
+private
+
+def decode_signed(id_token)
+  JWT.decode(id_token, nil, true,
+    algorithms: ["RS256"],
+    iss: "https://securetoken.google.com/#{@project_id}", verify_iss: true,
+    aud: @project_id, verify_aud: true, verify_expiration: true, verify_iat: true
+  ) { |h| public_key_for(h["kid"]) }.first
+end
+
+# エミュレーター: 署名検証なしでデコードし、payload は手動で検証する。
+# 本番経路では絶対に呼ばない（emulator? でしか到達しない）。
+def decode_unsigned(id_token)
+  payload, _header = JWT.decode(id_token, nil, false)   # 署名検証スキップ
+  raise Auth::InvalidToken, "bad iss" unless payload["iss"] == "https://securetoken.google.com/#{@project_id}"
+  raise Auth::InvalidToken, "bad aud" unless payload["aud"] == @project_id
+  raise Auth::InvalidToken, "expired" if payload["exp"].is_a?(Integer) && Time.now.to_i >= payload["exp"]
+  payload
+end
+```
+
+> **本番混入の防止**: `decode_unsigned` は `AppAuth.emulator?` が true のときしか呼ばれない。production で誤って `FIREBASE_AUTH_EMULATOR_HOST` を設定しないこと（環境設定・CI Secrets で隔離）。
+
+## 3. Admin REST の host 切替（delete_user / revoke / mfa_enrolled?）
+
+エミュレーター時は `http://${EMULATOR_HOST}/identitytoolkit.googleapis.com` に向け、認可ヘッダを `Bearer owner` に変える。サービスアカウント鍵は不要。
+
+```ruby
+# app/adapters/auth/firebase_adapter.rb（差分: private ヘルパー）
+def access_token
+  return "owner" if AppAuth.emulator?       # ★ エミュレーター専用トークン
+  return @token[:value] if @token && Time.now < @token[:expires_at]
+  cred = Google::Auth::ServiceAccountCredentials.make_creds(
+    json_key_io: StringIO.new(File.read(ENV.fetch("GOOGLE_APPLICATION_CREDENTIALS"))),
+    scope: "https://www.googleapis.com/auth/identitytoolkit"
+  )
+  t = cred.fetch_access_token!
+  @token = { value: t["access_token"], expires_at: Time.now + t["expires_in"].to_i - 30 }
+  @token[:value]
+end
+
+def identitytoolkit_uri(method)
+  base = AppAuth.emulator? ? "http://#{AppAuth.emulator_host}/identitytoolkit.googleapis.com" : "https://identitytoolkit.googleapis.com"
+  URI("#{base}/v1/projects/#{@project_id}/#{method}")
+end
+
+def identitytoolkit_post(method, **body)
+  uri = identitytoolkit_uri(method)
+  req = Net::HTTP::Post.new(uri)
+  req["Authorization"] = "Bearer #{access_token}"     # 本番=OAuth2 / emulator=owner
+  req["Content-Type"]  = "application/json"
+  req.body = JSON.dump(body)
+  res = Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == "https") { |h| h.request(req) }
+  raise Auth::NotFoundError if res.code == "404"
+  raise Auth::Error, "identitytoolkit #{method}: #{res.code}" unless res.is_a?(Net::HTTPSuccess)
+  res.body.to_s.empty? ? {} : JSON.parse(res.body)
+end
+```
+
+`delete_user` / `revoke` / `mfa_enrolled?` は変更なし（このヘルパーを通る）。emulator 上のユーザー削除・失効・enrollment 状態取得が `Bearer owner` でそのまま動く。
+
+## 4. 起動
+
+`docker-compose.yml` から `FIREBASE_AUTH_EMULATOR_HOST=auth-emulator:9099` と `FIREBASE_PROJECT_ID=demo-telemed` を渡す（[`docker-compose.md`](./docker-compose.md)）。`AUTH_ADAPTER=firebase` で `FirebaseAdapter` が選ばれ、内部で emulator? によって署名・Admin host が自動切替する。
+
+```bash
+# ローカル単体起動の例（docker を使わない場合）
+FIREBASE_AUTH_EMULATOR_HOST=localhost:9099 \
+FIREBASE_PROJECT_ID=demo-telemed \
+AUTH_ADAPTER=firebase \
+bin/rails s
+```
+
+## 5. テスト（エミュレーター E2E）
+
+既存の minitest 結合テスト（`TestAdapter`）はそのまま回す。**emulator E2E は別途、emulator を起動した状態で `AUTH_ADAPTER=firebase` のテストグループ**を分けると整理しやすい（CI ではエミュレーター起動が要るので、ローカル/E2E ジョブのみで実行）。本レシピのスコープは「実装と起動」までで、E2E スクリプトは案件側で組む（例: `bin/e2e` で curl 連打）。
+
+## 6. 既知の制約
+
+- 本番経路で `FIREBASE_AUTH_EMULATOR_HOST` を**絶対に有効化しない**。`decode_unsigned` と `Bearer owner` が本番に出ると、認証が無効化される重大事故になる。production ENV / CI Secrets で隔離し、起動時に Rails.env=production && AppAuth.emulator? なら **abort** する一行を入れるとさらに安全。
+- Ruby に公式 Firebase Admin SDK が無い前提のため、Admin 操作は Identity Toolkit REST のホスト切替で対応している（本スキル独自の手段ではなく `firebase-auth-setup` の REST 経路を流用）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
@@ -15,6 +15,8 @@ description: Firebase Auth をフロントエンド（クライアント）に�
 
 > **MFA（多要素認証, DP-008）は本スキルの対象外。** 第2要素の登録（enrollment）・サインイン時の追加認証（challenge）も client 実装だが、backend/iaas にまたがる横断機能のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約している。MFA を実装するときはそちらを参照。
 
+> **ローカル検証（Docker で Auth Emulator 起動・E2E）**は対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) を参照。`connectAuthEmulator` の初期化と **SMS MFA での E2E 検証**手順をそちらに集約（TOTP MFA はエミュレーター非対応のため、ローカルは SMS で代替し TOTP の E2E は実 Identity Platform）。
+
 ## 入出力（スキーマ）
 
 - 入力: `schemas/design.schema.json`（`authentication` / `responsibility_split` の client 項目 / セッション戦略）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-mfa/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-mfa/SKILL.md
@@ -89,6 +89,10 @@ enroll / unenroll が成功したら **サーバに通知**し、`backend.revoke
 | client | Next.js | [`references/nextjs.md`](./references/nextjs.md) | ✅ |
 | その他 | — | — | 追加可（契約を満たす形で `<stack>.md` を追加） |
 
+## ローカル検証（エミュレーター）
+
+`firebase-auth-emulator` で Docker 起動した Auth Emulator に対して、**SMS(phone) MFA** は enrollment/challenge の E2E が回せる。**TOTP MFA はエミュレーター非対応**（[firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)）なので、ローカル検証は SMS で代替し、TOTP の E2E は実 Identity Platform を使う。詳細・接続パラメータ・手順は [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) を参照。
+
 ## 既知の制約
 
 - **Identity Platform 必須**: TOTP / SMS いずれの MFA も Google Cloud Identity Platform（GCIP）へのアップグレードが必要。Firebase コンソール → Authentication → Sign-in method → Advanced で MFA を有効化してから実装・検証する。無印の Firebase Auth プロジェクトのままでは enroll/challenge が失敗する。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
@@ -15,6 +15,8 @@ description: Firebase Auth を任意のバックエンドに統合するスキ�
 
 > **スコープ: バックエンド（サーバ）専用。** ID トークン検証・JWT 認可・退会時の Admin SDK 削除・トークン失効など。フロントエンド（サインインUI・パスワード/メール変更・トークン保持・API への Bearer 付与）は対の [`firebase-auth-frontend`](../firebase-auth-frontend/SKILL.md) を参照。`responsibility_split` の **backend = 本スキル / client = firebase-auth-frontend / iaas = Firebase が提供**。MFA（多要素認証, DP-008）は client/backend/iaas 横断のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約（本スキルが担う MFA 部分は「クレーム検証・管理者強制・変更時の失効」）。
 
+> **ローカル検証（Docker で Auth Emulator 起動・E2E）**は対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) を参照。`FIREBASE_AUTH_EMULATOR_HOST` 検出時の **署名検証スキップ**と **Admin REST の host 切替（`Bearer owner`）** はそちらに集約し、本スキルの本番経路（RS256 + サービスアカウント）と分離する。
+
 ## 入出力（スキーマ）
 
 - 入力: `schemas/design.schema.json`（`authentication.stack` / `architecture.stack` / decision_record）


### PR DESCRIPTION
## 概要

T-021 再パイロットで「実際に動かして実装が問題ないか確認したい／Docker で Firebase エミュレーター環境を構築したい」という要望を受け、**Auth Emulator を Docker で起動して認証フローを E2E 検証する横断スキル**を新設します。backend / client / MFA にまたがるトピックなので、既存スキルではなく新スキルに集約します（`firebase-auth-mfa` と同じ論理）。

- 関連: T-021 / DP-007 / DP-008 / [firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)
- 参考: [Connect your app to the Authentication Emulator（日本語版）](https://firebase.google.com/docs/emulator-suite/connect_auth?hl=ja)

## 調査で判明した重要な前提

| 項目 | エミュレーター対応 |
|---|---|
| メール+PW / パスワードレス / 退会 / トークン失効 / Bearer 認可 | ✅ E2E 可 |
| **SMS(phone) MFA** | ✅ E2E 可（コードはターミナル/REST で取得） |
| **TOTP MFA** | ❌ 非対応（#6224）→ E2E は実 Identity Platform |
| ID トークン | **unsigned**（backend は EMULATOR_HOST 検出時に署名検証スキップ） |
| Admin REST | host を `http://${EMU}/identitytoolkit.googleapis.com` に切替・`Bearer owner` |

つまり **MFA required の E2E は SMS MFA でローカル可能**。本案件 design は TOTP 主体／SMS 補助なので、**検証は SMS、本番は TOTP** という分担で整合します。

## 変更内容

**新スキル `skills/implementation/firebase-auth-emulator/`**

- `SKILL.md` — 接続パラメータ・契約（backend: 署名スキップ、Admin REST 切替 / client: connectAuthEmulator・SMS MFA）・既知の制約（TOTP不可・本番混入防止）・判断ポイント
- `references/docker-compose.md` — `firebase.json`、自前 Dockerfile（Node + JRE）、`docker-compose.yml`（emulator + backend + frontend、host の使い分け）
- `references/rails.md` — `verify_token` で EMULATOR_HOST 時のみ署名検証スキップ + 手動 iss/aud/exp 検証、Admin REST の host・`Bearer owner` 切替
- `references/nextjs.md` — `connectAuthEmulator` 初期化、SMS MFA E2E、SMS コード REST 取得ヘルパー、TOTP 環境別バイパス

**既存への相互参照追加**

- `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` の SKILL.md に「ローカル検証は firebase-auth-emulator を参照」
- `auth-plugin-guide` の判断ポイント節に「ローカル E2E は emulator（SMS可・TOTP不可）」

## 判断ポイント（人間判断をスルーさせない）

- [x] **TOTP の E2E 代替方針**を SKILL.md / 既存スキルに明記（ローカル=SMS、TOTP=実 Identity Platform）
- [x] **本番経路への混入防止**を SKILL.md / rails.md に明記（`decode_unsigned` と `Bearer owner` は emulator? でしか到達しない）
- [ ] mock user の初期データ管理（auth_export/）と本番／emulator 切替戦略 → 案件側で決定

## マージ要件（T-014）

- [ ] **R-011**: CI がパスし、1 名以上の Approve がある
- [x] **R-012**: スキルのみのため test/ スタブ範囲。検証は次フェーズ（サンプルアプリの実起動 E2E）
- [x] **R-013**: 追加は Markdown のみ（Lint 影響なし）

## レビュアー

- 豊田（T-005 本決定で 1 名体制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)