### PR TITLE
docs(B-15 followup): planner 表に auth-e2e-verify 行を追加 + B-17 起票反映

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/backlog.md
@@ -25,11 +25,12 @@ T-022 内部パイロット（[pilot-report.md](./pilot-report.md)）で発見�
 | **B-12** | [#157](https://github.com/xtone/ai_development_tools/issues/157) | Architecture | High | **Firebase Emulator + Docker をローカル開発の既定化**。B-13 で schema 側 `local_dev_stack` は導入済み。本件は **スキル中身**（docker-compose テンプレ / Adapter 分岐 / connectAuthEmulator 統合）を整備。B-14 の前提 | SKL- | sample-auth |
 | **B-15** | [#158](https://github.com/xtone/ai_development_tools/issues/158) | Architecture | Med | **`auth-e2e-verify` スキル新設**。Playwright で `representative_use_cases` を全件通すまで責務化。`alert()` 禁止 等の MCP/Headless 配慮も込み。前提: B-12 | SKL- | sample-auth |
 | **B-16** | [#159](https://github.com/xtone/ai_development_tools/issues/159) | Plugin | Low | hotwire レシピ細部修正（Rails singular resource / `alert()` 禁止 / Firebase v9 modular 統一） | SKL- | sample-auth |
+| **B-17** | [#164](https://github.com/xtone/ai_development_tools/issues/164) | Architecture | Med | **`tech-version-check` を横断スキル化**。`xtone-shared-plugin` / `xtone-plugin-template` への移管（配置先は判断ポイント）。B-11 で auth-plugin 内に暫定配置したため、複数プラグイン展開時に複製が発生する | SKL- / CONV-14 | PR #162（B-11）|
 
 ## 優先度の考え方
 
 - **High（Rollout 前に解消推奨）**: B-01 / B-02 / B-05 / B-06。いずれも「型の穴」で、24 ユースケース展開で繰り返しコスト化する。
-- **Med（Rollout と並行可）**: B-03 / B-04 / B-07 / B-10 / B-14 / B-15。
+- **Med（Rollout と並行可）**: B-03 / B-04 / B-07 / B-10 / B-14 / B-15 / B-17。
 - **Low（任意・改善）**: B-08 / B-09 / B-16。
 - **Rollout 後追加 High**（24 ユースケース展開と並行で塞ぐ）: B-11（バージョン取得）/ B-12（Emulator 既定化）/ B-13（スキル呼び出し計画）。いずれもサンプル案件 sample-auth 由来。
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/implementation-skill-planner/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: implementation-skill-planner
-description: 設計成果物（design.yaml）から実装フェーズで呼び出すべきスキルを導出して skill_plan を生成するスキル。実装フェーズの Step 0 として、architecture.stack / responsibility_split / page_access_control / authentication.mfa_requirement / local_dev_stack の値に応じて tech-version-check / firebase-auth-setup / firebase-auth-frontend / firebase-auth-mfa / firebase-auth-emulator のうち呼ぶべきものを列挙し、implementation-plan.json の skill_plan に反映、`delivery/implementation-skill-plan.md` を出力する。frontend スキル等の呼び出し漏れ防止（B-13 由来）。skill_plan の最先頭は tech-version-check（B-11）。
+description: 設計成果物（design.yaml）から実装フェーズで呼び出すべきスキルを導出して skill_plan を生成するスキル。実装フェーズの Step 0 として、architecture.stack / responsibility_split / page_access_control / authentication.mfa_requirement / local_dev_stack / representative_use_cases の値に応じて tech-version-check / firebase-auth-setup / firebase-auth-frontend / firebase-auth-mfa / firebase-auth-emulator / auth-e2e-verify のうち呼ぶべきものを列挙し、implementation-plan.json の skill_plan に反映、`delivery/implementation-skill-plan.md` を出力する。frontend スキル等の呼び出し漏れ防止（B-13 由来）。skill_plan の最先頭は tech-version-check（B-11）、最末尾は auth-e2e-verify（B-15）。
 ---
 
 # Implementation Skill Planner
@@ -36,10 +36,13 @@ design の値から **必ず** 以下を skill_plan に列挙する。
 | `authentication.mfa_requirement` ∈ {`required`, `admin_only`, `optional`} | `firebase-auth-mfa` | rails＋hotwire / rails＋nextjs 等の組合せ | `[backend, client, iaas]` | `required`/`admin_only` は true、`optional` は false（推奨） |
 | `local_dev_stack` ∈ {`emulator_docker`, `emulator_host`} **または未指定** | `firebase-auth-emulator` | docker-compose（基本） | `[shared]` | true（既定はローカル開発 = emulator） |
 | `page_access_control.pages` が定義されている | `firebase-auth-frontend`（既出なら統合） | 同上 | 同上＋`applies_to` に各 page.path を入れる | true |
+| `representative_use_cases` に 1 件以上の UC が定義されている **かつ** 上記いずれかで setup / frontend のどちらかが skill_plan に入る | `auth-e2e-verify` | playwright | `[shared]` | true（**skill_plan の最末尾に置く**。setup / frontend / mfa / emulator がすべて呼ばれた後に E2E 検証） |
 
 > **`local_dev_stack` が未指定**でも emulator スキルを追加するのは、B-12（Emulator+Docker を既定とする方針）に整合させるため。`cloud_direct` を選んだ場合のみ planner は emulator を外し、その判断を `decision_record` に残すよう促す。
 
 > **`tech-version-check` は最先頭に置く**（B-11）。バージョン非互換に気付くのが遅れる事故（sample-auth で発生）を防ぐため、setup / frontend / mfa / emulator のいずれよりも前に呼ぶ。既に `delivery/version-matrix.md` が直近で作成済みなら skip 可（trigger に "version-matrix.md is fresh" を残す）。
+
+> **`auth-e2e-verify` は最末尾に置く**（B-15）。設計フェーズで決めた `representative_use_cases` を **ブラウザ実機で全件 PASS** するまでが実装フェーズの DoD。`tech-version-check`（最先頭）と対の構造で、skill_plan を「前段=バージョン取得 → 中段=各実装スキル → 末尾=E2E 検証」の流れで構成する。
 
 ## 手順
 
@@ -72,6 +75,7 @@ design.yaml から自動導出（implementation-skill-planner / B-13）。
 | firebase-auth-frontend | hotwire | client, shared | /login, /signup, /settings/* | true | ☐ |
 | firebase-auth-mfa | rails+hotwire | backend, client, iaas | DP-008 | true | ☐ |
 | firebase-auth-emulator | docker-compose | shared | local_dev_stack=emulator_docker（既定） | true | ☐ |
+| auth-e2e-verify | playwright | shared | UC-A01〜A07（全 representative_use_cases） | true | ☐ |
 
 ## 未呼び出し警告（フェーズ完了時に更新）
 

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/tech-version-check/SKILL.md
@@ -91,4 +91,4 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
 
 - 後続: `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` / `firebase-auth-emulator`（本スキルの version-matrix.md に従って Gemfile / package.json / Dockerfile を埋める）
 - バージョン方針: [`ai-delivery/docs/environment-setup.md`](../../../../../docs/environment-setup.md)
-- 横展開: 本スキルは現状 xtone-auth-plugin 内に配置するが、本来は **横断スキル**（複数プラグインで共通利用）。`xtone-shared-plugin` / `xtone-plugin-template` への移管は **backlog B-17（PR #162 マージ後に起票予定）** で扱う。本 PR ではプラグイン内配置のままで進める。
+- 横展開: 本スキルは現状 xtone-auth-plugin 内に配置するが、本来は **横断スキル**（複数プラグインで共通利用）。`xtone-shared-plugin` / `xtone-plugin-template` への移管は **B-17（[#164](https://github.com/xtone/ai_development_tools/issues/164)）** で扱う。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/test/auth-e2e-verify/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/test/auth-e2e-verify/SKILL.md
@@ -128,6 +128,6 @@ design からマップして、最低でも以下を通す（不該当は skip�
 
 ## 関連
 
-- 前提スキル: `firebase-auth-emulator`（B-12）/ `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` / `tech-version-check`（B-11、**マージ後に有効**）
-- planner 連携: `implementation-skill-planner` の skill_plan 最末尾エントリ。**B-11（PR #162）とのコンフリクト回避**のため、本 PR では planner 表への `auth-e2e-verify` 行追加は行わず、**B-11 マージ後のフォロー PR**で追記する
+- 前提スキル: `firebase-auth-emulator`（B-12）/ `firebase-auth-setup` / `firebase-auth-frontend` / `firebase-auth-mfa` / `tech-version-check`（B-11）
+- planner 連携: `implementation-skill-planner` の **skill_plan 最末尾エントリ**として `representative_use_cases` のいずれかが定義 & setup/frontend のどちらかが skill_plan に入る場合に必須化（[`../../implementation/implementation-skill-planner/SKILL.md`](../../implementation/implementation-skill-planner/SKILL.md) の導出ルール表参照）
 - 関連方針: B-16（`alert()` / `confirm()` 禁止＝ E2E 固まり防止）


### PR DESCRIPTION
## Summary

PR #163（B-15）マージ後のフォローアップ。B-15 PR では B-11（PR #162）とのコンフリクト回避のため `implementation-skill-planner` の導出ルール表編集を意図的に保留していた。B-11 がマージされた今、コンフリクトなしで追記できる。

加えて、B-17（tech-version-check の横展開）が Issue #164 として起票されたため、SKILL.md 内の参照を Issue 番号に更新。

## 変更点

- **`implementation-skill-planner/SKILL.md`**
  - 導出ルール表に **`auth-e2e-verify` 行を追加**（トリガ: `representative_use_cases` に 1 件以上 & setup/frontend のどちらかが skill_plan に入る場合）
  - 出力テンプレ（`implementation-skill-plan.md` サンプル）にも `auth-e2e-verify` 行を追加
  - description フィールドに `representative_use_cases` と `auth-e2e-verify` を追記（SKL-12 準拠）
  - 「**最末尾配置**」の注記を追加（`tech-version-check` の「最先頭配置」と対の構造）
- **`tech-version-check/SKILL.md`**
  - 横展開リンクを **B-17（[#164](https://github.com/xtone/ai_development_tools/issues/164)）** に更新
- **`auth-e2e-verify/SKILL.md`**
  - 「planner 連携」記述から「コンフリクト回避のため保留」注記を除去し、planner の導出ルール表への参照を直接記述
- **`docs/backlog.md`**
  - B-17（Med、#164）を追加、優先度分類を更新

Refs: #155 (B-14 の前提として skill_plan の完備が必要), #164 (B-17)

## 検証

- `claude plugin validate --strict` ✔
- 表中の skill 順序（先頭=tech-version-check / 末尾=auth-e2e-verify）が「前段=バージョン取得 → 中段=各実装スキル → 末尾=E2E 検証」のフローと整合
- description が更新後も SKL-12 の 3 要素（何を / いつ / どんな条件で）を満たす

## Test plan

- [x] plugin validate
- [x] 表行追加の整合性
- [ ] B-14（sample-outputs 再生成）時に planner 出力が新スキーマで auth-e2e-verify を最末尾に列挙することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)