### PR TITLE
feat(B-11): tech-version-check スキル新設（context7 で最新版確認・互換性事前検査）

### DIFF
--- a/ai-delivery/docs/environment-setup.md
+++ b/ai-delivery/docs/environment-setup.md
@@ -45,3 +45,4 @@ mise use node@lts   # または nvm install --lts
 
 - プラグインの**言語別レシピ**: `plugins/<plugin>/skills/implementation/<skill>/references/<stack>.md`
 - 特定バージョン固定が必要な場合の起票先: プラグインの `docs/pending-decisions.md`
+- **本方針を実行するスキル（B-11）**: `plugins/xtone-auth-plugin/skills/implementation/tech-version-check/` — 実装着手前に context7（WebFetch / WebSearch fallback）で公式最新を取得し `delivery/version-matrix.md` に記録する。`firebase-auth-setup` / `firebase-auth-frontend` を呼ぶ前提として実行する（横断スキルへの移管は別 Issue）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
@@ -23,6 +23,8 @@ Firebase Auth Emulator を Docker で起動して、`firebase-auth-setup`（back
 
 未呼び出しのまま実装フェーズが完了に到達した場合は warn_and_document に従い警告（T-002）。
 
+> **前提（B-11）**: 本スキルを呼ぶ前に [`tech-version-check`](../tech-version-check/SKILL.md) を実行し、`firebase-tools`（CLI）/ Node base image / Docker base image の **最新安定版**を `delivery/version-matrix.md` に取得・記録しておく。`emulator/Dockerfile` の `FIREBASE_TOOLS_VERSION` などはそこから引く。
+
 ## スコープと既知の制約
 
 | 項目 | エミュレーター対応 | 検証方針 |

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-frontend/SKILL.md
@@ -20,6 +20,8 @@ description: Firebase Auth をフロントエンド（クライアント）に�
 
 未呼び出しのまま実装フェーズが完了に到達した場合は `delivery/implementation-skill-plan.md` の `called` が false で残り、`docs/pending-decisions.md` に「未呼び出しスキル」として警告される（warn_and_document, T-002）。
 
+> **前提（B-11）**: 本スキルを呼ぶ前に [`tech-version-check`](../tech-version-check/SKILL.md) を実行し、Node / `firebase` JS SDK / FW（Next.js / Rails+Hotwire）等の **最新安定版と要求ランタイム**を `delivery/version-matrix.md` に取得・記録しておく。`package.json` の `firebase` バージョン（v9+ modular 前提）もそこから引く。
+
 > 役割分担: **Firebase クライアント SDK** が認証フロー（サインイン・パスワード/メール変更等）を担い、**サーバ（firebase-auth-setup）** は ID トークンの検証のみ。フロントは取得した ID トークンを API に Bearer で渡す。
 
 > **MFA（多要素認証, DP-008）は本スキルの対象外。** 第2要素の登録（enrollment）・サインイン時の追加認証（challenge）も client 実装だが、backend/iaas にまたがる横断機能のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約している。MFA を実装するときはそちらを参照。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-mfa/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-mfa/SKILL.md
@@ -25,6 +25,8 @@ description: Firebase Auth の MFA（多要素認証, TOTP/SMS）を実装する
 
 未呼び出しのまま実装フェーズが完了に到達した場合は warn_and_document に従い警告（T-002）。
 
+> **前提（B-11）**: 本スキルを呼ぶ前に [`tech-version-check`](../tech-version-check/SKILL.md) を実行し、Firebase Admin SDK / Firebase JS SDK / TOTP / SMS 関連ライブラリ等の **最新安定版と要求ランタイム**を `delivery/version-matrix.md` に取得・記録しておく。`Gemfile` / `package.json` に書く version はそこから引く。
+
 ## スコープと責務分割（responsibility_split）
 
 | 層 | 担当 | 本スキルでの内容 |

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/SKILL.md
@@ -19,6 +19,8 @@ description: Firebase Auth を任意のバックエンドに統合するスキ�
 
 未呼び出しのまま実装フェーズが完了に到達した場合は `delivery/implementation-skill-plan.md` の `called` が false で残り、`docs/pending-decisions.md` に警告される（warn_and_document, T-002）。
 
