### PR TITLE
feat(B-12): Firebase Emulator + Docker をローカル開発の既定にする

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
@@ -89,6 +89,7 @@ Firebase Auth Emulator を Docker で起動して、`firebase-auth-setup`（back
 | 環境 | Docker | [`references/docker-compose.md`](./references/docker-compose.md) | ✅ |
 | backend | Ruby on Rails | [`references/rails.md`](./references/rails.md) | ✅ |
 | client | Next.js | [`references/nextjs.md`](./references/nextjs.md) | ✅ |
+| client | Rails + Hotwire | [`references/hotwire.md`](./references/hotwire.md) | ✅ |
 | その他 | — | — | 追加可（契約を満たす形で追加） |
 
 ## 既知の制約（くりかえし）

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
@@ -88,6 +88,39 @@ services:
 
 > **host の使い分け**: backend は Docker ネットワーク内なので `auth-emulator:9099`。frontend のブラウザ側コードは **ホスト OS のブラウザから** emulator に繋ぐので `localhost:9099`（コンテナ間 DNS は使えない）。NEXT_PUBLIC_ で分けるのが安全。
 
+### Rails + Hotwire 構成（backend と frontend が同居）
+
+Hotwire ベースの Rails アプリでは frontend を別コンテナにせず、backend サービスから ERB で window 経由でブラウザに値を渡す（[`hotwire.md`](./hotwire.md) 参照）。次のように `backend` サービスだけで完結する:
+
+```yaml
+services:
+  auth-emulator:
+    build: ./emulator
+    ports: ["9099:9099", "4000:4000"]
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:9099"]
+      interval: 5s
+      timeout: 3s
+      retries: 30
+
+  rails:
+    build: ./   # Rails アプリのルート（Gemfile / Dockerfile が直下）
+    environment:
+      AUTH_ADAPTER: "firebase"
+      FIREBASE_PROJECT_ID: "demo-project"
+      # Rails コンテナ内（backend 側）が emulator REST に繋ぐホスト名
+      FIREBASE_AUTH_EMULATOR_HOST: "auth-emulator:9099"
+      # ブラウザ（ホスト OS）が emulator に繋ぐホスト名。Rails の ERB で window に渡す
+      FIREBASE_PUBLIC_EMULATOR_HOST: "localhost:9099"
+      MFA_REQUIREMENT: "required"
+    ports: ["3000:3000"]
+    depends_on:
+      auth-emulator:
+        condition: service_healthy
+```
+
+> Rails 側は **2 つの ENV** を持つ点に注意（コンテナ間用 `FIREBASE_AUTH_EMULATOR_HOST` ／ ブラウザ用 `FIREBASE_PUBLIC_EMULATOR_HOST`）。両者を混同するとブラウザから繋がらない（同じ値にすると、コンテナ内の AdminClient が失敗する）。詳細は [`hotwire.md` の 1 節](./hotwire.md)。
+
 ## 4. 起動と確認
 
 ```bash

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/hotwire.md
@@ -73,9 +73,14 @@ emulator の REST から最新の検証コードを取り、`firebase-auth-mfa/r
 export async function fetchLatestEmulatorSmsCode(projectId = "demo-project") {
   const host = window.FIREBASE_AUTH_EMULATOR_HOST
   if (!host) throw new Error("emulator not configured")
-  const r = await fetch(`http://${host}/emulator/v1/projects/${projectId}/verificationCodes`)
+  // Authorization: Bearer owner は emulator の Admin REST 共通ヘッダ（nextjs.md と一貫）。
+  // emulator 専用。本番経路では絶対に使わない。
+  const r = await fetch(`http://${host}/emulator/v1/projects/${projectId}/verificationCodes`, {
+    headers: { Authorization: "Bearer owner" },
+  })
   if (!r.ok) throw new Error(`emulator REST failed: ${r.status}`)
   const { verificationCodes } = await r.json()
+  if (!verificationCodes?.length) throw new Error("no SMS code in emulator")
   return verificationCodes.at(-1)?.code   // 最新のコード
 }
 ```

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/hotwire.md
@@ -1,0 +1,102 @@
+# レシピ: Rails + Hotwire frontend のエミュレーター対応
+
+`firebase-auth-emulator` スキルの **client(Hotwire) 実装レシピ**。SKILL.md の client 契約（`connectAuthEmulator` / SMS MFA / SMS コード REST 取得）を、Rails 内の Stimulus + Firebase JS SDK 構成で満たす。土台は [`firebase-auth-frontend/references/hotwire.md`](../../firebase-auth-frontend/references/hotwire.md) と [`firebase-auth-mfa/references/hotwire.md`](../../firebase-auth-mfa/references/hotwire.md)。本レシピはその**差分のみ**を示す。
+
+- 対象: Rails（importmap または jsbundling）/ Firebase JS SDK v9+ modular — 公式の最新安定版
+
+## 1. EMULATOR_HOST をブラウザに渡す
+
+Rails サーバから window 経由でブラウザに渡す。本番ビルドでは未設定（`nil`）にしておけば、自動的に本番経路に切り替わる。
+
+```ruby
+# config/initializers/firebase_config.rb
+# `FIREBASE_AUTH_EMULATOR_HOST` を ENV から取得。production では未設定にする（本番混入ガード）。
+if Rails.env.production? && ENV["FIREBASE_AUTH_EMULATOR_HOST"].present?
+  abort "FATAL: FIREBASE_AUTH_EMULATOR_HOST is set in production. Refusing to start (firebase-auth-emulator)."
+end
+```
+
+```erb
+<%# app/views/layouts/application.html.erb の <head> 内に追加 %>
+<%# ブラウザ向け: ホスト OS からエミュレーターに繋ぐので localhost:9099。
+    Docker 内 Rails から rails コンテナ → emulator は auth-emulator:9099 と別物に注意。 %>
+<script>
+  window.FIREBASE_CONFIG = <%=
+    raw({
+      apiKey:     ENV.fetch("FIREBASE_API_KEY", "demo-key"),
+      projectId:  ENV.fetch("FIREBASE_PROJECT_ID", "demo-project"),
+      authDomain: ENV["FIREBASE_AUTH_DOMAIN"],
+      appId:      ENV["FIREBASE_APP_ID"],
+    }.to_json)
+  %>;
+  window.FIREBASE_AUTH_EMULATOR_HOST = <%= raw(ENV["FIREBASE_PUBLIC_EMULATOR_HOST"].to_json) %>;  // 例 "localhost:9099"。本番は null
+</script>
+```
+
+> Rails コンテナの ENV では `FIREBASE_AUTH_EMULATOR_HOST=auth-emulator:9099`（コンテナ間 DNS）、ブラウザ向けには **別の ENV キー** `FIREBASE_PUBLIC_EMULATOR_HOST=localhost:9099`（ホスト OS の Docker ポートフォワード経由）を分けて持つ。混同するとブラウザから繋がらない。
+
+## 2. connectAuthEmulator（初期化の差分）
+
+`firebase-auth-frontend/references/hotwire.md` の `app/javascript/auth/client.js` に **差分**を入れる。一度だけ呼ぶ（HMR / Turbo 再評価で複数回呼ぶとエラーになる）。
+
+```javascript
+// app/javascript/auth/client.js（差分）
+import { initializeApp } from "firebase/app"
+import {
+  getAuth, setPersistence, inMemoryPersistence, connectAuthEmulator,
+  signInWithEmailAndPassword, /* ... 以下省略 */
+} from "firebase/auth"
+
+const auth = getAuth(initializeApp(window.FIREBASE_CONFIG))
+setPersistence(auth, inMemoryPersistence)
+
+// ★ EMULATOR_HOST が設定されている場合のみエミュレーターに接続。本番ビルドでは window.FIREBASE_AUTH_EMULATOR_HOST が null/undefined。
+const EMU = window.FIREBASE_AUTH_EMULATOR_HOST
+if (EMU) {
+  try {
+    connectAuthEmulator(auth, `http://${EMU}`, { disableWarnings: true })
+  } catch {
+    // Turbo Drive で auth/client.js が再評価された場合、connectAuthEmulator は2回目以降エラーを投げる。
+    // 既に接続済みなので握りつぶしてよい（emulator/references/nextjs.md と同じ）。
+  }
+}
+```
+
+> Hotwire は Turbo Drive で頁遷移時に JS をリロードしないが、開発時の HMR や手動リロードでファイルが再評価される場面はある。`try/catch` で握りつぶすパターンは nextjs.md と一貫。
+
+## 3. SMS MFA コード自動取得（E2E テスト用）
+
+emulator の REST から最新の検証コードを取り、`firebase-auth-mfa/references/hotwire.md` の `confirmSms` に渡す。
+
+```javascript
+// test/system 等から呼ぶ E2E ヘルパ。production 環境では import しない。
+export async function fetchLatestEmulatorSmsCode(projectId = "demo-project") {
+  const host = window.FIREBASE_AUTH_EMULATOR_HOST
+  if (!host) throw new Error("emulator not configured")
+  const r = await fetch(`http://${host}/emulator/v1/projects/${projectId}/verificationCodes`)
+  if (!r.ok) throw new Error(`emulator REST failed: ${r.status}`)
+  const { verificationCodes } = await r.json()
+  return verificationCodes.at(-1)?.code   // 最新のコード
+}
+```
+
+> ブラウザ実機で UI 操作する場合は Emulator UI（`http://localhost:4000`）の「Auth → Phone numbers」から手動でコードを取れる。
+
+## 4. Stimulus からの利用（差分は無し）
+
+Stimulus controller（`firebase-auth-frontend/references/hotwire.md` の `auth_controller.js`）は **emulator/本番のどちらでも同じコード**。`AuthClient` 経由で呼ぶため、ホストの違いは `client.js` 内に閉じる。`alert()` 禁止・DOM フォールバック（B-16）は emulator でも本番でも同じ。
+
+## 5. 既知の制約 / 注意
+
+- 本レシピは `firebase-auth-frontend/references/hotwire.md` の差分。レシピ単独では動かない（土台と組み合わせる）。
+- `setPersistence(auth, inMemoryPersistence)` は emulator でも維持する（XSS 配慮の理由は本番と変わらない）。
+- 開発時に「`apiKey` 不正で `auth/api-key-not-valid` が出る」場合、`FIREBASE_API_KEY` は emulator なら任意値（"demo-key" 等）で OK。emulator は apiKey を検証しない。
+- **本番ビルドの混入ガード**: `Rails.env.production? && ENV["FIREBASE_AUTH_EMULATOR_HOST"].present?` を起動時 abort で塞ぐ（initializer 例参照）。
+- TOTP MFA は emulator 非対応。Hotwire でも TOTP の E2E は実 Identity Platform で実行する。
+
+## 6. 関連レシピ
+
+- 環境（compose）: [`./docker-compose.md`](./docker-compose.md)
+- backend: [`./rails.md`](./rails.md)
+- 別 FW client: [`./nextjs.md`](./nextjs.md)
+- 本レシピの土台: [`../../firebase-auth-frontend/references/hotwire.md`](../../firebase-auth-frontend/references/hotwire.md)

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
@@ -24,7 +24,7 @@ description: Firebase Auth をフロントエンド（クライアント）に�
 
 > **MFA（多要素認証, DP-008）は本スキルの対象外。** 第2要素の登録（enrollment）・サインイン時の追加認証（challenge）も client 実装だが、backend/iaas にまたがる横断機能のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約している。MFA を実装するときはそちらを参照。
 
