### PR TITLE
docs(auth-plugin): usage-guide にプロンプト例（T-021 再パイロット実例）を追加

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
@@ -67,3 +67,138 @@ claude plugin validate --strict plugins/xtone-auth-plugin
 ## 6. 差し替え可能設計（他 IaaS 追加）
 
 Firebase 固有処理は `AuthAdapter` 実装に閉じ込める。別 IaaS（Cognito / Auth0 / Devise 等）追加時はアダプタ実装の差し替えで対応する（Rollout フェーズで実証）。
+
+## 7. プロンプト例（T-021 再パイロットの実例から）
+
+T-021 再パイロット（架空案件「オンライン診療・問診」/ 医療 × MFA required × Next.js + Rails）で**実際に使われた指示文**をフェーズごとに整理する。プロンプトは **「案件前提・判断ポイントの決定・任せる範囲」を明示**することで、AI が `undecided` を残さず `decision_record` に書く / 適切なスキルとレシピを呼ぶ動きをする。
+
+### 7.1 要件定義（`/req-collect` ＋ `auth-requirements-extraction`）
+
+案件の前提と要望を 1 メッセージで揃え、要件抽出スキルを呼ぶ。
+
+```
+医療「オンライン診療・問診」案件で要件定義を進めてください。
+- ロール: 医療従事者 / 患者の2ロール
+- 認証方式: メール+パスワード、パスワードレス（OIDC は could）
+- MFA: 全ユーザー必須（要配慮個人情報のため）
+- 規制: 個人情報保護法（要配慮個人情報）、3省2ガイドライン
+- 退会: 認証アカウント削除と診療データ保存の分離（法定保存期間）
+- 構成: Next.js(App Router) フロント + Rails API バックエンド
+DP-007 / DP-008 は要件段階では undecided にして設計に引き継いでください。
+ページ単位の認証要否（A/B/C）も洗い出してください。
+```
+
+→ `delivery/requirements.json`（`scope` / `representative_use_cases` / `functional_requirements` / `undecided=[DP-007,DP-008]`）。
+
+### 7.2 設計（`/auth-design` ＋ `authentication-architect` / `firebase-auth-design`）
+
+判断ポイントの決定 + 責務仕分け + ページアクセス制御を一度に揃える。
+
+```
+requirements.json をもとに認証設計（design.yaml）を作ってください。
+- DP-007: Firebase Auth を採用候補とし、Devise+OmniAuth と Auth0 と比較した
+  ADR-001 を残す（差し替え可能設計を AuthAdapter で維持）
+- DP-008: MFA = required（全員必須・TOTP 主体、emulator 検証では SMS で代替）
+- responsibility_split を Next.js=client / Rails=backend / iaas / shared で明示
+- セッション戦略: BFF（HttpOnly クッキー）を採用 → ADR-002 に記録
+- ページ単位アクセス制御: firebase-auth-frontend のデフォルト 3 パターン
+  （A: protected-only / B: public-aware / C: guest-only）を採用
+- 医療規制（3省2GL）を domain_specific_checks に
+```
+
+→ `delivery/design.yaml` + `ADR-001` `ADR-002`、`responsibility_split` + `page_access_control` + `decision_record`、`undecided=[]`。
+
+### 7.3 スキーマ検証（B-01 解消の確認）
+
+```
+delivery/requirements.json と delivery/design.yaml を xtone-shared-plugin/schemas/v1/
+の本実装スキーマで検証してください。必須フィールド欠落のネガティブ検証
+（検証が実際に効くこと）も含めて確認してください。
+```
+
+→ `jsonschema` で PASS、ネガティブで NG を検出。
+
+### 7.4 実装：backend（`firebase-auth-setup` + `firebase-auth-mfa` の Rails レシピ）
+
+```
+Rails API backend を実装してください。
+- firebase-auth-setup の rails レシピ: AuthAdapter 抽象 / FirebaseAdapter /
+  TestAdapter / Authenticatable concern / 運用契約（退会 Admin 削除・証明書
+  キャッシュ・2 段階失効）
+- firebase-auth-mfa の rails レシピ: verify_token に second_factor 取り込み /
+  MfaEnforceable concern（required を強制）/ MfaController#changed（soft 失効）
+- 退会は hard_revoke_tokens! を呼び、診療データは法定保存期間まで保持（ADR-002）
+- TestAdapter で結合テスト（実 Firebase 不要、9件想定）
+- bin/rails test と bin/rails zeitwerk:check が通ることを確認
+```
+
+→ minitest で MFA required / ロール認可 / 退会データ分離 / トークン失効 を検証。
+
+### 7.5 実装：frontend（`firebase-auth-frontend` + `firebase-auth-mfa` の Next.js レシピ + 3 パターン）
+
+```
+Next.js (App Router) frontend を実装してください。
+- firebase-auth-frontend の nextjs レシピ: lib/firebase.ts / lib/auth-client.ts /
+  メモリ保持 + 自動リフレッシュ
+- firebase-auth-mfa の nextjs レシピ: SMS MFA enrollment/challenge
+- 3 パターンの AuthGate コンポーネント（type="protected" | "public-aware" | "guest"）
+- /login と /signup は別ページ・相互リンク・callback 引き継ぎ（open redirect 防止）
+- /mfa/enroll, /settings, /consultations は protected-only
+- / は public-aware（認証状態でコンテンツ切替）
+- tsc --noEmit と next build が通ることを確認
+```
+
+→ `<AuthGate>` でルートガード、`safeCallback` で URL 検証。
+
+### 7.6 ローカル E2E（`firebase-auth-emulator` の Docker レシピ）
+
+```
+ローカルで E2E 検証するため、Docker で Firebase Auth Emulator 環境を構築してください。
+- firebase-auth-emulator の docker-compose / rails / nextjs レシピに沿う
+- backend は EMULATOR_HOST 設定時のみ署名検証スキップ + Admin REST 切替（Bearer owner）
+- frontend は connectAuthEmulator
+- 本番混入ガード（production && emulator? → abort）を入れる
+- docker compose up で起動、E2E スクリプトで:
+  signUp → emailVerified=true 設定 → signIn → /auth/session →
+  /consultations が 403 mfa_required → SMS MFA enroll → /consultations 200 →
+  ロール認可（医師=全件・患者=自分のみ）→ 退会 → 再ログイン拒否
+```
+
+→ docker-compose（auth-emulator / backend / frontend）が healthy、E2E 全 PASS。
+
+> **MFA は SMS で検証**（Auth Emulator は TOTP 非対応＝[firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)）。TOTP の E2E は実 Identity Platform で。
+
+### 7.7 ブラウザ動作確認（最小 UI）
+
+```
+http://localhost:3001 でフルフローをブラウザから操作できる最小 UI を実装してください。
+- /login（サインイン・/signup へのリンク・callback 引き継ぎ・guest-only）
+- /signup（サインアップ・/login へのリンク・callback 引き継ぎ・guest-only。
+  emulator では emailVerified=true 自動設定）
+- /mfa/enroll（SMS 登録、emulator からコード自動取得・protected-only）
+- /consultations（保護リソース・protected-only）
+- /settings（退会・protected-only）
+- /（認証状態に応じてコンテンツ切替・public-aware）
+- AuthGate で 3 パターン宣言的にラップ。tsc/next build 通過。
+```
+
+### 7.8 不具合報告 → 実機再現 → スキル根本対応
+
+実機で不具合を踏んだら「再現・原因特定・スキル修正」までセットで指示する。型を直すことで再発を防ぐ。
+
+```
+http://localhost:3001/consultations にログイン／MFA 設定後にアクセスすると
+401 が返ってきます。実際にブラウザで操作して確認してください。
+不具合を修正したら、スキルのどの部分が原因で発生した不具合かを調査し、
+スキル側でこの不具合が起きないように修正してください。
+```
+
+→ Playwright で再現 → 根本原因（**`auth_time` は MFA enrollment で更新されない** vs スキル既定の即時失効の衝突）特定 → **2 段階失効**にスキル更新（hard / soft 分離）。サンプル+スキル両方を修正し、再発を防ぐ。
+
+### 7.9 プロンプト設計のコツ
+
+- **案件前提と判断ポイントの決定を最初に揃える**: 「DP-XXX をこう決めた」と明示すると AI が `undecided` に残さず `decision_record` に書く
+- **判断は人間、実装は AI**: スタック比較・MFA 方針・セッション戦略・ページ A/B/C 振り分けはユーザーが決め、コードはスキルが書く（warn_and_document に沿う）
+- **不具合報告は「実機再現 + 原因特定 + スキル修正」までセットで**: 型を直すことで他案件にも効く（本プラグインの中核価値）
+- **横断機能は新スキル化を依頼する**: MFA / emulator / フロント 3 パターンのように backend/client 双方にまたがる機能は、既存スキルに無理に詰めず**横断スキル新設**を指示すると整合性が保たれる（前例: `firebase-auth-mfa`、`firebase-auth-emulator`）
+- **要件で別指定があれば要件優先**: スキル既定（例: ページ 3 パターンのデフォルト一覧）に反する案件特性はプロンプトで明示し、`decision_record` に逸脱根拠を残す


