### PR TITLE
docs(rollout): プラグイン開発者ガイド・プラグインユーザーガイドを新設

### DIFF
--- a/ai-delivery/README.md
+++ b/ai-delivery/README.md
@@ -4,13 +4,15 @@ Xtone の開発プロセスを **Claude Code プラグイン**で型化するプ
 
 ## ドキュメント案内
 
-| ファイル | 内容 |
-|---|---|
-| [CLAUDE.md](./CLAUDE.md) | Claude Code での作業ルール（鉄則・進め方・ID 体系） |
-| [docs/notion-db-catalog.md](./docs/notion-db-catalog.md) | 全 Notion DB の一覧と data_source_id、俯瞰ページ |
-| [docs/mcp-setup-guide.md](./docs/mcp-setup-guide.md) | MCP サーバー設定・トークン管理・WSL2・エラーハンドリング・トラブルシューティング |
-| [docs/environment-setup.md](./docs/environment-setup.md) | 実行環境のセットアップとバージョン方針（固定せず公式の最新安定版を使う） |
-| [docs/pending-decisions.md](./docs/pending-decisions.md) | 未決の判断ポイント（warn_and_document の出力先） |
+| ファイル | 内容 | 主な読者 |
+|---|---|---|
+| [CLAUDE.md](./CLAUDE.md) | Claude Code での作業ルール（鉄則・進め方・ID 体系） | 全員 |
+| **[docs/plugin-developer-guide.md](./docs/plugin-developer-guide.md)** | **プラグイン開発者ガイド** — 24 ユースケースの**新しいプラグインを作る**ための型と設計パターン（横断スキル化・契約と references の分離・既知の制約明文化・実機 E2E） | プラグイン開発者 |
+| **[docs/plugin-user-guide.md](./docs/plugin-user-guide.md)** | **プラグインユーザーガイド** — 案件で**プラグインを使う**ときの基本フロー・判断ポイント・フィードバックの送り方（backlog 形式）・トラブルシューティング | 案件チーム（PM・BE・FE 等） |
+| [docs/notion-db-catalog.md](./docs/notion-db-catalog.md) | 全 Notion DB の一覧と data_source_id、俯瞰ページ | 全員 |
+| [docs/mcp-setup-guide.md](./docs/mcp-setup-guide.md) | MCP サーバー設定・トークン管理・WSL2・エラーハンドリング・トラブルシューティング | 全員 |
+| [docs/environment-setup.md](./docs/environment-setup.md) | 実行環境のセットアップとバージョン方針（固定せず公式の最新安定版を使う） | 全員 |
+| [docs/pending-decisions.md](./docs/pending-decisions.md) | 未決の判断ポイント（warn_and_document の出力先） | 全員 |
 
 ## 真実の源（Source of Truth）は Notion にある
 