-> **ローカル検証（Docker で Auth Emulator 起動・E2E）**は対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) を参照。`connectAuthEmulator` の初期化と **SMS MFA での E2E 検証**手順をそちらに集約（TOTP MFA はエミュレーター非対応のため、ローカルは SMS で代替し TOTP の E2E は実 Identity Platform）。
+> **ローカル開発の既定は Firebase Auth Emulator + Docker（B-12）。** 本スキルが client 実装を進めるときも、ローカルは実 Firebase に直接つながず、対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) スキルが提供する Auth Emulator を Docker で起動する。`connectAuthEmulator` の初期化と **SMS MFA での E2E 検証**手順は emulator 側に集約（TOTP MFA はエミュレーター非対応のため、ローカルは SMS で代替し TOTP の E2E は実 Identity Platform）。本番経路（実 Firebase Auth）と分岐するコードは emulator スキルの references にある。設計時に `design.yaml.local_dev_stack` を `cloud_direct` にする選択は判断ポイント扱い。
 
 ## 入出力（スキーマ）
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
@@ -23,7 +23,7 @@ description: Firebase Auth を任意のバックエンドに統合するスキ�
 
 > **スコープ: バックエンド（サーバ）専用。** ID トークン検証・JWT 認可・退会時の Admin SDK 削除・トークン失効など。フロントエンド（サインインUI・パスワード/メール変更・トークン保持・API への Bearer 付与）は対の [`firebase-auth-frontend`](../firebase-auth-frontend/SKILL.md) を参照。`responsibility_split` の **backend = 本スキル / client = firebase-auth-frontend / iaas = Firebase が提供**。MFA（多要素認証, DP-008）は client/backend/iaas 横断のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約（本スキルが担う MFA 部分は「クレーム検証・管理者強制・変更時の失効」）。
 
