### PR TITLE
feat(T-021): フロントエンドの3パターンページ振る舞いを既定化

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/design/firebase-auth-design/templates/auth-section.template.md
@@ -47,6 +47,23 @@ owner は **単一の enum 値**（`backend` / `client` / `iaas` / `shared`）�
 
 > owner の値: **backend**=サーバ実装 / **client**=アプリ・フロント SDK / **iaas**=Firebase 等が提供 / **shared**=両方。
 
+## ページ単位のアクセス制御（firebase-auth-frontend のデフォルトに従う / 逸脱は明示）
+
+`firebase-auth-frontend` の **3 パターン**（A: protected-only / B: public-aware / C: guest-only）と**デフォルトページ**を採用する。案件のページを以下の表に追記し、**デフォルトに反する設定は逸脱として明示**する（warn_and_document）。
+
+| パス | パターン | `default_after_login` | callback 受け取り | 補足 |
+|---|---|---|---|---|
+| `/login` | C: guest-only | `/`（既定） | 〇 | `/signup` と相互リンク・callback 引き継ぎ |
+| `/signup` | C: guest-only | `/`（既定） | 〇 | **`/login` と別ページ**。`/login` と相互リンク |
+| `/mfa/enroll` | A: protected-only | — | — | DP-008 の MFA 方針に従う |
+| `/settings/*` | A: protected-only | — | — | 退会・パスワード変更・メール変更 |
+| `/` | B: public-aware | — | — | 認証状態でコンテンツ切替 |
+| `<案件のページ>` | A/B/C | | | |
+
+- 既定遷移先（ログイン後の `default_after_login`）: `/`。案件で別にする場合はここに明示（例 `/dashboard`）
+- callback の URL 検証ポリシー: 同一オリジンの `/` 始まりのみ、`//` 拒否（open redirect 防止）
+- デフォルトに反する設定（例: `/settings` を公開、`/login` と `/signup` を統合 等）は `decision_record` に根拠を残す
+
 ## 未決（undecided）
 
 - DP-XXX: <概要>（`docs/pending-decisions.md` に起票済み）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
@@ -47,6 +47,48 @@ description: Firebase Auth をフロントエンド（クライアント）に�
 
 アプリは `AuthClient` 越しに Firebase を呼ぶ。API 呼び出しには `getIdToken()` の Bearer を付け、サーバ（firebase-auth-setup）が検証する。
 
