### PR TITLE
feat(B-16): hotwire レシピ細部修正（v9 modular / singular resource / alert 禁止）

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
@@ -21,13 +21,17 @@ T-022 内部パイロット（[pilot-report.md](./pilot-report.md)）で発見�
 | **B-10** | [#141](https://github.com/xtone/ai_development_tools/issues/141) | Architecture | Med | **フロントエンド認証実装スキル新設**（`firebase-auth-frontend` ＋ hotwire/nextjs レシピ）。#130 で責務分類した `client` 側の実装ガイドが欠落（firebase-auth-setup は backend 専用）。セッション戦略は判断ポイント扱い | SKL- / #130 | #130 レビュー後 |
 | **B-13** | [#153](https://github.com/xtone/ai_development_tools/issues/153) | Architecture | High | **実装フェーズに skill_plan 生成を強制**。`implementation-skill-planner` スキル新設＋ `design.schema.page_access_control` / `local_dev_stack` 追加＋ `implementation-plan.schema.skill_plan` 追加（**required かつ minItems=1**。MVP 期は CONV-14 並行保持を厳格適用せず最新スキーマで型化を強制 / DP-MVP-COMPAT）。frontend / emulator スキル呼び出し漏れ防止 | SKL- / FLD- | サンプル案件 sample-auth |
 | **B-14** | [#155](https://github.com/xtone/ai_development_tools/issues/155) | Documentation | Med | **`sample-outputs/` を 1 から再生成**。B-13 で削除（古いサンプルが新スキーマと不整合のため）。B-11〜B-14 一連のサンプル案件由来型化修正が完了したタイミングで、新スキーマ（page_access_control / local_dev_stack / skill_plan）と新スキル群（implementation-skill-planner 等）に沿った成果物を再構築 | SKL- / FLD- | PR #154 レビュー（豊田）|
+| **B-11** | [#156](https://github.com/xtone/ai_development_tools/issues/156) | Tooling | High | **`tech-version-check` スキル新設**。context7 / WebFetch で公式最新安定版・互換性を事前取得し `delivery/version-matrix.md` に記録。Ruby/Rails 等の非互換に途中で当たる事故を防止 | SKL- / TPL- | sample-auth |
+| **B-12** | [#157](https://github.com/xtone/ai_development_tools/issues/157) | Architecture | High | **Firebase Emulator + Docker をローカル開発の既定化**。B-13 で schema 側 `local_dev_stack` は導入済み。本件は **スキル中身**（docker-compose テンプレ / Adapter 分岐 / connectAuthEmulator 統合）を整備。B-14 の前提 | SKL- | sample-auth |
+| **B-15** | [#158](https://github.com/xtone/ai_development_tools/issues/158) | Architecture | Med | **`auth-e2e-verify` スキル新設**。Playwright で `representative_use_cases` を全件通すまで責務化。`alert()` 禁止 等の MCP/Headless 配慮も込み。前提: B-12 | SKL- | sample-auth |
+| **B-16** | [#159](https://github.com/xtone/ai_development_tools/issues/159) | Plugin | Low | hotwire レシピ細部修正（Rails singular resource / `alert()` 禁止 / Firebase v9 modular 統一） | SKL- | sample-auth |
 
 ## 優先度の考え方
 
 - **High（Rollout 前に解消推奨）**: B-01 / B-02 / B-05 / B-06。いずれも「型の穴」で、24 ユースケース展開で繰り返しコスト化する。
-- **Med（Rollout と並行可）**: B-03 / B-04 / B-07 / B-10 / B-14。
-- **Low（任意・改善）**: B-08 / B-09。
-- **Rollout 後追加 High**（24 ユースケース展開と並行で塞ぐ）: B-13（サンプル案件 sample-auth 由来。設計→実装のスキル呼び出しが暗黙的で frontend / emulator が素通りした穴）。
+- **Med（Rollout と並行可）**: B-03 / B-04 / B-07 / B-10 / B-14 / B-15。
+- **Low（任意・改善）**: B-08 / B-09 / B-16。
+- **Rollout 後追加 High**（24 ユースケース展開と並行で塞ぐ）: B-11（バージョン取得）/ B-12（Emulator 既定化）/ B-13（スキル呼び出し計画）。いずれもサンプル案件 sample-auth 由来。
 
 ## 次アクション
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -7,15 +7,17 @@
 
 ## 1. Firebase JS SDK の導入
 
+> **前提: Firebase JS SDK v9+（modular API）を採用する。** v8 namespaced API（`firebase.auth().signInWithEmailAndPassword(...)` 形式）は非推奨。本レシピのコード片はすべて modular（`import { signInWithEmailAndPassword } from "firebase/auth"`）。`package.json` の `firebase` が `^9.0.0` 未満の場合は更新してから本レシピを適用する。
+
 importmap（Rails 標準）の例:
 
 ```ruby
 # config/importmap.rb
-pin "firebase/app", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-app.js"
-pin "firebase/auth", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-auth.js"
+pin "firebase/app",  to: "https://www.gstatic.com/firebasejs/<latest>/firebase-app.js"   # v9+ modular CDN
+pin "firebase/auth", to: "https://www.gstatic.com/firebasejs/<latest>/firebase-auth.js"  # v9+ modular CDN
 ```
 
-> `<latest>` は固定値でなく公式の最新安定版を使う（environment-setup.md）。esbuild/jsbundling を使う場合は `npm i firebase`。Firebase の Web 設定値（apiKey 等）は公開前提の値だが、`config/credentials` か ENV から埋め込む。
+> `<latest>` は固定値でなく公式の最新安定版を使う（[`ai-delivery/docs/environment-setup.md`](../../../../../../docs/environment-setup.md)）。特定バージョン固定は判断ポイントとして `pending-decisions.md` に起票する。esbuild/jsbundling を使う場合は `npm i firebase`。Firebase の Web 設定値（apiKey 等）は公開前提の値だが、`config/credentials` か ENV から埋め込む。
 
 ## 2. AuthClient（契約の実装）
 
@@ -226,12 +228,62 @@ end
 get  "login",  to: "sessions#new",      as: :login
 post "login",  to: "sessions#create"
 get  "signup", to: "registrations#new", as: :signup
-# /mfa/enroll, /settings/* も同様に定義
+
+# /settings/* は singular resource（resource、複数形 resources ではない）で揃える。
+# 各 settings 配下は 1 ユーザに 1 件のため、ヘルパーは edit_profile_path / profile_path のように
+# Rails 規約どおりに生成される（profile_edit_path のような誤名で混乱しないよう singular に統一）。
+namespace :settings do
+  resource :profile,    only: [:show, :edit, :update]
+  resource :email,      only: [:edit, :update]    # メール変更（responsibility=iaas、表示用のみ）
+  resource :password,   only: [:edit, :update]    # PW 変更（responsibility=iaas、表示用のみ）
+  resource :withdrawal, only: [:new,  :create]    # 退会（responsibility=shared、DELETE /account を呼ぶ）
+end
+
+# MFA enrollment（firebase-auth-mfa との組合せ）
+resource :mfa_enrollment, only: [:new, :create], path: "mfa/enroll"
+
 root to: "home#index"
 ```
+
+> **routes 命名**: `/settings/*` 配下は **すべて singular resource（`resource :name`）** で揃え、`resources :names` を使わない。1 ユーザに 1 件の設定を扱うため。これにより `edit_settings_profile_path` のようなヘルパが生成され、`profile_edit_path` 系の手書き誤名が混入しなくなる。
 
 ## 7. 既知の制約 / 注意
 
 - Firebase JS SDK はブラウザ実行。`localStorage` ではなくメモリ保持 ＋ リフレッシュを既定にし、XSS リスクを下げる（戦略 A）。
 - パスワード変更・リセット・メール変更は Firebase JS SDK で完結し **Rails 実装不要**（responsibility=iaas）。
 - 退会はフロントから `DELETE /account` を呼び、サーバが論理削除＋Admin SDK 削除を行う（responsibility=shared）。
+- **Firebase JS SDK は v9+ modular 前提**。本レシピのコード片を v8 namespaced API（`firebase.auth().*`）に混ぜないこと。混在するとビルドは通っても挙動が壊れる。
+- **`alert()` / `confirm()` / `prompt()` を使わない**。MCP（claude-in-chrome / playwright）や Headless 実行で **モーダルダイアログが他の入力をブロック**し、E2E（B-15）が固まる。エラーや確認はすべて DOM への描画と `console.error` で行う（下記パターン）。
+
+### エラー / 確認の DOM フォールバック（alert 代替）
+
+```javascript
+// app/javascript/controllers/auth_controller.js（一部）
+import { Controller } from "@hotwired/stimulus"
+import { AuthClient } from "auth/client"
+
+export default class extends Controller {
+  static targets = ["email", "password", "flash"]   // flashTarget = エラー表示先の <div data-auth-target="flash">
+
+  async signIn(e) {
+    e.preventDefault()
+    try {
+      await AuthClient.signInWithPassword(this.emailTarget.value, this.passwordTarget.value)
+      await this.establishSession()
+    } catch (err) {
+      this.notify("ログインに失敗しました。メールアドレスとパスワードを確認してください。", err)
+    }
+  }
+
+  notify(message, err = null) {
+    // alert() は使わない（MCP/E2E で固まる）。DOM に出して console.error にも残す。
+    if (this.hasFlashTarget) {
+      this.flashTarget.textContent = message
+      this.flashTarget.hidden = false
+    }
+    if (err) console.error("[auth]", err)
+  }
+}
+```
+
+> 退会のように「ユーザー確認が必要」な操作は `confirm()` を使わず、**確認用の専用 Turbo Frame / ダイアログ要素**を出して二段階の操作にする（ブラウザ標準モーダルを避けることで E2E と一貫させる）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/references/hotwire.md
@@ -257,33 +257,41 @@ root to: "home#index"
 
 ### エラー / 確認の DOM フォールバック（alert 代替）
 
-```javascript
-// app/javascript/controllers/auth_controller.js（一部）
-import { Controller } from "@hotwired/stimulus"
-import { AuthClient } from "auth/client"
+[Section 3](#3-stimulus-コントローラサインイン--authsession) の `auth_controller.js` に、**try/catch と `flashTarget` への DOM 通知を追加する**差分。Section 3 が最小例で、本節がエラー処理を加えた拡張版。同じファイルなので Section 3 とは置き換える形で適用する（Section 3 と本節を**両方並べて配置しない**）。
 
-export default class extends Controller {
-  static targets = ["email", "password", "flash"]   // flashTarget = エラー表示先の <div data-auth-target="flash">
+```diff
+ // app/javascript/controllers/auth_controller.js
+ import { Controller } from "@hotwired/stimulus"
+ import { AuthClient } from "auth/client"
 
-  async signIn(e) {
-    e.preventDefault()
-    try {
-      await AuthClient.signInWithPassword(this.emailTarget.value, this.passwordTarget.value)
-      await this.establishSession()
-    } catch (err) {
-      this.notify("ログインに失敗しました。メールアドレスとパスワードを確認してください。", err)
-    }
-  }
+ export default class extends Controller {
+-  static targets = ["email", "password"]
++  static targets = ["email", "password", "flash"]   // flashTarget = エラー表示先の <div data-auth-target="flash">
 
-  notify(message, err = null) {
-    // alert() は使わない（MCP/E2E で固まる）。DOM に出して console.error にも残す。
-    if (this.hasFlashTarget) {
-      this.flashTarget.textContent = message
-      this.flashTarget.hidden = false
-    }
-    if (err) console.error("[auth]", err)
-  }
-}
+   async signIn(e) {
+     e.preventDefault()
+-    await AuthClient.signInWithPassword(this.emailTarget.value, this.passwordTarget.value)
+-    await this.establishSession()
++    try {
++      await AuthClient.signInWithPassword(this.emailTarget.value, this.passwordTarget.value)
++      await this.establishSession()
++    } catch (err) {
++      this.notify("ログインに失敗しました。メールアドレスとパスワードを確認してください。", err)
++    }
+   }
+
+   async establishSession() { /* ... Section 3 のまま ... */ }
+   csrf()            { /* ... Section 3 のまま ... */ }
+
++  notify(message, err = null) {
++    // alert() は使わない（MCP/E2E で固まる）。DOM に出して console.error にも残す。
++    if (this.hasFlashTarget) {
++      this.flashTarget.textContent = message
++      this.flashTarget.hidden = false
++    }
++    if (err) console.error("[auth]", err)
++  }
+ }
 ```
 
 > 退会のように「ユーザー確認が必要」な操作は `confirm()` を使わず、**確認用の専用 Turbo Frame / ダイアログ要素**を出して二段階の操作にする（ブラウザ標準モーダルを避けることで E2E と一貫させる）。


### PR DESCRIPTION
## Summary

サンプル案件 sample-auth で発見した `firebase-auth-frontend/references/hotwire.md` の細部問題への対応。3 点とも軽量だが、Claude が hotwire レシピを参照したときの誤コード混入や E2E 凍結（B-15 と関連）に直結するため早期に塞ぐ。

- **Firebase JS SDK v9+ modular 前提を明記**（v8 namespaced API は非推奨。`package.json` の `firebase` が `^9.0.0` 未満なら更新してから本レシピを適用）
- **`/settings/*` を singular resource パターンに統一**（routes.rb の例示を `resource :profile / :email / :password / :withdrawal` の形で追加。`edit_profile_path` 系の手書き誤名混入を防ぐ）
- **`alert()` / `confirm()` / `prompt()` 禁止**を「既知の制約 / 注意」に追加し、DOM フォールバック + `console.error` の Stimulus パターン例を追記（MCP / Playwright / Headless でモーダルが固まり B-15 E2E と相性が悪いため）

併せて `backlog.md` に B-11/B-12/B-15/B-16 の 4 件を追記、優先度分類を更新。

Closes #159
関連: #156 (B-11) / #157 (B-12) / #158 (B-15)

## 検証

- `claude plugin validate --strict` ✔
- hotwire.md のコード片の整合性確認（v9 modular import が既にコード例で使われていることを確認、v8 混在なし）

## Test plan

- [x] plugin validate
- [x] modular API 前提と既存コード片の整合性
- [ ] レビュー後、後続 B-12（Emulator 既定化）に着手

🤖 Generated with [Claude Code](https://claude.com/claude-code)