-> **ローカル検証（Docker で Auth Emulator 起動・E2E）**は対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) を参照。`FIREBASE_AUTH_EMULATOR_HOST` 検出時の **署名検証スキップ**と **Admin REST の host 切替（`Bearer owner`）** はそちらに集約し、本スキルの本番経路（RS256 + サービスアカウント）と分離する。
+> **ローカル開発の既定は Firebase Auth Emulator + Docker（B-12）。** 本スキルの「手順」を進めるとき、**ローカル検証は実 Firebase に直接つながず、対の [`firebase-auth-emulator`](../firebase-auth-emulator/SKILL.md) スキルが提供する Auth Emulator を Docker で起動する**ことを既定にする。`FIREBASE_AUTH_EMULATOR_HOST` 検出時の **署名検証スキップ**と **Admin REST の host 切替（`Bearer owner`）** はそちらに集約し、本スキルの本番経路（RS256 + サービスアカウント）と分離する。設計時に `design.yaml.local_dev_stack` を `cloud_direct` にする選択（実 Firebase 直接接続）は判断ポイント扱いで、根拠を `decision_record` に残させる。
 
 ## 入出力（スキーマ）
 


### PR DESCRIPTION
## Summary

サンプル案件 sample-auth で `firebase-auth-emulator` スキルが Claude の自己判断で素通りされ、Docker / Emulator 環境構築が手動になっていた。B-13（PR #154）で `design.schema.local_dev_stack` を追加・既定 `emulator_docker` 化したが、スキル側中身（特に Hotwire 用レシピ）に未整備な箇所が残っていたため、本 PR で完結させる。