+## デフォルトページ構成と認証アクセス制御
+
+スキルが既定で要求するページ構成と振る舞い。**要件で別指定がある場合は要件優先**（`design` に `page_access_control` を追加して逸脱を明示・warn_and_document）。
+
+### 3 つのアクセス制御パターン
+
+| パターン | 名前 | ログイン時 | ログアウト時 |
+|---|---|---|---|
+| **A** | `protected-only`（認証必須） | 表示 | **`/login?callback=<元URL>` へリダイレクト** |
+| **B** | `public-aware`（認証感知・公開） | 認証状態でコンテンツ切替（リダイレクトなし） | 同（リダイレクトなし） |
+| **C** | `guest-only`（ゲスト専用） | **`callback`（または既定遷移先）へリダイレクト** | 表示 |
+
+### デフォルトページ一覧（要件で別指定がない限り採用）
+
+| パス | パターン | 振る舞い |
+|---|---|---|
+| `/login` | C: guest-only | サインイン。`?callback=<path>` を受け取り、ログイン後にそのパスへ遷移。`/signup` と**相互リンク**し callback を引き継ぐ |
+| `/signup` | C: guest-only | 新規登録。**`/login` と別ページ**・相互リンク。`callback` を引き継ぐ |
+| `/mfa/enroll` | A: protected-only | MFA 第2要素登録（[`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) と組み合わせ） |
+| `/settings/*`（退会・PW変更・メール変更 等） | A: protected-only | アカウント設定 |
+| `/`（トップ） | B: public-aware | 認証状態でコンテンツ切替 |
+
+> 案件のページが上記に無い場合は **A/B/C を明示**して `page_access_control` に追加する。デフォルトに反する設定（例: `/settings` を `public-aware` に開放する等）が要件で出たら、`design.decision_record` に根拠を残して逸脱を記録する。
+
+### コールバックURL の仕様（共通契約）
+
+- パラメータ名: **`callback`**（プロジェクトで統一）
+- 値は **同一オリジンのパス**（先頭 `/`、外部 URL 不可）。**open redirect 防止**のため、`//` 始まり・絶対 URL・別ホストは拒否し、既定遷移先にフォールバック
+- 既定遷移先（未指定時）: `/`（トップ）。案件で別にする場合は `page_access_control.default_after_login` を明示
+- `/login` ↔ `/signup` の相互リンクは `callback` を**そのまま引き継ぐ**（ユーザーが行き来しても遷移先が保たれる）
+- パターン A のページに未認証でアクセスした場合は `callback=<元URL>` を付けて `/login` にリダイレクト
+
+### ガード実装契約（FW 非依存）
+
+| パターン | 実装の意図 |
+|---|---|
+| A: protected-only | レンダー前にセッション無を検出してリダイレクト。**子コンテンツは認証確定後にのみマウント**。ローディング中はスケルトン |
+| B: public-aware | 認証状態を子に渡すだけ。リダイレクトなし。SSR/RSC では session cookie を見て切替 |
+| C: guest-only | セッション有を検出してリダイレクト。`callback` 優先・無ければ既定遷移先 |
+
+各レシピ（`references/<stack>.md`）は **3 パターンの雛形**と上記**デフォルトページのスケルトン**を含む。
+
 ## バックエンド連携（firebase-auth-setup と対）
 
 - ログイン後: `getIdToken()` → `POST /auth/session`（サーバがユーザーを upsert）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -114,7 +114,123 @@ AuthClient.onAuthStateChanged((user) => {
 })
 ```
 
-## 6. 既知の制約 / 注意
+## 6. デフォルトページ構成と認証ガード（3パターン）
+
+SKILL.md の 3 パターン（protected-only / public-aware / guest-only）を Rails + Hotwire で実装する雛形。SSR 主体なのでサーバ側 controller の `before_action` で宣言的にガードする。
+
+### 共通モジュール
+
+```ruby
+# app/controllers/concerns/page_access_control.rb
+module PageAccessControl
+  extend ActiveSupport::Concern
+  DEFAULT_AFTER_LOGIN = "/" # page_access_control.default_after_login
+
+  class_methods do
+    def protected_only(except: []) = before_action(:authenticate_user!,        except: except)
+    def guest_only(except: [])     = before_action(:redirect_if_authenticated, except: except)
+  end
+
+  private
+
+  def authenticate_user!
+    return if user_signed_in?
+    redirect_to login_path(callback: request.fullpath), allow_other_host: false
+  end
+
+  def redirect_if_authenticated
+    return unless user_signed_in?
+    redirect_to safe_callback(params[:callback]) || DEFAULT_AFTER_LOGIN, allow_other_host: false
+  end
+
+  # open redirect 防止: 同一オリジンの「/」始まりのみ・「//」拒否
+  def safe_callback(c) = (c.is_a?(String) && c.start_with?("/") && !c.start_with?("//")) ? c : nil
+end
+```
+
+### `/login`（guest-only）・`/signup`（guest-only） — 別 controller・相互リンク
+
+```ruby
+# app/controllers/sessions_controller.rb — /login
+class SessionsController < ApplicationController
+  include PageAccessControl
+  guest_only
+
+  def new
+    @callback = safe_callback(params[:callback])
+  end
+
+  def create
+    # クライアント SDK でサインイン後、サーバセッションを確立。成功時:
+    redirect_to safe_callback(params[:callback]) || DEFAULT_AFTER_LOGIN
+  end
+end
+```
+
+```ruby
+# app/controllers/registrations_controller.rb — /signup（/login と別 controller）
+class RegistrationsController < ApplicationController
+  include PageAccessControl
+  guest_only
+
+  def new
+    @callback = safe_callback(params[:callback])
+  end
+end
+```
+
+```erb
+<%# app/views/sessions/new.html.erb — /login → /signup へのリンク（callback 引き継ぎ）%>
+<%= link_to "新規登録はこちら", signup_path(callback: @callback) %>
+
+<%# app/views/registrations/new.html.erb — /signup → /login へのリンク（callback 引き継ぎ）%>
+<%= link_to "ログインはこちら", login_path(callback: @callback) %>
+```
+
+### `/mfa/enroll`・`/settings/*`（protected-only）
+
+```ruby
+class MfaEnrollmentsController < ApplicationController
+  include PageAccessControl
+  protected_only
+  # ビューで firebase-auth-mfa の client コード（Stimulus）を読み込む
+end
+
+class SettingsController < ApplicationController # 退会・PW 変更・メール変更
+  include PageAccessControl
+  protected_only
+end
+```
+
+### `/`（public-aware）
+
+```ruby
+class HomeController < ApplicationController
+  include PageAccessControl
+  # ガード無し（public-aware）。user_signed_in? でビューを切替
+end
+```
+
+```erb
+<%# app/views/home/index.html.erb %>
+<% if user_signed_in? %>
+  <%= render "dashboard_preview" %>
+<% else %>
+  <%= render "public_landing" %>
+<% end %>
+```
+
+### routes.rb
+
+```ruby
+get  "login",  to: "sessions#new",      as: :login
+post "login",  to: "sessions#create"
+get  "signup", to: "registrations#new", as: :signup
+# /mfa/enroll, /settings/* も同様に定義
+root to: "home#index"
+```
+
+## 7. 既知の制約 / 注意
 
 - Firebase JS SDK はブラウザ実行。`localStorage` ではなくメモリ保持 ＋ リフレッシュを既定にし、XSS リスクを下げる（戦略 A）。
 - パスワード変更・リセット・メール変更は Firebase JS SDK で完結し **Rails 実装不要**（responsibility=iaas）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/nextjs.md
@@ -113,7 +113,179 @@ export function middleware(req: NextRequest) {
 }
 ```
 
-## 5. 既知の制約 / 注意
+## 5. デフォルトページ構成と認証ガード（3パターン）
+
+SKILL.md の 3 パターン契約（protected-only / public-aware / guest-only）を Next.js (App Router) で実装する雛形。`<AuthGate>` クライアントコンポーネントで宣言的にガードする。
+
+### AuthGate コンポーネント
+
+```tsx
+// components/AuthGate.tsx
+"use client";
+import { useEffect, useState, type ReactNode } from "react";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
+import { AuthClient } from "@/lib/auth-client";
+
+type Type = "protected" | "public-aware" | "guest";
+
+// open redirect 防止: 同一オリジンの「/」始まりのみ、「//」は拒否
+function safeCallback(c: string | null): string | null {
+  if (!c || !c.startsWith("/") || c.startsWith("//")) return null;
+  return c;
+}
+const DEFAULT_AFTER_LOGIN = "/"; // page_access_control.default_after_login
+
+export function AuthGate({ type, children, render }: {
+  type: Type;
+  children?: ReactNode;
+  render?: (s: { uid: string | null; ready: boolean }) => ReactNode;
+}) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const search = useSearchParams();
+  const [ready, setReady] = useState(false);
+  const [uid, setUid] = useState<string | null>(null);
+
+  useEffect(() => AuthClient.onAuthStateChanged((u) => { setUid(u?.uid ?? null); setReady(true); }), []);
+
+  useEffect(() => {
+    if (!ready) return;
+    if (type === "protected" && !uid) {
+      router.replace(`/login?callback=${encodeURIComponent(pathname)}`);
+    } else if (type === "guest" && uid) {
+      router.replace(safeCallback(search.get("callback")) ?? DEFAULT_AFTER_LOGIN);
+    }
+  }, [ready, uid, type, pathname, search, router]);
+
+  if (!ready) return null;                           // ローディング（必要ならスケルトン）
+  if (type === "protected" && !uid) return null;     // リダイレクト中は何も出さない
+  if (type === "guest" && uid) return null;
+  if (render) return <>{render({ uid, ready })}</>;
+  return <>{children}</>;
+}
+```
+
+### `/login`（guest-only）と `/signup`（guest-only）— 別ページ・相互リンク
+
+```tsx
+// app/login/page.tsx
+"use client";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useState } from "react";
+import { AuthClient } from "@/lib/auth-client";
+import { AuthGate } from "@/components/AuthGate";
+
+function safe(c: string | null) { return c && c.startsWith("/") && !c.startsWith("//") ? c : "/"; }
+
+export default function LoginPage() {
+  const router = useRouter();
+  const callback = useSearchParams().get("callback");
+  const [email, setEmail] = useState(""); const [pw, setPw] = useState(""); const [msg, setMsg] = useState("");
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await AuthClient.signInWithPassword(email, pw);
+      const t = await AuthClient.getIdToken(true);
+      await fetch(`${process.env.NEXT_PUBLIC_API_BASE}/auth/session`, { method: "POST", headers: { Authorization: `Bearer ${t}` } });
+      router.replace(safe(callback));
+    } catch (e) { setMsg((e as Error).message); }
+  };
+
+  return (
+    <AuthGate type="guest">
+      <main>
+        <h1>ログイン</h1>
+        <form onSubmit={submit}>{/* email / password */}</form>
+        <p>アカウントをお持ちでない方は <Link href={`/signup${callback ? `?callback=${encodeURIComponent(callback)}` : ""}`}>新規登録</Link></p>
+        {msg && <p>{msg}</p>}
+      </main>
+    </AuthGate>
+  );
+}
+```
+
+```tsx
+// app/signup/page.tsx — /login と別ページ。callback を引き継ぐ。
+"use client";
+import Link from "next/link";
+import { useSearchParams } from "next/navigation";
+import { AuthGate } from "@/components/AuthGate";
+// signUp は createUserWithEmailAndPassword 等で実装し、成功時に router.replace(safe(callback)) する
+
+export default function SignupPage() {
+  const callback = useSearchParams().get("callback");
+  return (
+    <AuthGate type="guest">
+      <main>
+        <h1>新規登録</h1>
+        {/* signUp フォーム */}
+        <p>既にアカウントをお持ちの方は <Link href={`/login${callback ? `?callback=${encodeURIComponent(callback)}` : ""}`}>ログイン</Link></p>
+      </main>
+    </AuthGate>
+  );
+}
+```
+
+### `/mfa/enroll`・`/settings/*`（protected-only）
+
+```tsx
+// app/mfa/enroll/page.tsx
+import { AuthGate } from "@/components/AuthGate";
+export default function MfaEnrollPage() {
+  return (
+    <AuthGate type="protected">
+      <main>{/* MfaClient.enrollSms / confirmSms （firebase-auth-mfa） */}</main>
+    </AuthGate>
+  );
+}
+```
+
+```tsx
+// app/settings/layout.tsx — /settings 配下をまとめて protected に
+import { AuthGate } from "@/components/AuthGate";
+export default function SettingsLayout({ children }: { children: React.ReactNode }) {
+  return <AuthGate type="protected">{children}</AuthGate>;
+}
+```
+
+### `/`（public-aware）
+
+```tsx
+// app/page.tsx
+"use client";
+import { AuthGate } from "@/components/AuthGate";
+export default function Home() {
+  return (
+    <AuthGate type="public-aware" render={({ uid }) => (
+      <main>{uid ? <DashboardPreview /> : <PublicLanding />}</main>
+    )} />
+  );
+}
+```
+
+### middleware（任意・BFF 採用時）
+
+セッション戦略が **BFF（Route Handler + HttpOnly クッキー）**の場合は、`middleware.ts` で cookie を見てサーバサイドガードを併用する（クライアントガードと二重化で堅牢）。クライアント Bearer 直叩きの場合は AuthGate のみで十分。
+
+```ts
+// middleware.ts（BFF 採用時の例）
+import { NextResponse, type NextRequest } from "next/server";
+const PROTECTED = [/^\/mfa\//, /^\/settings(?:\/|$)/];
+const GUEST_ONLY = [/^\/login$/, /^\/signup$/];
+function safe(c: string | null) { return c && c.startsWith("/") && !c.startsWith("//") ? c : "/"; }
+export function middleware(req: NextRequest) {
+  const path = req.nextUrl.pathname;
+  const session = req.cookies.get("session");
+  if (PROTECTED.some((r) => r.test(path)) && !session)
+    return NextResponse.redirect(new URL(`/login?callback=${encodeURIComponent(path)}`, req.url));
+  if (GUEST_ONLY.some((r) => r.test(path)) && session)
+    return NextResponse.redirect(new URL(safe(req.nextUrl.searchParams.get("callback")), req.url));
+}
+```
+
+## 6. 既知の制約 / 注意
 
 - ID トークンはメモリ保持＋リフレッシュを既定にし、`localStorage` を避ける（XSS 配慮）。BFF 採用時は HttpOnly クッキー。
 - パスワード変更・リセット・メール変更は Firebase JS SDK で完結し **backend 実装不要**（responsibility=iaas）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/requirements/auth-requirements-extraction/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/requirements/auth-requirements-extraction/SKILL.md
@@ -38,6 +38,19 @@ description: クライアント要件の説明から認証関連要件を抽出�
 - [ ] セキュリティ規制・業界要件（金融/医療/B2B など → DP-008 MFA、DP-015 dAccount）
 - [ ] docomo / dメニュー系連携の有無（→ DP-015）
 
+## ページ単位のアクセス制御（firebase-auth-frontend と協調）
+
+`firebase-auth-frontend` スキルは 3 パターン（**A: protected-only / B: public-aware / C: guest-only**）と既定ページ（`/login` `/signup` `/mfa/enroll` `/settings/*` `/`）を持つ。要件抽出時に**案件特有のページ**を A/B/C に振り分け、デフォルトに反する設定があれば明示する（要件で別指定がある場合は要件優先）。
+
+- [ ] 認証必須ページ（A）の列挙（例: マイページ / 申込フォーム / 決済 / `/mfa/enroll` / `/settings/*`）
+- [ ] 認証感知ページ（B、公開だが認証で表示が変わる）の列挙（例: トップ / 商品一覧）
+- [ ] ゲスト専用ページ（C）の列挙（通常は `/login` と `/signup`。案件追加があれば）
+- [ ] **既定遷移先（ログイン後のホーム）**: 既定 `/`。案件で別指定がある場合は明示（例 `/dashboard`）
+- [ ] **callback パラメータ**の採用（既定パラメータ名 `callback`）と検証ポリシー（既定: 同一オリジンの `/` 始まりのみ・`//` 拒否で open redirect 防止）
+- [ ] `/login` と `/signup` を**別ページ**で提供することの確認（既定。統合する案件指定があれば理由とともに明示）
+
+検出した内容は `representative_use_cases` / `functional_requirements` に反映し、設計フェーズへ `page_access_control` として引き継ぐ（authentication-architect / firebase-auth-design の責務）。
+
 ## 手順
 
 1. 説明テキストを読み、上記チェックリストで認証要件を洗い出す。


### PR DESCRIPTION
## 概要

フロントエンドの認証アクセス制御を **3 パターン × デフォルトページ × コールバックURL** の形で型化し、スキルが既定で要求するようにします。要件で別指定がある場合は要件優先（warn_and_document）。

- 関連: T-021 / DP-008（MFA）/ ADR-002（セッション戦略）

## 3 パターン契約

| パターン | 名前 | ログイン時 | ログアウト時 |
|---|---|---|---|
| A | `protected-only` | 表示 | `/login?callback=<元URL>` へリダイレクト |
| B | `public-aware` | 認証状態でコンテンツ切替（リダイレクトなし） | 同 |
| C | `guest-only` | `callback` か既定遷移先へリダイレクト | 表示 |

## デフォルトページ（要件で別指定がない限り採用）

| パス | パターン | 備考 |
|---|---|---|
| `/login` | C | `?callback=` を受け取り、`/signup` と相互リンク（callback 引き継ぎ） |
| `/signup` | C | **`/login` と別ページ**。同上 |
| `/mfa/enroll` | A | `firebase-auth-mfa` と組み合わせ |
| `/settings/*` | A | 退会・PW変更・メール変更 |
| `/` | B | 認証状態で表示切替 |

callback パラメータは **同一オリジンのパスのみ・`//` 拒否**で open redirect を防止。

## 変更ファイル（5）

| ファイル | 反映内容 |
|---|---|
| `firebase-auth-frontend/SKILL.md` | 3 パターン契約、デフォルトページ表、callback 仕様、ガード実装契約 |
| `firebase-auth-frontend/references/nextjs.md` | `<AuthGate type=...>` 雛形 + `/login` `/signup` `/mfa/enroll` `/settings(layout)` `/` のスケルトン + middleware 例 |
| `firebase-auth-frontend/references/hotwire.md` | `PageAccessControl` concern + `SessionsController` / `RegistrationsController`（別 controller・相互リンク）+ `MfaEnrollmentsController` / `SettingsController` (protected) + `HomeController` (public-aware) |
| `auth-requirements-extraction/SKILL.md` | ページ単位の認証要否チェックリスト追加 |
| `firebase-auth-design/templates/auth-section.template.md` | ページ単位アクセス制御表（A/B/C 記入欄、逸脱は `decision_record`） |

## 判断ポイント

- [x] **要件で別指定がある場合は要件優先**を SKILL.md / design テンプレ / 要件抽出スキルで一貫して明記
- [x] **`/login` と `/signup` を別ページ**として既定化（統合する案件指定があれば理由とともに decision_record に明示）
- [x] callback URL の検証ポリシー（open redirect 防止）を明文化
- [ ] 既定遷移先（`/`）を変える案件のためのフィールド `page_access_control.default_after_login` を design スキーマに追加するか（次フェーズ／別 PR）

## マージ要件（T-014）

- [ ] **R-011**: CI がパスし、1 名以上の Approve がある
- [x] **R-012**: スキルのみ。サンプル実装での E2E は次フェーズ（PR 後）
- [x] **R-013**: 追加は Markdown のみ

## レビュアー

- 豊田（T-005 本決定で 1 名体制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)