+> **前提（B-11）**: 本スキルを呼ぶ前に [`tech-version-check`](../tech-version-check/SKILL.md) を実行し、Ruby / Rails / 主要 gem 等の **最新安定版と要求ランタイム**を `delivery/version-matrix.md` に取得・記録しておく。`Gemfile` に書く version はそこから引く（バージョン非互換に気付くのが遅れる事故の防止）。
+
 > 設計方針: 言語が変わっても **契約は不変**、実装手段（SDK/コード）だけがレシピごとに変わる。Rails 固定にせず、Node/Laravel 等へ展開できる構造にする。
 
 > **スコープ: バックエンド（サーバ）専用。** ID トークン検証・JWT 認可・退会時の Admin SDK 削除・トークン失効など。フロントエンド（サインインUI・パスワード/メール変更・トークン保持・API への Bearer 付与）は対の [`firebase-auth-frontend`](../firebase-auth-frontend/SKILL.md) を参照。`responsibility_split` の **backend = 本スキル / client = firebase-auth-frontend / iaas = Firebase が提供**。MFA（多要素認証, DP-008）は client/backend/iaas 横断のため対の [`firebase-auth-mfa`](../firebase-auth-mfa/SKILL.md) に集約（本スキルが担う MFA 部分は「クレーム検証・管理者強制・変更時の失効」）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-skill-planner
-description: 設計成果物（design.yaml）から実装フェーズで呼び出すべきスキルを導出して skill_plan を生成するスキル。実装フェーズの Step 0 として、responsibility_split / page_access_control / authentication.mfa_requirement / local_dev_stack の値に応じて firebase-auth-setup / firebase-auth-frontend / firebase-auth-mfa / firebase-auth-emulator のうち呼ぶべきものを列挙し、implementation-plan.json の skill_plan に反映、`delivery/implementation-skill-plan.md` を出力する。frontend スキル等の呼び出し漏れ防止（B-13 由来）。
+description: 設計成果物（design.yaml）から実装フェーズで呼び出すべきスキルを導出して skill_plan を生成するスキル。実装フェーズの Step 0 として、architecture.stack / responsibility_split / page_access_control / authentication.mfa_requirement / local_dev_stack の値に応じて tech-version-check / firebase-auth-setup / firebase-auth-frontend / firebase-auth-mfa / firebase-auth-emulator のうち呼ぶべきものを列挙し、implementation-plan.json の skill_plan に反映、`delivery/implementation-skill-plan.md` を出力する。frontend スキル等の呼び出し漏れ防止（B-13 由来）。skill_plan の最先頭は tech-version-check（B-11）。
 ---
 
 # Implementation Skill Planner
@@ -67,6 +67,7 @@ design.yaml から自動導出（implementation-skill-planner / B-13）。
 
 | skill | recipe | owners | applies_to | required | called |
 |---|---|---|---|---|---|