## 変更点

- **`firebase-auth-emulator/references/hotwire.md` を新規作成** — これまで Hotwire 用の emulator レシピが欠落しており、Rails + Hotwire アプリでは `nextjs.md` が使えなかった。Hotwire 用に以下を網羅:
  - Rails ERB から `window` 経由でブラウザに `FIREBASE_AUTH_EMULATOR_HOST` を渡す方法（コンテナ用 vs ブラウザ用の host 使い分け）
  - `connectAuthEmulator` の初期化（Turbo Drive / HMR 再評価への耐性）
  - SMS MFA コード自動取得 REST（E2E テスト用）
  - **本番ビルド混入ガード**（`Rails.env.production? && ENV["FIREBASE_AUTH_EMULATOR_HOST"].present?` で起動 abort）
- **`firebase-auth-emulator/SKILL.md` のレシピ表に hotwire を追加**
- **`firebase-auth-emulator/references/docker-compose.md` に Rails+Hotwire 構成のスニペットを追加**（backend と frontend が同居する Hotwire 流。Next.js とは別パターン）
- **`firebase-auth-setup/SKILL.md` の「ローカル検証」記述**を「ローカル開発の既定は Auth Emulator + Docker」と**既定化を明示**するよう書き換え。`local_dev_stack=cloud_direct` は判断ポイント扱い
- **`firebase-auth-frontend/SKILL.md`** も同様に「ローカル既定」明示

Closes #157
関連: #154（B-13）/ #155（B-14 sample-outputs 再生成、本件完了後に着手）

## 検証

- `claude plugin validate --strict` ✔
- 新規 hotwire.md の構成は emulator/references/nextjs.md と並列（client 契約は SKILL.md と整合）
- docker-compose.md の追記は既存 Next.js 構成を破壊しない（別セクションとして追加）

## Test plan

- [x] plugin validate
- [x] hotwire/nextjs/rails の各レシピ間で host 使い分け（コンテナ間 vs ブラウザ）の整合性確認
- [ ] B-14（sample-outputs 再生成）時に Rails+Hotwire 構成のサンプルで実機検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)