--- a/ai-delivery/docs/plugin-developer-guide.md
+++ b/ai-delivery/docs/plugin-developer-guide.md
@@ -1,0 +1,181 @@
+# プラグイン開発者ガイド（Rollout 24 ユースケース）
+
+このドキュメントは、AIデリバリシステムの **24 ユースケースのうち、新しいプラグインを実装する開発者**向け。MVP（T-021 認証プラグイン）と内部パイロット（T-022 ＋ T-021 再パイロット）で確立した型を使い、自分のドメインのプラグインを作るために必要な情報をここに集約する。
+
+> **既存資産との関係**: 本ガイドは「型の使い方」の発展形（プラグイン*ユーザー*向け）である [`plugin-user-guide.md`](./plugin-user-guide.md) と対をなす。プラグインを使う案件チームではなく、**プラグインを作る**側の視点。
+
+## このガイドの読者
+
+- 24 ユースケースのいずれか（管理画面 / コンテンツ配信 / 決済 / 通知 / コミュニティ 等）を担当する**型化プラグイン開発者**
+- 既存プラグインに新スキルを追加する開発者
+
+## 0. 中核価値（必読）
+
+リポジトリの [`ai-delivery/CLAUDE.md`](../CLAUDE.md) の鉄則をそのまま守る:
+
+1. **実装の根拠は Notion / コメントに ID 参照**（CONV- / SKL- / DP- / SCH- 等）
+2. **判断ポイントは「気づいたその場で」記録**（後でまとめない）
+3. **CI / Hook / Subagent は warn_and_document**（警告のみ・ブロックなし）
+4. **スキーマは Single Source of Truth**（CONV-14、`xtone-shared-plugin/schemas/v1/` のみに置く）
+
+これに反する設計をしないこと。型化プロジェクトの中核価値「**人間の判断を要するポイントをスルーさせない**」を全層で守る。
+
+## 1. プラグインの作り方（手順）
+
+### Step 1: マスターテンプレからコピー
+
+```bash
+# 将来 generate-plugin.sh が整備されたら（B-07 / TPL-26）:
+cd ai-delivery
+./xtone-plugin-template/scripts/generate-plugin.sh my-plugin
+
+# 現状は手動コピー
+cp -r xtone-plugin-template plugins/xtone-<your-domain>-plugin
+```
+
+### Step 2: プラグイン構造に従う
+
+```
+plugins/xtone-<domain>-plugin/
+├── .claude-plugin/plugin.json     # Claude Code 標準フィールドのみ
+├── README.md                      # 人間向け概要
+├── agents/                        # Subagent（基盤 6 + ドメイン特化）
+├── commands/                      # Slash Command（基盤 8 + ドメイン特化）
+├── hooks/                         # hooks.json + 4 Hook（warn_and_document）
+├── skills/
+│   ├── <domain>-plugin-guide/SKILL.md   # 運用ガイド（旧ルート CLAUDE.md / DP-27）
+│   ├── requirements/<domain>-requirements-extraction/
+│   ├── design/<domain>-design/ (+ templates/)
+│   ├── implementation/<domain>-setup/ (+ references/)
+│   └── implementation/<domain>-frontend/ など
+├── schemas/                       # xtone-shared-plugin への symlink（編集不可・CONV-14）
+├── docs/                          # decision-points / usage-guide / pending-decisions / adr
+├── sample-inputs/, sample-outputs/  # 架空案件の作り込み例
+└── .github/                       # PRテンプレ・CI
+```
+
+### Step 3: スキル設計の原則（言語非依存契約 + references）
+
+認証プラグインで確立した型:
+
+- **SKILL.md は言語/FW 非依存の「契約」と「手順」**を定義
+- 具体コードは `references/<stack>.md`（言語別レシピ）に分離
+- レシピを追加するときは契約を変えない（差し替え可能設計を維持）
+- **「既知の制約」を徹底的に明文化**（後続の開発者が同じ穴を踏まないため）
+- **「要件で別指定があれば要件優先」**を全層で明記
+
+### Step 4: 判断ポイント（DP-XXX）の追跡
+
+- 案件で出てくる判断は、既存 DP-XXX を再利用するか新規起票
+- 新規 DP は `docs/pending-decisions.md` に起票 → Notion 判断ポイントカタログDB に登録 → スキル側に「**未決のまま実装に来た場合は確定せず残す**」と明記
+- フェーズ移行時に `undecided` が残ると pre-phase-transition Hook が**警告**（ブロックはしない）
+
+### Step 5: パイロット → 訂正バックログ → 再パイロット
+
+認証プラグインで型化した検証サイクル:
+
+1. **架空案件**で要件→設計→実装を 1 本通す
+2. 発見事項を `pilot-report.md` に列挙（成功事例 + 失敗・摩擦）
+3. 訂正タスクを `backlog.md` ＋ GitHub Issue 化（High / Med / Low）
+4. High を解消した後で**再パイロット**（前回と異なる条件で）
+5. 再判定で Rollout Go/No-go を決める
+
+## 2. 認証プラグインから学べる設計パターン（必読）
+
+参考実装である [`xtone-auth-plugin`](../plugins/xtone-auth-plugin/) は MVP として完成し、Rollout Go 判定済み（ADR-002）。設計判断の根拠は再パイロット報告と一連の PR に残っているので、自分のドメインでも踏襲する。
+
+### 2.1 横断機能は独立スキルにする
+
+backend / client / iaas のどれか 2 つ以上にまたがる機能は、既存スキルに無理に詰めず**独立スキル**にする。
+
+- `firebase-auth-mfa`（[PR #143](https://github.com/xtone/ai_development_tools/pull/143)）— enrollment(client) / 検証・強制(backend) / iaas にまたがる
+- `firebase-auth-emulator`（[PR #145](https://github.com/xtone/ai_development_tools/pull/145)）— Docker / 署名検証スキップ / connectAuthEmulator にまたがる
+
+スキル内部で `responsibility_split` を表で示し、何が client / backend / iaas / shared かを明示する。
+
+### 2.2 言語非依存契約 + references レシピ
+
+すべてのスキルは「契約」と「実装手段」を分離する:
+
+| 層 | 役割 |
+|---|---|
+| `SKILL.md` | 言語非依存の契約・手順・既知の制約・判断ポイント |
+| `references/<stack>.md` | 言語/FW 別の具体コード（例: rails.md / nextjs.md / hotwire.md） |
+
+別言語が増えても契約は不変。新言語のレシピを追加するだけ。
+
+### 2.3 既知の制約は徹底的に明文化
+
+後続の開発者が同じ穴を踏まないように、スキル側にすべて書く:
+
+- 例: `firebase-auth-mfa/SKILL.md`「**`auth_time` は MFA enrollment で更新されない**」 / 「**emulator は `emailVerified=true` が前提**」
+- これらは再パイロットで実機の不具合として顕在化し、根本対応（[PR #147](https://github.com/xtone/ai_development_tools/pull/147)・2 段階失効）でスキルに反映された
+
+### 2.4 「要件で別指定があれば要件優先」を全層で明記
+
+スキル既定パターン（例: フロント 3 パターンの protected/public-aware/guest、デフォルトページ一覧）を作るときも、**案件で別指定があれば要件優先**を必ず書く:
+
+- `design.responsibility_split` または `page_access_control` で逸脱を明示
+- `decision_record` に逸脱根拠を残す
+- warn_and_document に沿わせる
+
+### 2.5 実機 E2E まで通す
+
+test スタブのみだと**型の穴を見逃す**。Docker + emulator + Playwright で実機まで通すと、再パイロットでの発見（auth_time 仕様の不具合）が拾える:
+
+- backend は TestAdapter で結合テスト（実 IaaS 不要）
+- frontend は tsc/build を通す
+- ローカル E2E は Docker emulator（auth-emulator / backend / frontend 3 サービス）
+- ブラウザ動作確認は最小 UI で実プロンプト経由
+
+### 2.6 不具合は「再現 + 原因特定 + スキル根本対応」までセットで
+
+実機で不具合を踏んだら、スキルの型を直すまでが 1 タスク。再パイロットの auth_time 不具合は **Playwright で再現 → 原因（Firebase 仕様）特定 → スキルの 2 段階失効化**まで進めた（PR #147）。これにより他案件での再発を防ぐ。
+
+## 3. 参考実装と便利リンク
+
+- **xtone-auth-plugin（MVP / Rollout Go 判定済み）**
+  - 全体ガイド: [`auth-plugin-guide`](../plugins/xtone-auth-plugin/skills/auth-plugin-guide/SKILL.md)
+  - 使い方とプロンプト例: [`docs/usage-guide.md`](../plugins/xtone-auth-plugin/docs/usage-guide.md)（§7 が実プロンプト例）
+  - パイロット報告: [`pilot-report.md`](../plugins/xtone-auth-plugin/docs/pilot-report.md) / [`re-pilot-report.md`](../plugins/xtone-auth-plugin/docs/re-pilot-report.md)
+  - 訂正バックログ: [`backlog.md`](../plugins/xtone-auth-plugin/docs/backlog.md)
+  - 関連 PR: [#143](https://github.com/xtone/ai_development_tools/pull/143)〜[#150](https://github.com/xtone/ai_development_tools/pull/150)
+- **共通スキーマ**: `ai-delivery/xtone-shared-plugin/schemas/v1/`（編集不可・CONV-14）
+- **環境前提**: [`environment-setup.md`](./environment-setup.md)（バージョンは固定せず公式の最新安定版）
+- **Notion DB カタログ**: [`notion-db-catalog.md`](./notion-db-catalog.md)（16 DB 一覧）
+- **MCP 設定**: [`mcp-setup-guide.md`](./mcp-setup-guide.md)
+- **持ち越し事項管理（ADR 含む）**: Notion / ADR-001 作業ベース、ADR-002 Rollout Go
+
+## 4. レビュー・フィードバックの流れ
+
+### あなたから外への流れ
+
+- **PR レビュー**: 豊田（T-005 1 名体制）。Vertex AI 自動レビューが先に triage → review で指摘を出すので、Major までは対応してから人間レビュー依頼が効率的
+- **新規 DP / 規約改訂**: Notion 持ち越し事項管理に **ADR-NNN**（プロジェクト ADR）として起票
+- **新規 SKL / SCH / CONV**: Notion の各 DB に登録
+
+### プラグインユーザーからのフィードバックを受ける
+
+[`plugin-user-guide.md`](./plugin-user-guide.md) が案件チームに案内する**フィードバックフォーマット**は次の通り:
+
+- 案件で使って気づいた問題は、プラグインの `docs/backlog.md` 形式（**B-NNN**）で GitHub Issue 起票
+- 「症状 / 想定挙動 vs 実挙動 / 影響範囲 / 回避策」を含める
+- 開発者は **High（型の穴）/ Med / Low** でトリアージし、Rollout 並行で消化
+
+T-021 再パイロットの auth_time 不具合（PR #147）はこのフォーマットで「実機再現 → 原因特定 → スキル根本対応」まで到達した好例。プラグインユーザーからの報告も同じ流れで型を改善できる。
+
+## 5. Rollout 期間中の進め方
+
+- **新しいプラグインのキックオフ**: 該当ユースケース（24 のうち未着手のもの）の Notion タスク（T-NNN）を確認し、対応する DP / MOD を読み、本ガイドの Step 1〜5 で実装
+- **複数並行**: 24 を 1 人で全部はやらない。**ユースケース担当者**を Notion 型化タスクDB の「担当ロール」で明示する
+- **共通基盤の改善**: 複数プラグインで似たパターンが出たら、**xtone-shared-plugin / xtone-plugin-template に昇格**させて他プラグインで使えるようにする（CONV-XX への昇格は持ち越し事項管理に ADR 化）
+
+## 6. T-049（四半期レビュー）との連携
+
+- 四半期で**未解決の DP / 持ち越し事項**を一括チェック（スタック禁止）
+- 各プラグインの **backlog 残存数**を集計し、型の改善優先度を決める
+- パイロット報告で見つかった発見事項のうち、Rollout 並行で消化できなかったものを次四半期に持ち越し
+
+---
+
+> **質問・提案**: GitHub Issue（`xtone/ai_development_tools` リポジトリ）or 豊田に直接。「やりたいことが既存スキルに無い」場合は遠慮なく**新スキル新設**を提案。横断機能なら独立スキル、特定の言語/FW 向けの実装は references レシピに、という分離を意識する。

--- a/ai-delivery/docs/plugin-user-guide.md
+++ b/ai-delivery/docs/plugin-user-guide.md
@@ -1,0 +1,169 @@
+# プラグインユーザーガイド（案件で型化プラグインを使う）
+
+このドキュメントは、AIデリバリシステムの **型化プラグインを使って実案件を進める開発者**向け。要件→設計→実装の各フェーズで、プラグインがどう支援するか、**自分が何を判断するか**、不具合や改善要望をどう開発者に届けるかを示す。
+
+> **対をなすガイド**: プラグインを*作る*側は [`plugin-developer-guide.md`](./plugin-developer-guide.md)。
+
+## このガイドの読者
+
+- 実案件で型化プラグインを使う**プロジェクトメンバー**（PM / バックエンド / フロント / アプリ / インフラ）
+- プラグインのフィードバック（うまく動かない / 改善要望）をプラグイン開発者に伝えたい開発者
+
+## 0. まず読んでほしい中核価値
+
+> **AI に決めさせない判断は、必ず人間に上がってくる仕組みです。**
+
+CI / Hook / Subagent はすべて **warn_and_document**（警告のみ・ブロックなし）。フェーズ移行時に未決ポイントが残っていると警告が出るが、進めることはできる。**警告を放置せず、最終的に必ず人間判断で確定する**ことが型化の中核価値です。
+
+## 1. 基本の流れ
+
+### 1.1 ドメインに合うプラグインをロード
+
+```bash
+# 例: 認証案件
+cd ai-delivery
+claude --plugin-dir plugins/xtone-auth-plugin
+```
+
+利用可能なプラグイン一覧は `ai-delivery/plugins/` 配下を参照（Rollout フェーズで段階的に増える）。
+
+### 1.2 フェーズを順に進める
+
+```
+/req-collect → /design → /implement
+```
+
+各プラグインに**フェーズ固有のコマンド**が追加されている（例: 認証は `/auth-design`、認証ドメイン特化の設計）。
+
+### 1.3 補助コマンド
+
+- `/decide` — 判断記録
+- `/status` — 進捗
+- `/next` — 次アクション
+- `/pending-list` — 未決一覧
+- `/skip-review` — AI レビュー
+
+## 2. あなたが決めること / AI が書くこと
+
+### あなた（人間）が決めること = 判断ポイント
+
+| カテゴリ | 例 |
+|---|---|
+| スタック選定 | DP-007 認証スタック / DP-004 アーキテクチャ |
+| セキュリティ・規制 | DP-008 MFA 方針 / DP-015 dAccount / DP-016 PCI-DSS |
+| 非機能要件 | ユーザー規模 / SLA / 退会データ保存期間 |
+| ドメイン特化 | 業界規制・コンプライアンス（医療なら 3省2GL、金融なら FISC など） |
+| 既定パターンからの逸脱 | フロント 3 パターン（protected/public-aware/guest）と違う配置にする 等 |
+
+これらは **AI が決めず推奨だけ提示**する設計。あなたが決めたものを `decision_record` に記録、決まらないものは `undecided` に残す。
+
+### AI が書くこと
+
+- スキーマに沿った構造化成果物（requirements.json / design.yaml / implementation-plan.json）
+- 言語非依存の契約に従ったコード（プラグインの references レシピ準拠）
+- スキル既定パターン（例: 認証なら「2 段階の失効」「3 パターンの認証ガード」「/login と /signup の別ページ化」）
+
+## 3. 「警告」と「未決」の扱い方
+
+### 警告が出たら
+
+フェーズ移行時に **pre-phase-transition Hook** が `undecided` を検出して警告を出す（ブロックはしない）。
+
+- **未決を残したまま進める** — 後で必ず人間判断で確定する前提なら OK。`docs/pending-decisions.md` に残る
+- **その場で決める** — 判断材料が揃っているなら、`/decide` で `decision_record` に記録して `undecided` から外す
+
+### 未決を放置しない
+
+- 案件横断で再発する未決は **DP-NNN として正式起票**（Notion 判断ポイントカタログDB）
+- T-049（四半期レビュー）で未決一括チェックがあるので、それまでには消化する
+
+## 4. delivery 成果物の確認
+
+各フェーズで `delivery/` 配下に成果物が出る:
+
+| フェーズ | 成果物 |
+|---|---|
+| 要件定義 | `requirements.json` |
+| 設計 | `design.yaml` + `docs/adr/ADR-NNN.md` |
+| 実装 | `implementation-plan.json` + 実装コード |
+
+**スキーマ検証**は必ず通す（B-01 で本実装済み）。検証が落ちる場合は、案件特有の要件で逸脱しているのか、スキーマ側の穴かを切り分けてフィードバックする。
+
+## 5. フィードバックの送り方（重要）
+
+プラグインを使って気づいた問題（穴・改善余地・不具合・改善要望）は、**訂正バックログ形式**でプラグイン開発者に送ります。
+
+### 5.1 フォーマット
+
+参考: [認証プラグインの backlog.md](../plugins/xtone-auth-plugin/docs/backlog.md)
+
+| 項目 | 内容 |
+|---|---|
+| **症状** | 実機で再現できる具体的な手順 |
+| **想定挙動 vs 実挙動** | スキルや usage-guide に書かれている内容との差 |
+| **重要度** | High（型の穴・実装が止まる）/ Med（並行対応可）/ Low（任意改善） |
+| **影響範囲** | 自分の案件のみ / 同種案件にも影響 / 横断的 |
+| **回避策**（あれば） | 案件で踏んだ対処 |
+| **再現コード**（あれば） | プロンプトや E2E スクリプトの抜粋 |
+
+### 5.2 起票先
+
+- **プラグイン特定の問題** → そのプラグインの `docs/backlog.md` に **B-NNN** で追記 + GitHub Issue
+- **横断的な問題**（複数プラグインに関わる、CONV/スキーマレベル）→ `ai-delivery/` 全体の GitHub Issue
+- **新規 DP 候補** → プラグインの `docs/pending-decisions.md` に起票
+
+### 5.3 良いフィードバックの例
+
+T-021 再パイロットで踏んだ `auth_time` 不具合（[PR #147](https://github.com/xtone/ai_development_tools/pull/147)）は：
+
+1. **症状**: `/consultations` でログイン→ MFA 設定後に **401 `token revoked`**
+2. **想定 vs 実挙動**: 想定は 200（MFA 充足）。実挙動は 401（backend が `auth_time < tokens_valid_after` で拒否）
+3. **重要度**: High（実装が止まる）
+4. **影響範囲**: MFA を使う全案件
+5. **回避策**: なし
+6. **再現コード**: Playwright で `/signup → /mfa/enroll → /consultations` の操作
+
+→ 開発者が原因を特定（Firebase の `auth_time` は MFA enrollment で更新されない仕様）し、**スキルの型を直す**まで進めた（2 段階失効化、再発防止）。
+
+このように、**実機再現 + 原因仮説**まで添えるとスキルの根本改善につながりやすい。
+
+## 6. トラブルシューティング（よくある罠）
+
+各プラグインの「既知の制約」は SKILL.md に書いてあるので、まずそこを読む。代表的なもの:
+
+### 認証プラグイン
+
+- **Firebase Auth Emulator は TOTP MFA 非対応** — ローカル検証は SMS で代替、TOTP は実 Identity Platform で（[firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)）
+- **emulator の MFA enrollment は `emailVerified=true` 前提** — signUp 後に `accounts:update` で立てる
+- **`auth_time` は MFA enrollment で更新されない** — MFA 変更時は **soft 失効**（IaaS refresh のみ、サーバ側 `tokens_valid_after` は触らない）
+- 詳細: [`firebase-auth-mfa` SKILL.md の既知の制約](../plugins/xtone-auth-plugin/skills/implementation/firebase-auth-mfa/SKILL.md)
+
+### 環境前提
+
+- バージョンは固定しない方針（[`environment-setup.md`](./environment-setup.md)）— 公式の最新安定版を使う。古いシステム Ruby/Node を踏みやすいので、rbenv / mise / nvm 等で最新を入れる
+
+## 7. 参考プラグインの使い方
+
+最初に読むべきは、対応プラグインの **`docs/usage-guide.md`** の「プロンプト例」節。実プロンプトが各フェーズで載っているので、自分の案件に置き換えて使える。
+
+代表例: [認証プラグイン usage-guide §7「プロンプト例」](../plugins/xtone-auth-plugin/docs/usage-guide.md#7-プロンプト例t-021-再パイロットの実例から)
+
+- 7.1 要件定義
+- 7.2 設計（判断ポイント決定）
+- 7.3 スキーマ検証
+- 7.4 backend 実装
+- 7.5 frontend 実装
+- 7.6 ローカル E2E（Docker emulator）
+- 7.7 ブラウザ動作確認
+- 7.8 不具合報告 → 実機再現 → スキル根本対応
+- 7.9 プロンプト設計のコツ
+
+## 8. レビュー・サポート
+
+- **使い方の質問・困りごと**: 開発チーム（Slack の関連チャンネル）or 豊田に直接
+- **機能要望・不具合**: 上記 §5 のフォーマットで GitHub Issue
+- **案件横断の判断ポイント**: Notion 持ち越し事項管理（ADR）
+
+---
+
+> **プラグインユーザーは「型化の改善ループ」の重要な担い手**です。実案件で踏んだ穴ほど、型化の品質を上げる材料になります。気軽に GitHub Issue を立ててください。


### PR DESCRIPTION
## 概要

T-022 Rollout = Go 判定後、24 ユースケースに展開するための基盤整備として、2 読者向けのガイドを新設します。

| ガイド | 読者 | 主な内容 |
|---|---|---|
| **`plugin-developer-guide.md`** | 24 ユースケースの**新規プラグイン実装者** | マスターテンプレからの流れ、認証プラグイン(MVP)で確立した設計パターン、レビュー/フィードバック動線、Rollout 期間中の進め方 |
| **`plugin-user-guide.md`** | 案件で**プラグインを使う**メンバー（PM/BE/FE 等）| 中核価値、基本フロー、人間判断 vs AI、警告と未決の扱い、フィードバック送付（backlog 形式）、トラブルシューティング |

`ai-delivery/README.md` のドキュメント案内に両ガイドへの導線を追加（主な読者列も新設）。

## plugin-developer-guide.md の要点

認証プラグインで確立した設計パターンを 6 つに整理して再利用可能化:

1. **横断機能は独立スキルに**（MFA / emulator）
2. **言語非依存契約 + references レシピ**
3. **既知の制約の徹底的な明文化**（後続が同じ穴を踏まない）
4. **「要件で別指定があれば要件優先」を全層で明記**
5. **実機 E2E まで通す**（test スタブだけだと型の穴を見逃す）
6. **不具合は「再現 + 原因特定 + スキル根本対応」までセット**

参考実装として `xtone-auth-plugin` の SKILL / usage-guide / pilot-report / backlog 全てを相互リンク。

## plugin-user-guide.md の要点

**フィードバックの送り方**を T-021 再パイロットの auth_time 不具合（PR #147）を実例として明示:

- 症状 / 想定 vs 実挙動 / 重要度 / 影響範囲 / 回避策 / 再現コードを揃える
- 起票先: プラグイン特定なら `docs/backlog.md` + GitHub Issue、横断なら ai-delivery 全体 Issue、新規 DP 候補は `pending-decisions.md`
- 「型化の改善ループの担い手はプラグインユーザー」というメッセージで締める

## マージ要件

- [ ] R-011: CI + Approve
- [x] R-012: ドキュメントのみ
- [x] R-013: Markdown のみ

## レビュアー

- 豊田

🤖 Generated with [Claude Code](https://claude.com/claude-code)