+| tech-version-check | — | shared | architecture.stack に Ruby / Rails / Firebase JS SDK 等を記述 | true | ☐ |
 | firebase-auth-setup | rails | backend, shared | "ID トークン検証", "退会" | true | ☐ |
 | firebase-auth-frontend | hotwire | client, shared | /login, /signup, /settings/* | true | ☐ |
 | firebase-auth-mfa | rails+hotwire | backend, client, iaas | DP-008 | true | ☐ |

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
@@ -30,6 +30,7 @@ design の値から **必ず** 以下を skill_plan に列挙する。
 
 | design のフィールドと値 | 追加するスキル | recipe | owners | required |
 |---|---|---|---|---|
+| `architecture.stack` に**何らかの言語/FW が記述されている**（実装フェーズの全案件で必須） | `tech-version-check` | — | `[shared]` | true（**skill_plan の最先頭に置く**。既に `version-matrix.md` が直近に作成済みなら skip 可、その旨を trigger に明示） |
 | `responsibility_split[].owner` に `backend` or `shared` がある | `firebase-auth-setup` | 採用言語/FW（例: rails / node / laravel） | `[backend]`（shared 含む場合 `[backend, shared]`） | true |
 | `responsibility_split[].owner` に `client` or `shared` がある | `firebase-auth-frontend` | hotwire / nextjs / その他 | `[client]`（shared 含む場合 `[client, shared]`） | true |
 | `authentication.mfa_requirement` ∈ {`required`, `admin_only`, `optional`} | `firebase-auth-mfa` | rails＋hotwire / rails＋nextjs 等の組合せ | `[backend, client, iaas]` | `required`/`admin_only` は true、`optional` は false（推奨） |
@@ -37,6 +38,8 @@ design の値から **必ず** 以下を skill_plan に列挙する。
 | `page_access_control.pages` が定義されている | `firebase-auth-frontend`（既出なら統合） | 同上 | 同上＋`applies_to` に各 page.path を入れる | true |
 
 > **`local_dev_stack` が未指定**でも emulator スキルを追加するのは、B-12（Emulator+Docker を既定とする方針）に整合させるため。`cloud_direct` を選んだ場合のみ planner は emulator を外し、その判断を `decision_record` に残すよう促す。
+
+> **`tech-version-check` は最先頭に置く**（B-11）。バージョン非互換に気付くのが遅れる事故（sample-auth で発生）を防ぐため、setup / frontend / mfa / emulator のいずれよりも前に呼ぶ。既に `delivery/version-matrix.md` が直近で作成済みなら skip 可（trigger に "version-matrix.md is fresh" を残す）。
 
 ## 手順
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
@@ -65,44 +65,21 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
 5. 非互換が発覚した場合は判断ポイント化（pending-decisions に「採用バージョンを下げるか / 互換ライブラリを変えるか」を起票）。
 6. 取得情報を `implementation-plan.json.skill_plan` の本エントリ `called=true` に更新。
 
-## 出力テンプレ（version-matrix.md）
+## 出力テンプレ
 
-```markdown
-# 採用バージョン記録（tech-version-check / B-11）
+雛形（プレースホルダ・サンプル値・Gemfile/package.json/Dockerfile のコメント例を含む完全版）は **[`templates/version-matrix.template.md`](./templates/version-matrix.template.md)** を参照。`delivery/version-matrix.md` を新規作成するときは、このテンプレートをコピーして `<...>` プレースホルダを実値で埋める。
 
-- 作成日: 2026-05-26
-- 案件: <project>
-- design.yaml.architecture.stack: <quoted>
+テンプレートには次の節がある:
 
-## 言語ランタイム
-| 名前 | 採用バージョン | 公式最新 | 要求 | 根拠 URL |
-|---|---|---|---|---|
-| Ruby | 3.x.x (採用時点の最新安定版) | 3.x.x | — | https://www.ruby-lang.org/en/downloads/ |
+1. 言語ランタイム表
+2. メイン FW 表
+3. 主要ライブラリ・SDK 表
+4. ツール / コンテナ表
+5. 既知の非互換性 / 警戒事項
+6. 採用根拠の要約
+7. **Gemfile / package.json / Dockerfile に残すコメント例**（手順 4 で各依存ファイルへ追記する形式の見本）
 
-## メイン FW
-| 名前 | 採用 | 公式最新 | 要求ランタイム | 根拠 URL |
-|---|---|---|---|---|
-| Rails | 8.x.x | 8.x.x | Ruby 3.x+ | https://rubygems.org/gems/rails |
-
-## 主要ライブラリ・SDK
-| 名前 | 採用 | 公式最新 | 要求 | 根拠 URL |
-|---|---|---|---|---|
-| firebase (JS) | 9.x+ (modular) | 11.x.x | Node 18+ | https://www.npmjs.com/package/firebase |
-| jwt (gem) | 3.x | 3.x | Ruby 3.x+ | https://rubygems.org/gems/jwt |
-
-## ツール / コンテナ
-| 名前 | 採用 | 公式最新 | 用途 | 根拠 URL |
-|---|---|---|---|---|
-| firebase-tools | 14.x | 14.x | Emulator (B-12) | https://github.com/firebase/firebase-tools/releases |
-| node (base image) | 22-slim | 22.x | Emulator container | https://hub.docker.com/_/node |
-
-## 既知の非互換性 / 警戒事項
-- _(取得時点で問題があれば 1 行ずつ記録)_
-
-## 採用根拠の要約
-- 「公式の最新安定版」方針（environment-setup.md）に従い、`<確認日>` 時点で context7 / 公式リリースで取得した最新を採用。
-- 特定バージョン固定が必要な要件は受け取っていない。
-```
+> SKILL.md にインライン例を二重に持たない（テンプレートとの乖離回避）。Single Source of Truth はテンプレートファイル側。
 
 ## 判断ポイント（人間判断をスルーさせない）
 
@@ -114,4 +91,4 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
 
 - 後続: `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` / `firebase-auth-emulator`（本スキルの version-matrix.md に従って Gemfile / package.json / Dockerfile を埋める）
 - バージョン方針: [`ai-delivery/docs/environment-setup.md`](../../../../../docs/environment-setup.md)
-- 横展開: 本スキルは現状 xtone-auth-plugin 内に配置するが、本来は **横断スキル**（複数プラグインで共通利用）。`xtone-shared-plugin` / `xtone-plugin-template` への移管は別 Issue。
+- 横展開: 本スキルは現状 xtone-auth-plugin 内に配置するが、本来は **横断スキル**（複数プラグインで共通利用）。`xtone-shared-plugin` / `xtone-plugin-template` への移管は **backlog B-17（PR #162 マージ後に起票予定）** で扱う。本 PR ではプラグイン内配置のままで進める。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: tech-version-check
+description: 採用予定の言語/FW/主要ライブラリの **最新安定版と相互互換性** を実装着手の前に取得・記録するスキル。実装フェーズで firebase-auth-setup / firebase-auth-frontend / firebase-auth-mfa / firebase-auth-emulator を呼ぶ前の前提作業として、context7（または WebFetch / WebSearch fallback）で公式情報を引き、`delivery/version-matrix.md` にバージョン採用根拠と既知の非互換性を残す。バージョン固定はせず公式最新を採る方針（`docs/environment-setup.md`）の実行スキル。
+---
+
+# Tech Version Check Skill
+
+> SKL-12: `description` は Claude が Skill を選ぶための主要判断材料。3要素（何を / いつ / どんな条件で）を含む。
+
+## 概要
+
+実装着手の前に、`design.yaml.architecture.stack` に列挙された採用スタック（言語 / FW / 主要ライブラリ）について **公式の最新安定版とフレームワーク要求の最小言語バージョン**を取得し、`delivery/version-matrix.md` に採用根拠と日付を残す。
+
+サンプル案件 sample-auth で **Ruby/Rails の最新版確認が事前に行われず**、`connection_pool 3.0.2` が Ruby 3.3 非互換に当たって途中で気づく事故が発生した（B-11）。本スキルはこの種の事故を未然に塞ぐ。
+
+> 方針: バージョンは固定しない（陳腐化回避）、基本は公式の最新安定版、特定バージョンが必要な場合は判断ポイント — [`ai-delivery/docs/environment-setup.md`](../../../../../docs/environment-setup.md)。本スキルはその「公式最新を取得する」手順の実体。
+
+## 呼び出しトリガ（B-13 連携）
+
+`implementation-skill-planner` が以下の判定で skill_plan に列挙する（required=true 既定）:
+
+- `design.yaml.architecture.stack` に**何らかの言語/FW が記述されている**（実装フェーズの全案件で必須）
+- 既に `delivery/version-matrix.md` が存在し、かつ作成日が直近（プロジェクトの基準内、例: 30 日以内）なら **skip 可**（trigger に "version-matrix.md is fresh" を残す）
+
+未呼び出しのまま実装フェーズが完了に到達した場合は warn_and_document に従い警告（T-002）。
+
+> 本スキルは firebase-auth-setup / -frontend / -mfa / -emulator のいずれよりも**前**に呼ぶ。skill_plan 上の順序として最先頭に置く。
+
+## 入出力
+
+- 入力: `delivery/design.yaml` の `architecture.stack` / 採用ライブラリ一覧（および要件由来の制約）
+- 出力: `delivery/version-matrix.md`（採用バージョン + 既知の非互換性 + 採用日 + 採用根拠 URL）
+
+スキーマは編集しない（CONV-14）。
+
+## 取得対象（言語非依存）
+
+採用スタックから抽出される **最低 4 群** を必ず記録する:
+
+1. **言語ランタイム**（Ruby / Node.js / Python / PHP / Go 等）
+2. **メイン FW**（Rails / Next.js / Laravel / Django / Express / FastAPI 等）
+3. **主要ライブラリ・SDK**（Firebase Admin SDK / `firebase` JS SDK / DB アダプタ / 認証関連 gem-pkg 等）
+4. **ツール / コンテナ**（`firebase-tools`（CLI）/ Docker base image / Node base image 等）
+
+> サンプル案件 sample-auth では `connection_pool` のような**間接依存**が問題化した。直接依存だけでなく、**主要ライブラリの間接依存で言語バージョン制約が出るもの**は気付いた時点で記録対象に追加する。
+
+## 取得手段（優先順）
+
+| 優先 | 手段 | 使い所 |
+|---|---|---|
+| 1 | **context7 MCP**（`mcp__plugin_context7_context7__resolve-library-id` → `query-docs`） | 公式 docs から最新版 / 要求ランタイムを構造化取得（精度高） |
+| 2 | **WebFetch** | 公式リリースページ（例: https://github.com/firebase/firebase-tools/releases、https://rubygems.org/gems/rails ）を直接取得 |
+| 3 | **WebSearch** | 1/2 で当たらない場合のフォールバック（曖昧検索） |
+
+> context7 が解決しない / 結果が古い場合は WebFetch に降り、最終手段で WebSearch。**根拠 URL は必ず version-matrix.md に残す**（採用日時点の確認証跡）。
+
+## 手順
+
+1. `design.yaml.architecture.stack` から採用スタックを列挙（記述粒度が粗い場合は人間に確認）。
+2. 上記「取得対象」4 群を順に context7 等で取得:
+   - 各言語/FW/ライブラリの **最新安定版**（major.minor.patch）と **要求ランタイム**（例: Rails 8.x → Ruby 3.x 以上）
+   - **既知の非互換性**（採用最新版で問題があれば公式 issue / リリースノートから抽出）
+3. `delivery/version-matrix.md` に表形式で記録（[`templates/version-matrix.template.md`](./templates/version-matrix.template.md) 参照）。
+4. **`Gemfile` / `package.json` / `Dockerfile`** にコメント形式で「採用根拠（B-11 で確認、日付、根拠 URL）」を残す。固定バージョン値は判断ポイントなので、AI が勝手に固定しない（明示的な要望がある場合のみ pin）。
+5. 非互換が発覚した場合は判断ポイント化（pending-decisions に「採用バージョンを下げるか / 互換ライブラリを変えるか」を起票）。
+6. 取得情報を `implementation-plan.json.skill_plan` の本エントリ `called=true` に更新。
+
+## 出力テンプレ（version-matrix.md）
+
+```markdown
+# 採用バージョン記録（tech-version-check / B-11）
+
+- 作成日: 2026-05-26
+- 案件: <project>
+- design.yaml.architecture.stack: <quoted>
+
+## 言語ランタイム
+| 名前 | 採用バージョン | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| Ruby | 3.x.x (採用時点の最新安定版) | 3.x.x | — | https://www.ruby-lang.org/en/downloads/ |
+
+## メイン FW
+| 名前 | 採用 | 公式最新 | 要求ランタイム | 根拠 URL |
+|---|---|---|---|---|
+| Rails | 8.x.x | 8.x.x | Ruby 3.x+ | https://rubygems.org/gems/rails |
+
+## 主要ライブラリ・SDK
+| 名前 | 採用 | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| firebase (JS) | 9.x+ (modular) | 11.x.x | Node 18+ | https://www.npmjs.com/package/firebase |
+| jwt (gem) | 3.x | 3.x | Ruby 3.x+ | https://rubygems.org/gems/jwt |
+
+## ツール / コンテナ
+| 名前 | 採用 | 公式最新 | 用途 | 根拠 URL |
+|---|---|---|---|---|
+| firebase-tools | 14.x | 14.x | Emulator (B-12) | https://github.com/firebase/firebase-tools/releases |
+| node (base image) | 22-slim | 22.x | Emulator container | https://hub.docker.com/_/node |
+
+## 既知の非互換性 / 警戒事項
+- _(取得時点で問題があれば 1 行ずつ記録)_
+
+## 採用根拠の要約
+- 「公式の最新安定版」方針（environment-setup.md）に従い、`<確認日>` 時点で context7 / 公式リリースで取得した最新を採用。
+- 特定バージョン固定が必要な要件は受け取っていない。
+```
+
+## 判断ポイント（人間判断をスルーさせない）
+
+- **特定バージョン固定の要望**: クライアント制約・レガシー互換などで「最新ではない特定バージョン」を要求された場合、`docs/pending-decisions.md` に DP として起票し、確認後に固定する（AI が勝手に古いバージョンを採らない）。
+- **非互換性の解消方針**: 採用最新版に既知の非互換性がある場合、代替ライブラリへの差し替えか採用バージョンの一時的な前進版採用かの選択。pending-decisions に起票。
+- **取得粒度**: 全依存をスキャンするか / 主要依存のみに留めるか。プロジェクトのリスク許容度で人間が決める。
+
+## 関連スキル
+
+- 後続: `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` / `firebase-auth-emulator`（本スキルの version-matrix.md に従って Gemfile / package.json / Dockerfile を埋める）
+- バージョン方針: [`ai-delivery/docs/environment-setup.md`](../../../../../docs/environment-setup.md)
+- 横展開: 本スキルは現状 xtone-auth-plugin 内に配置するが、本来は **横断スキル**（複数プラグインで共通利用）。`xtone-shared-plugin` / `xtone-plugin-template` への移管は別 Issue。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
@@ -1,0 +1,40 @@
+# 採用バージョン記録（tech-version-check / B-11）
+
+> 本テンプレートは `tech-version-check` スキルの出力雛形。値は採用時点で context7 / 公式リリースから取得した実際の数値に置換する（プレースホルダ `<...>` を埋める）。`docs/environment-setup.md` の方針に従い、AI は固定値を勝手に決めない。
+
+- 作成日: `<YYYY-MM-DD>`
+- 案件: `<project name>`
+- 採用根拠: `docs/environment-setup.md`「公式の最新安定版」+ 採用日時点の確認
+
+## 1. 言語ランタイム
+
+| 名前 | 採用バージョン | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| `<lang>` | `<version>` | `<version>` | — | `<url>` |
+
+## 2. メイン FW
+
+| 名前 | 採用 | 公式最新 | 要求ランタイム | 根拠 URL |
+|---|---|---|---|---|
+| `<fw>` | `<version>` | `<version>` | `<lang> <constraint>` | `<url>` |
+
+## 3. 主要ライブラリ・SDK
+
+| 名前 | 採用 | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| `<lib>` | `<version>` | `<version>` | `<lang> <constraint>` | `<url>` |
+
+## 4. ツール / コンテナ
+
+| 名前 | 採用 | 公式最新 | 用途 | 根拠 URL |
+|---|---|---|---|---|
+| `<tool>` | `<version>` | `<version>` | `<purpose>` | `<url>` |
+
+## 5. 既知の非互換性 / 警戒事項
+
+- `<例: connection_pool 3.0.2 が Ruby 3.3 で例外 — リリースノート https://... を参照>`
+
+## 6. 採用根拠の要約
+
+- `<例: 「公式最新を採る方針（environment-setup.md）」に従い、context7 で 2026-05-26 時点の最新を確認・採用。特定バージョン固定の要望なし。>`
+- 特定バージョン固定の要望があった場合は `docs/pending-decisions.md` の DP-XXX として記録（warn_and_document）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
@@ -38,3 +38,35 @@
 
 - `<例: 「公式最新を採る方針（environment-setup.md）」に従い、context7 で 2026-05-26 時点の最新を確認・採用。特定バージョン固定の要望なし。>`
 - 特定バージョン固定の要望があった場合は `docs/pending-decisions.md` の DP-XXX として記録（warn_and_document）。
+
+## 7. Gemfile / package.json / Dockerfile に残すコメント例
+
+`tech-version-check`（B-11）スキルの「手順 4」で各依存ファイルに採用根拠を**コメント形式**で残す。実装時のレビューと将来の追従に効く。
+
+```ruby
+# Gemfile（Ruby/Rails 案件）
+ruby "<採用バージョン>"  # tech-version-check (B-11) <YYYY-MM-DD> 確認: https://www.ruby-lang.org/en/downloads/
+gem "rails"              # tech-version-check (B-11) <YYYY-MM-DD> 確認 / 公式最新: https://rubygems.org/gems/rails
+gem "jwt"                # tech-version-check (B-11) <YYYY-MM-DD> 確認: https://rubygems.org/gems/jwt
+gem "googleauth"         # tech-version-check (B-11) <YYYY-MM-DD> 確認: https://rubygems.org/gems/googleauth
+```
+
+```json
+// package.json（Node 案件、抜粋）
+{
+  "_versionPolicy": "tech-version-check (B-11) <YYYY-MM-DD> 確認 / environment-setup.md 方針: 公式最新を採用",
+  "dependencies": {
+    "firebase": "^9.0.0"
+  }
+}
+```
+
+```dockerfile
+# Dockerfile（emulator や Rails / Next.js コンテナ）
+# tech-version-check (B-11) <YYYY-MM-DD> 確認: https://hub.docker.com/_/node
+FROM node:22-bookworm-slim
+# tech-version-check (B-11) 確認: https://github.com/firebase/firebase-tools/releases
+ARG FIREBASE_TOOLS_VERSION=<採用バージョン>
+```
+
+> **AI は固定値を勝手に決めない**。`<採用バージョン>` は context7 / 公式リリースで確認した実値で置換し、`<YYYY-MM-DD>` は確認日に置換する。確認日と URL が残っていれば、後から「いつの時点の最新を採用したか」が遡れる。


### PR DESCRIPTION
## Summary

サンプル案件 sample-auth で Ruby/Rails の最新版確認が事前に行われず、`connection_pool 3.0.2` が Ruby 3.3 非互換に当たって途中で気付く事故が発生した。`docs/environment-setup.md` は方針宣言（公式最新を採る）のみで、**実装時に最新を取得する手順がスキルに無い**のが根本原因。本 PR で実体スキルを新設。

## 変更点

- **`skills/implementation/tech-version-check/SKILL.md` を新設**
  - 入力: `design.yaml.architecture.stack`（採用言語/FW/ライブラリ）
  - 取得対象 4 群: 言語ランタイム / メイン FW / 主要ライブラリ・SDK / ツール・コンテナ
  - 取得手段: **context7 MCP（最優先）** → WebFetch → WebSearch のフォールバック
  - 出力: `delivery/version-matrix.md`（採用 / 公式最新 / 要求ランタイム / 根拠 URL / 採用日）
- **`skills/implementation/tech-version-check/templates/version-matrix.template.md` を同梱**
- **`implementation-skill-planner` の導出ルール表に `tech-version-check` を最先頭エントリで追加**（required=true、既に直近 `version-matrix.md` があれば skip 可）。skill_plan 内で setup/frontend/mfa/emulator のいずれよりも前に呼ぶ
- **`firebase-auth-setup` / `firebase-auth-frontend` SKILL.md 冒頭に「前提（B-11）」節を追加** — `tech-version-check` を先に呼ぶよう明示
- **`docs/environment-setup.md` に参照を追加** — 「本方針を実行するスキル」として tech-version-check を明示

> 横断スキルへの移管（`xtone-shared-plugin` or `xtone-plugin-template` への複製）は別 Issue で扱う。暫定で xtone-auth-plugin 内に配置。

Closes #156
関連: B-12（emulator 既定）/ B-14（sample-outputs 再生成、本件完了後）

## 検証

- `claude plugin validate --strict` ✔
- スキル description は 3 要素（何を / いつ / どんな条件で）を含む（SKL-12 準拠）

## Test plan

- [x] plugin validate
- [x] planner の導出ルール表に整合性（最先頭エントリ）
- [ ] B-14（sample-outputs 再生成）で実際に context7 から最新版取得を実行・version-matrix.md を作成して検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)