### PR DESCRIPTION
## 概要

xtone-auth-plugin の **usage-guide.md** に、T-021 再パイロット（架空案件「オンライン診療・問診」/ 医療 × MFA required × Next.js + Rails）で実際に使われた指示文を引用した「プロンプト例」節を追加します。

「**各ステップで実際にどのようなプロンプトを入力すればいいか**」という要望に応えて、要件定義 → 設計 → スキーマ検証 → backend 実装 → frontend 実装 → ローカル E2E → ブラウザ動作確認 → 不具合修正 までを 9 セクションで例示しています。

## 追加した節

| 節 | 内容 |
|---|---|
| 7.1 要件定義 | 案件前提 + `undecided=[DP-007,DP-008]` で設計引き継ぎ |
| 7.2 設計 | DP-007/008 / 責務仕分け / セッション戦略(BFF) / ページ3パターン を一度に決定 |
| 7.3 スキーマ検証 | B-01 解消の確認（ネガティブ検証込み） |
| 7.4 backend 実装 | setup + mfa の Rails レシピ + 2 段階失効 + TestAdapter テスト |
| 7.5 frontend 実装 | AuthGate + 3 パターン + /login/signup 分離 + tsc/build |
| 7.6 ローカル E2E | emulator スキル + Docker + SMS MFA で MFA required を E2E |
| 7.7 ブラウザ動作確認 | 最小 UI 実装 |
| 7.8 不具合報告 | 実機再現 + 原因特定 + スキル根本対応をセットで指示 |
| 7.9 プロンプト設計のコツ | 判断は人間/実装は AI、横断機能は新スキル化、要件で別指定があれば要件優先 |

## 期待効果

- 新しい認証案件着手時に、各フェーズで何を指示すれば適切なスキル/レシピが起動するかが**実例で**わかる
- 「DP-XXX をこう決めた」を明示することで AI が `undecided` を残さず `decision_record` に書く動きを促す
- 不具合報告フォーマット（実機再現 + 原因特定 + スキル修正）を例示することで、型の改善が継続する流れを残す

## マージ要件（T-014）

- [ ] **R-011**: CI がパスし、Approve がある
- [x] **R-012**: ドキュメントのみ（テスト対象外）
- [x] **R-013**: 追加は Markdown のみ

## レビュアー

- 豊田（T-005 本決定で 1 名体制）

🤖 Generated with [Claude Code](https://claude.com/claude-code)