### PR TITLE
docs(B-14): sample-outputs/ を新スキーマ・新スキル群で 1 から再生成

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/ADR-001-auth-stack.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/ADR-001-auth-stack.md
@@ -1,0 +1,81 @@
+# ADR-001: 認証スタックに Firebase Auth を採用
+
+- **ステータス**: accepted
+- **決定日**: 2026-05-27
+- **決定者**: 豊田
+- **関連判断ポイント**: DP-007（認証スタック選択）/ DP-008（MFA 方針, `admin_only`）
+- **案件**: みんなの読書会（架空、xtone-auth-plugin 通し検証）
+
+## コンテキスト
+
+BtoC コミュニティアプリ（Web SPA + iOS + Android）の認証基盤を選定する。要件は以下:
+
+- メール+パスワード / パスワードレス（メールリンク）/ OIDC（Google・Apple）の 3 方式に対応
+- 認証方式の追加（連携）/ パスワード・メール変更 / 退会
+- API（Rails）の JWT 認可、Web/アプリでのセッション保持
+- 初年度数万人規模、規制業界ではない、docomo 連携なし
+- 開発チームは Firebase 経験あり
+- ベンダーロックインは避けたい（将来的に別 IaaS へ移行できる余地を残す）
+- 運営管理者だけは多要素認証（`admin_only`）で守りたい
+
+## 検討した選択肢
+
+### (A) Firebase Auth（採用）
+
+- メール+パスワード / メールリンク / OIDC（Google・Apple）を **標準機能**でカバー
+- 公式 JS / iOS / Android SDK が揃い、トークン発行と検証が安定
+- **Identity Platform** にアップグレードで TOTP / SMS MFA を提供（`admin_only` 実装が現実的）
+- ローカル検証は **Firebase Auth Emulator** を Docker で起動して完結（B-12）
+- 退会時の Admin SDK ユーザー削除、トークン失効、公開鍵キャッシュなどの **運用詳細**は `firebase-auth-setup` スキルが網羅（B-02）
+
+### (B) Devise + OmniAuth + 独自実装
+
+- Rails エコシステムで完結する伝統的な選択肢
+- パスワードレス（メールリンク）は独自実装が必要（gem 単体では弱い）
+- Apple ログインは OmniAuth Apple の実装と公開鍵検証の自前運用が増える
+- スマホアプリのセッション管理は別途設計が必要（gem の SessionsController は Web 向け）
+- MFA は Devise 拡張 gem の組合せが必要で、運営管理者強制の実装は自前
+
+### (C) Cognito / Auth0 等の別 IaaS
+
+- 機能面は Firebase Auth と同等以上だが、チームの経験 / コスト / コミュニティ規模で Firebase Auth に劣る
+- ベンダーロックイン懸念は (A) と同等で、差し替え可能設計（AuthAdapter）でカバー可能
+
+## 決定
+
+**(A) Firebase Auth を採用する。**
+
+ただし、Firebase 固有処理は `FirebaseAuthAdapter`（`Auth::AuthAdapter` インターフェース実装）に閉じ込め、**別 IaaS へ差し替え可能な構造**を維持する。テストは同インターフェースを満たす `TestAdapter` で実 Firebase 不要に回す（DP-007 の差し替え可能設計の核）。
+
+MFA は `admin_only`（管理者必須・一般オプトイン）を採用（DP-008）。実装は `firebase-auth-mfa` スキルが網羅（TOTP / SMS、enrollment / challenge / 管理者強制 / soft 失効）。
+
+ローカル開発は **Firebase Auth Emulator + Docker** を既定とし、`firebase-auth-emulator` スキルが提供する compose / レシピで完結する（B-12）。`design.yaml.local_dev_stack=emulator_docker`。
+
+## 帰結
+
+### 正の帰結
+- 3 方式（メール+PW / パスワードレス / OIDC）が SDK 標準でカバーされ、実装コストが低い
+- Identity Platform へのアップグレードで MFA 要件（DP-008 = `admin_only`）が満たせる
+- Auth Emulator + Docker でローカル / CI の E2E（`auth-e2e-verify`）が回せる
+- `AuthAdapter` 抽象化で将来の IaaS 移行が現実的
+
+### 負の帰結 / リスク
+- Firebase / Identity Platform への依存（緩和: AuthAdapter で差し替え可能、本 ADR で明示）
+- **TOTP MFA は Auth Emulator 非対応**（[firebase-tools #6224](https://github.com/firebase/firebase-tools/issues/6224)）。ローカルは SMS で代替、TOTP の E2E は staging / 実 Identity Platform（ADR にも本制約を明示、`auth-e2e-verify` の判断ポイントに記録）
+- Identity Platform は GCP プロジェクトのアップグレードと課金設定が必要（運用負荷の上振れ）
+
+## 関連スキル / 規約
+
+- `firebase-auth-setup`（backend、JWT 検証 / Admin SDK 削除 / 公開鍵キャッシュ / 2 段階の失効）
+- `firebase-auth-frontend`（client、AuthClient 契約 / セッション戦略 / page_access_control の A/B/C ガード）
+- `firebase-auth-mfa`（横断、admin_only 実装 / TOTP・SMS / soft 失効）
+- `firebase-auth-emulator`（ローカル E2E、docker-compose / 署名検証スキップ / Admin REST 切替）
+- `tech-version-check`（実装着手前に Ruby / Rails / Firebase JS SDK 等の最新安定版を `delivery/version-matrix.md` に記録、B-11）
+- `auth-e2e-verify`（実装後の DoD、representative_use_cases を Playwright で全件 PASS、B-15）
+- 規約: CONV-14（SSoT / スキーマは xtone-shared-plugin）
+
+## 履歴
+
+| 日付 | 出来事 |
+|---|---|
+| 2026-05-27 | 本 ADR を起票し、accepted。B-14（sample-outputs 再生成）時に最新スキル群と整合させて記述 |

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/README.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/README.md
@@ -1,0 +1,39 @@
+# 作り込み例（架空案件の通し検証）— sample-outputs
+
+架空案件 [「みんなの読書会」](../sample-inputs/bookclub-app.requirements-input.md) を xtone-auth-plugin で **要件定義 → 設計 → 実装計画**まで通した成果物例。
+
+> 本ディレクトリは **B-14（[#155](https://github.com/xtone/ai_development_tools/issues/155)）で再生成**された版。B-13 で旧サンプルを削除した後、B-11/B-12/B-13/B-15 一連の型化修正（新スキーマ・新スキル群）が完了したタイミング（2026-05-27）で 1 から作り直し。
+
+## 通しフローと成果物
+
+| フェーズ | コマンド / スキル | 成果物 | スキーマ |
+|---|---|---|---|
+| 要件定義 | `/req-collect` → `auth-requirements-extraction` | [`requirements.json`](./requirements.json)（**`page_access_control_candidates` を含む**、B-13） | `requirements.schema.json` |
+| 設計 | `/auth-design` → `firebase-auth-design` / `authentication-architect` | [`design.yaml`](./design.yaml) + [`ADR-001-auth-stack.md`](./ADR-001-auth-stack.md) | `design.schema.json`（**`responsibility_split` / `page_access_control` / `local_dev_stack` を含む**、B-03/B-13） |
+| 実装 | `/implement` → `implementation-skill-planner` → `tech-version-check` → `firebase-auth-setup` / `-frontend` / `-mfa` / `-emulator` → `auth-e2e-verify` | [`implementation-plan.json`](./implementation-plan.json)（**`skill_plan` を含む**、B-13） | `implementation-plan.schema.json` |
+
+## この例が示していること（DoD 対応）
+
+- **架空案件で要件定義〜実装まで一貫して進められる**: 上記 3 成果物が `page_access_control` / `responsibility_split` / `local_dev_stack` / `skill_plan` のフィールド名で **同一名のまま引き継ぎ**、フェーズ間の食い違いが出ない（B-13 で塞いだ穴）。
+- **2 種類以上の認証スタックを比較**: [ADR-001](./ADR-001-auth-stack.md) で Firebase Auth と Devise+OmniAuth（+ Cognito）を比較し、根拠付きで採用を決定。
+- **未決判断ポイントが warn_and_document される**:
+  - `requirements.json` の `undecided` は `["DP-007", "DP-008"]`（要件段階では認証スタックと MFA 方針が未決）
+  - 設計フェーズで人間（豊田）が DP-007/008/015 を決定し、`design.yaml.decision_record` に記録、`undecided` は `[]` に解消
+  - `implementation-plan.json` の `undecided` も `[]`
+- **`skill_plan` で全スキルが計画される**（B-13）: 最先頭 `tech-version-check`（B-11）→ `firebase-auth-setup` / `-frontend` / `-mfa` / `-emulator` → 最末尾 `auth-e2e-verify`（B-15）の流れ。設計フェーズで `responsibility_split.client` を含めば planner が **必ず `firebase-auth-frontend` を列挙**するので、サンプル案件 sample-auth で起きた「frontend スキル素通り」事故は再発しない。
+- **ローカル開発は Emulator + Docker 既定**（B-12）: `design.yaml.local_dev_stack=emulator_docker` で planner が `firebase-auth-emulator` を必ず列挙。
+- **architecture.stack と recipe の整合**: `architecture.stack` が React (Web SPA) なので `firebase-auth-frontend.recipe=nextjs`（Bearer 直送り）を流用、`firebase-auth-mfa.recipe=rails+nextjs` で揃う（PR #154 で確認した整合性問題に対応）。
+
+## 注記
+
+- `design.yaml` は DoD 記載の「design.yaml サンプル」。同内容を JSON 化すれば `design.schema.json` で検証できる（B-14 の検証スクリプトで実施、PR description / コミット参照）。
+- 実際に動く Rails + Firebase のサンプルアプリ実装は **T-022 内部パイロット**および **再パイロット**の範囲（[`docs/pilot-report.md`](../docs/pilot-report.md) / [`docs/re-pilot-report.md`](../docs/re-pilot-report.md) 参照）。本ディレクトリはあくまで「設計フェーズまでの成果物テンプレ」。
+- iOS / Android（Swift / Kotlin）レシピは未整備のため、`skill_plan.firebase-auth-frontend` の trigger に「判断ポイント」として記録（pending-decisions への起票は実装フェーズ着手時）。
+
+## 関連 backlog
+
+- B-14（本サンプル再生成、[#155](https://github.com/xtone/ai_development_tools/issues/155)）
+- B-11（[#156](https://github.com/xtone/ai_development_tools/issues/156) tech-version-check）
+- B-12（[#157](https://github.com/xtone/ai_development_tools/issues/157) Emulator+Docker 既定）
+- B-13（[#153](https://github.com/xtone/ai_development_tools/issues/153) skill_plan 機構）
+- B-15（[#158](https://github.com/xtone/ai_development_tools/issues/158) auth-e2e-verify）

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/design.yaml
@@ -1,0 +1,113 @@
+# 架空案件「みんなの読書会」の設計成果物（design.yaml サンプル）
+# firebase-auth-design スキル / authentication-architect の出力例。
+# schemas/design.schema.json（B-01 本実装、B-03 responsibility_split、B-13 page_access_control / local_dev_stack 追加）準拠。
+# YAML 表現（同内容を JSON 化すれば jsonschema で検証可能）。
+
+architecture:
+  stack: "Rails 8 (API) + React (Web SPA) + iOS/Android"
+  cloud: "Firebase（認証）+ アプリサーバ（任意）"
+  db_type: "PostgreSQL（本番）/ SQLite（パイロット）"
+  rationale: >
+    認証は AuthAdapter インターフェース越しに呼び、Firebase 固有処理は FirebaseAuthAdapter
+    に閉じ込める（DP-007 差し替え可能設計）。バックエンド（Rails）は API ミドルウェアで
+    Firebase 発行の ID トークン（JWT）を検証してユーザーを解決。Web/アプリは ID トークンと
+    リフレッシュトークンをメモリ保持し API リクエストに Bearer 付与。セッションは ID トークン
+    TTL=1h、リフレッシュで更新、退会時は Firebase ユーザー削除 + サーバ側論理削除。
+
+db_schema:
+  er_diagram_url: "https://www.figma.com/(架空)/minna-bookclub-er"
+  normalization_level: "3NF"
+  tables:
+    - { name: "users", columns: ["uid", "email", "providers", "mfa_enabled", "tokens_valid_after", "role", "deleted_at"] }
+    - { name: "clubs", columns: ["id", "host_uid", "name", "description"] }
+    - { name: "memberships", columns: ["club_id", "user_uid", "joined_at"] }
+
+api_spec:
+  openapi_path: "docs/openapi.yaml"
+  style: "REST"
+
+authentication:
+  stack: "Firebase Auth"          # DP-007 採用（MVP 推奨、AuthAdapter で差し替え可能）
+  mfa_requirement: "admin_only"   # DP-008（運営管理者は必須、一般はオプトイン）
+
+ui_design:
+  figma_url: "https://www.figma.com/(架空)/minna-bookclub-ui"
+  screen_count: 18
+  key_screens:
+    - "ログイン / 新規登録"
+    - "MFA 第2要素登録（管理者）"
+    - "ホーム（公開・認証感知）"
+    - "クラブ一覧 / 詳細"
+    - "アカウント設定（プロフィール / メール / パスワード / 退会）"
+
+adr_list:
+  - { id: "ADR-001", title: "認証スタックに Firebase Auth を採用", status: "accepted", path: "sample-outputs/ADR-001-auth-stack.md" }
+
+design_review_completed:
+  approved: true
+  approved_by: "豊田"
+  approved_at: "2026-05-27T10:00:00+09:00"
+
+domain_specific_checks:
+  dAccount: false       # DP-015 非該当（docomo 連携なし）
+  pci_dss: false        # 決済なし
+  community_guidelines: true  # コミュニティ規約あり（DP-018）
+
+responsibility_split:   # B-03 / #130: 機能の責務を backend/client/iaas/shared に仕分け
+  - { item: "サインイン（メール+パスワード/パスワードレス/OIDC）", owner: "client" }
+  - { item: "ID トークン検証 / JWT 認可", owner: "backend" }
+  - { item: "セッション確立（アプリ側ユーザー upsert）", owner: "backend" }
+  - { item: "パスワード変更・リセット", owner: "iaas" }      # Firebase クライアント SDK で完結＝BE 対象外
+  - { item: "メールアドレス変更", owner: "iaas" }
+  - { item: "認証方式の追加（アカウント連携）", owner: "client" }
+  - { item: "退会（IaaS 削除＋アプリ側論理削除）", owner: "shared" }
+  - { item: "MFA 第2要素の登録・追加認証", owner: "shared" }   # client(enroll/challenge) + backend(検証/強制/失効) + iaas(第2要素検証)
+  - { item: "MFA 変更時のトークン失効", owner: "backend" }     # soft 失効: refresh のみ、tokens_valid_after は触らない
+
+page_access_control:    # B-13: A/B/C アクセス制御パターンの確定（requirements.page_access_control_candidates → ここで確定）
+  default_after_login: "/"
+  callback_param: "callback"
+  signup_separate_page: true
+  pages:
+    - { path: "/login",                pattern: "C", description: "ゲスト専用。?callback でログイン後遷移先を受ける" }
+    - { path: "/signup",               pattern: "C", description: "ゲスト専用。/login と別ページ・相互リンク" }
+    - { path: "/mfa/enroll",           pattern: "A", description: "MFA 第2要素登録（admin_only に該当する管理者は強制リダイレクト）" }
+    - { path: "/settings/profile",     pattern: "A", description: "プロフィール設定（singular resource）" }
+    - { path: "/settings/email",       pattern: "A", description: "メール変更（iaas で完結、UI のみ）" }
+    - { path: "/settings/password",    pattern: "A", description: "パスワード変更（iaas で完結、UI のみ）" }
+    - { path: "/settings/withdrawal",  pattern: "A", description: "退会（shared、DELETE /account を呼ぶ）" }
+    - { path: "/clubs/new",            pattern: "A", description: "クラブ作成（ホスト権限）" }
+    - { path: "/clubs/:id/manage",     pattern: "A", description: "クラブ管理（ホスト権限）" }
+    - { path: "/",                     pattern: "B", description: "トップ。認証状態でコンテンツ切替（リダイレクトなし）" }
+    - { path: "/clubs",                pattern: "B", description: "クラブ一覧（公開、参加ボタンは認証状態で切替）" }
+    - { path: "/clubs/:id",            pattern: "B", description: "クラブ詳細（公開、参加ボタンは認証状態で切替）" }
+    - { path: "/books",                pattern: "B", description: "本一覧（公開）" }
+
+local_dev_stack: "emulator_docker"   # B-12 / B-13: 既定。実 Firebase 接続は本番のみ
+
+decision_record:
+  - dp_id: "DP-007"
+    chosen: "Firebase Auth"
+    compared: ["Firebase Auth", "Devise+OmniAuth"]
+    decided_by: "豊田"
+    decided_at: "2026-05-27T10:00:00+09:00"
+    rationale: >
+      チームに Firebase 経験があり、メール/パスワードレス/OIDC を標準機能で満たせる。
+      代替の Devise+OmniAuth はパスワードレスや Apple ログインで追加実装が増える。
+      ベンダーロックイン懸念は AuthAdapter 層で差し替え可能にして緩和。
+    adr_ref: "sample-outputs/ADR-001-auth-stack.md"
+  - dp_id: "DP-008"
+    chosen: "admin_only（管理者必須・一般オプトイン）"
+    decided_by: "豊田"
+    decided_at: "2026-05-27T10:00:00+09:00"
+    rationale: >
+      一般ユーザーに必須化すると離脱リスク。運営管理者は権限が強いため必須、
+      一般・ホストはオプトインで UX とセキュリティを両立。
+      Issue #131（B-04）の指針に整合。
+  - dp_id: "DP-015"
+    chosen: "非該当（スコープ外）"
+    decided_by: "豊田"
+    decided_at: "2026-05-27T10:00:00+09:00"
+    rationale: "docomo / dメニュー連携の予定がないため適用外。"
+
+undecided: []

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/implementation-plan.json
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/implementation-plan.json
@@ -1,0 +1,156 @@
+{
+  "$comment": "架空案件「みんなの読書会」の実装計画成果物。/implement → implementation-skill-planner → firebase-auth-* / tech-version-check / auth-e2e-verify の出力例。schemas/implementation-plan.schema.json（B-01 本実装、B-13 で skill_plan 必須化）準拠。skill_plan は最先頭=tech-version-check（B-11）/ 最末尾=auth-e2e-verify（B-15）の流れ。",
+
+  "modules": [
+    { "module_ref": "MOD-001", "priority": 1 }
+  ],
+
+  "tdd_strategy": "TestAfter",
+  "test_coverage_target": 70,
+
+  "ci_cd_config": {
+    "type": "GitHub Actions",
+    "hooks": ["lint", "test", "build", "e2e"]
+  },
+
+  "pr_strategy": {
+    "pr_max_size_lines": 400,
+    "branch_naming": "feat/<scope>",
+    "merge_strategy": "squash"
+  },
+
+  "skill_plan": [
+    {
+      "skill": "tech-version-check",
+      "recipe": "(言語非依存)",
+      "trigger": "architecture.stack に Rails / React / Firebase JS SDK 等の言語/FW が記述されている（B-11、実装フェーズ全案件で必須・最先頭）",
+      "owners": ["shared"],
+      "applies_to": [
+        "Ruby ランタイム",
+        "Rails 8.x",
+        "React (Web SPA)",
+        "iOS / Android（Swift / Kotlin）",
+        "firebase JS SDK (v9+ modular)",
+        "Firebase Admin（REST、Ruby 側）",
+        "jwt (Ruby gem)",
+        "googleauth (Ruby gem)",
+        "firebase-tools (Emulator)",
+        "node base image (Emulator Docker)"
+      ],
+      "required": true,
+      "called": false
+    },
+    {
+      "skill": "firebase-auth-setup",
+      "recipe": "rails",
+      "trigger": "responsibility_split に backend / shared を含む（ID トークン検証・セッション確立・退会・MFA 失効）",
+      "owners": ["backend", "shared"],
+      "applies_to": [
+        "ID トークン検証 / JWT 認可",
+        "セッション確立（/auth/session、ユーザー upsert）",
+        "退会（IaaS 削除＋アプリ側論理削除）",
+        "公開鍵キャッシュ（Cache-Control 準拠）",
+        "2 段階の失効（hard: tokens_valid_after / soft: refresh のみ）"
+      ],
+      "required": true,
+      "called": false
+    },
+    {
+      "skill": "firebase-auth-frontend",
+      "recipe": "nextjs",
+      "trigger": "responsibility_split に client / shared を含む & page_access_control.pages が定義されている。architecture.stack の Web SPA = React のため nextjs レシピ（Bearer 直送り）を流用。iOS / Android は別レシピ未整備＝判断ポイント（pending-decisions に起票）",
+      "owners": ["client", "shared"],
+      "applies_to": [
+        "サインイン（メール+PW / パスワードレス / OIDC）",
+        "認証方式の追加（アカウント連携）",
+        "退会（DELETE /account を呼ぶ）",
+        "page_access_control: A=protected-only (/mfa/enroll, /settings/*, /clubs/new, /clubs/:id/manage)",
+        "page_access_control: B=public-aware (/, /clubs, /clubs/:id, /books)",
+        "page_access_control: C=guest-only (/login, /signup)"
+      ],
+      "required": true,
+      "called": false
+    },
+    {
+      "skill": "firebase-auth-mfa",
+      "recipe": "rails+nextjs",
+      "trigger": "authentication.mfa_requirement = admin_only（運営管理者必須・一般オプトイン）",
+      "owners": ["backend", "client", "iaas"],
+      "applies_to": [
+        "DP-008 admin_only 実装",
+        "/mfa/enroll（管理者強制リダイレクト）",
+        "TOTP / SMS enrollment（client）",
+        "require_mfa!（backend、管理者ロールかつ mfa_satisfied?=false なら拒否）",
+        "MFA 変更時 soft 失効（refresh のみ、tokens_valid_after は触らない）"
+      ],
+      "required": true,
+      "called": false
+    },
+    {
+      "skill": "firebase-auth-emulator",
+      "recipe": "docker-compose",
+      "trigger": "local_dev_stack = emulator_docker（B-12 既定）。本番接続は staging / production のみ",
+      "owners": ["shared"],
+      "applies_to": [
+        "auth-emulator サービス（Docker、firebase-tools）",
+        "FIREBASE_AUTH_EMULATOR_HOST 検出時の署名検証スキップ（backend）",
+        "Admin REST のホスト切替（Bearer owner）",
+        "connectAuthEmulator（client）",
+        "SMS MFA コード自動取得 REST（E2E 用）",
+        "本番混入ガード（production で EMULATOR_HOST 設定なら起動 abort）"
+      ],
+      "required": true,
+      "called": false
+    },
+    {
+      "skill": "auth-e2e-verify",
+      "recipe": "playwright",
+      "trigger": "representative_use_cases に UC-A01〜A09 が定義 & setup / frontend が skill_plan に入っている（B-15、最末尾配置）",
+      "owners": ["shared"],
+      "applies_to": [
+        "UC-A01〜A09 全 9 件（基本サインイン / 連携 / 変更 / 退会 / MFA）",
+        "page_access_control の A/B/C ガード検証",
+        "MFA は SMS で E2E（TOTP は emulator 非対応のため staging 行き）",
+        "未通過 UC を pending-decisions に警告として残す（warn_and_document）"
+      ],
+      "required": true,
+      "called": false
+    }
+  ],
+
+  "tasks": [
+    { "id": "T-V01", "title": "tech-version-check 実行: Ruby / Rails / React / firebase JS / firebase-tools / Node イメージの最新安定版を delivery/version-matrix.md に記録（B-11）" },
+    { "id": "T-A01", "title": "AuthAdapter インターフェース定義（差し替え可能設計の核, DP-007）" },
+    { "id": "T-A02", "title": "FirebaseAuthAdapter 実装（ID トークン検証 / 公開鍵キャッシュ / Admin REST 経由のユーザー削除・refresh 失効）" },
+    { "id": "T-A03", "title": "Rails API ミドルウェアで JWT 認可（require_registered_user! / Authenticatable concern）" },
+    { "id": "T-A04", "title": "サインインフロー実装（UC-A01〜A03）: メール+PW / パスワードレス / OIDC（Google・Apple）" },
+    { "id": "T-A05", "title": "認証方式の追加（UC-A04）: linkProvider / linkWithPopup" },
+    { "id": "T-A06", "title": "パスワード変更・リセット（UC-A05）/ メール変更（UC-A06）は client 完結（iaas）。/settings/password・/settings/email の UI のみ" },
+    { "id": "T-A07", "title": "退会（UC-A07）: DELETE /account → Admin REST 削除 → 論理削除（deleted_at）→ 再ログイン 403" },
+    { "id": "T-A08", "title": "MFA 実装（UC-A08/A09, DP-008=admin_only）: 管理者強制リダイレクト / enrollment（TOTP・SMS）/ challenge / soft 失効通知（refresh のみ）" },
+    { "id": "T-A09", "title": "page_access_control 実装: A/B/C パターン（PageAccessControl concern / Next.js では layout 単位）" },
+    { "id": "T-A10", "title": "Web/アプリのセッション保持: inMemoryPersistence + 自動リフレッシュ。XSS 配慮で localStorage は使わない" },
+    { "id": "T-E01", "title": "Firebase Auth Emulator + Docker 環境構築（B-12）: docker-compose、firebase.json、本番混入ガード" },
+    { "id": "T-E02", "title": "auth-e2e-verify 実行（B-15）: UC-A01〜A09 全件を Playwright で実機検証、e2e-verification-report.md 生成。MFA は SMS で代替、TOTP は staging 行き" }
+  ],
+
+  "milestones": [
+    "M0: tech-version-check 完了 / version-matrix.md 確定（実装着手前）",
+    "M1: AuthAdapter + Firebase 実装 + JWT 認可（コア認証）",
+    "M2: 各サインインフロー（UC-A01〜A04）",
+    "M3: 連携・各種変更・退会（UC-A05〜A07）",
+    "M4: MFA 実装（UC-A08/A09）",
+    "M5: Emulator 環境で E2E 全件 PASS（auth-e2e-verify）→ 実装完了"
+  ],
+
+  "dependencies": [
+    "Firebase プロジェクト / サービスアカウント鍵（本番のみ、コミット禁止、.env / Secrets）",
+    "schemas/design.schema.json（承認済み設計）",
+    "Identity Platform アップグレード（MFA 実装のため）",
+    "docker compose 環境（emulator + backend + frontend）"
+  ],
+
+  "test_plan": "AuthAdapter のユニットテスト（TestAdapter）、JWT 検証の正常/失効/改ざんケース、各サインインフローの結合テスト。E2E は auth-e2e-verify で UC-A01〜A09 を Playwright（emulator 接続）で全件通す。CI では emulator スタックを立てて回す。",
+
+  "undecided": []
+}

--- a/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/requirements.json
+++ b/ai-delivery/plugins/xtone-auth-plugin/sample-outputs/requirements.json
@@ -1,0 +1,96 @@
+{
+  "$comment": "架空案件「みんなの読書会」の要件定義成果物。/req-collect → auth-requirements-extraction の出力例。schemas/requirements.schema.json 準拠（T-011 本実装、B-01）。B-13 で追加された page_access_control 候補も含む（auth-requirements-extraction が抽出 → design で確定）。",
+
+  "scope": {
+    "must": [
+      { "id": "M-01", "title": "メールアドレス + パスワード認証" },
+      { "id": "M-02", "title": "メールアドレス + 一時トークン（パスワードレス）認証" },
+      { "id": "M-03", "title": "OIDC 連携（Google / Apple）" },
+      { "id": "M-04", "title": "既存アカウントへの認証方式の追加" },
+      { "id": "M-05", "title": "パスワード変更 / リセット" },
+      { "id": "M-06", "title": "メールアドレス変更" },
+      { "id": "M-07", "title": "退会（アカウント削除）" },
+      { "id": "M-08", "title": "バックエンド API の JWT 認可" },
+      { "id": "M-09", "title": "Web / アプリでのログインセッション保持" }
+    ],
+    "should": [
+      { "id": "S-01", "title": "運営管理者ロールへの強い認証（多要素）" },
+      { "id": "S-02", "title": "クライアント側でのトークン保持の XSS 配慮" }
+    ],
+    "could": [
+      { "id": "C-01", "title": "一般ユーザーへの MFA オプトイン提供" }
+    ],
+    "wont": [
+      { "id": "W-01", "title": "docomo / dメニュー（dAccount）連携" },
+      { "id": "W-02", "title": "規制対応（金融・医療等）" }
+    ]
+  },
+
+  "representative_use_cases": [
+    { "id": "UC-A01", "name": "サインイン（メール+パスワード）", "kind": "core" },
+    { "id": "UC-A02", "name": "サインイン（メールリンク/パスワードレス）", "kind": "core" },
+    { "id": "UC-A03", "name": "サインイン（OIDC: Google / Apple）", "kind": "core" },
+    { "id": "UC-A04", "name": "認証方式の追加（既存アカウントへ Google 等を連携）", "kind": "sub" },
+    { "id": "UC-A05", "name": "パスワード変更・リセット", "kind": "sub" },
+    { "id": "UC-A06", "name": "メールアドレス変更", "kind": "sub" },
+    { "id": "UC-A07", "name": "退会（IaaS 削除 + アプリ側論理削除 + 再ログイン拒否）", "kind": "sub" },
+    { "id": "UC-A08", "name": "MFA enrollment（管理者必須・一般オプトイン）", "kind": "sub" },
+    { "id": "UC-A09", "name": "MFA challenge（再ログイン時の第2要素検証）", "kind": "sub" }
+  ],
+
+  "functional_requirements": [
+    { "id": "FR-01", "description": "Web SPA / iOS / Android からのサインイン・サインアップを統合的に扱う" },
+    { "id": "FR-02", "description": "ID トークンの API への Bearer 付与で Rails API を認可する" },
+    { "id": "FR-03", "description": "サーバ側で /auth/session を介してアプリのユーザーレコードを upsert する" },
+    { "id": "FR-04", "description": "退会時に Firebase Admin SDK でユーザー削除し、再ログイン時は 403 で拒否する（退会済み再登録ポリシーは DP 起票・B-08）" }
+  ],
+
+  "non_functional_requirements": [
+    { "category": "performance", "description": "初年度の想定規模: 数万ユーザー。セッション切れの再ログインは UX を損なわない速度（数百ms オーダー）" },
+    { "category": "security",    "description": "ID トークン短命 + リフレッシュで盗難耐性を確保。XSS 配慮（クライアントは inMemoryPersistence、localStorage には ID トークンを置かない）" },
+    { "category": "security",    "description": "運営管理者ロールは MFA 必須（admin_only）。一般ユーザーはオプトイン（DP-008）" },
+    { "category": "maintainability", "description": "認証 IaaS は AuthAdapter 越しに利用し、将来差し替え可能にする（DP-007）" }
+  ],
+
+  "domain_tags": ["BtoC", "community"],
+
+  "stakeholders": {
+    "client": "（架空）みんなの読書会 株式会社",
+    "pm": "（架空）プロダクトオーナー",
+    "lead": "（架空）開発リーダー"
+  },
+
+  "client_approval": {
+    "approved": true,
+    "approved_by": "豊田",
+    "approved_at": "2026-05-27T10:00:00+09:00",
+    "notes": "B-14 サンプル再生成時の架空承認。スコープ整理（MFA 方針は設計フェーズ判断）に合意。"
+  },
+
+  "page_access_control_candidates": {
+    "$comment": "B-13 / auth-requirements-extraction が要件段階で抽出するページ振り分け候補。設計フェーズ（authentication-architect / firebase-auth-design）が design.yaml.page_access_control に確定する。",
+    "protected_only_A": [
+      "/mfa/enroll",
+      "/settings/profile",
+      "/settings/email",
+      "/settings/password",
+      "/settings/withdrawal",
+      "/clubs/new",
+      "/clubs/:id/manage"
+    ],
+    "public_aware_B": [
+      "/",
+      "/clubs",
+      "/clubs/:id",
+      "/books"
+    ],
+    "guest_only_C": [
+      "/login",
+      "/signup"
+    ],
+    "signup_separate_page": true,
+    "default_after_login": "/"
+  },
+
+  "undecided": ["DP-007", "DP-008"]
+}


### PR DESCRIPTION
## Summary

B-13（PR #154）で削除した `sample-outputs/` を、B-11/B-12/B-13/B-15 一連の型化修正完了後の **新スキーマ + 新スキル群**に沿って再構築。架空案件「みんなの読書会」（[`sample-inputs/bookclub-app.requirements-input.md`](../blob/main/ai-delivery/plugins/xtone-auth-plugin/sample-inputs/bookclub-app.requirements-input.md)）を継続使用。

## 成果物 5 ファイル

| ファイル | 含む新フィールド / スキル |
|---|---|
| `requirements.json` | scope を **オブジェクト配列**で構造化 / UC-A01〜A09 / `page_access_control_candidates`（B-13 抽出層）/ undecided=[DP-007, DP-008] |
| `design.yaml` | `responsibility_split`（B-03、MFA enrollment/challenge と soft 失効も含む）/ `page_access_control`（B-13、13 ページ A/B/C）/ `local_dev_stack=emulator_docker`（B-12）/ DP-007/008/015 decision_record |
| `ADR-001-auth-stack.md` | Firebase Auth vs Devise+OmniAuth vs Cognito 比較 / AuthAdapter 差し替え可能設計 / 関連スキル 6 件への参照 |
| `implementation-plan.json` | **`skill_plan` 6 エントリ**（B-13 で required 化）。最先頭=`tech-version-check`（B-11）→ setup → **frontend (recipe=nextjs)** → mfa (recipe=rails+nextjs) → emulator → 最末尾=`auth-e2e-verify`（B-15）の流れ。`architecture.stack`=React (Web SPA) と recipe が整合（PR #154 で発見した不整合への対応） |
| `README.md` | 通しフロー解説、B-13 で塞いだ穴（フェーズ間食い違い）の明示 |

## 検証（`/tmp/validate_b14.py` で実施）

- **jsonschema meta-validation**: 3 スキーマ OK
- **各サンプルファイルのスキーマ検証**: 3/3 OK
- **整合性チェック 7 項目すべて PASS**:
  - [x] `responsibility_split.client/shared` あり → `firebase-auth-frontend` が skill_plan に
  - [x] `mfa_requirement=admin_only` → `firebase-auth-mfa` が skill_plan に
  - [x] `local_dev_stack=emulator_docker` → `firebase-auth-emulator` が skill_plan に
  - [x] skill_plan の最先頭が `tech-version-check`
  - [x] skill_plan の最末尾が `auth-e2e-verify`
  - [x] `page_access_control.pages` の `pattern` が全 A/B/C
  - [x] requirements 候補ページ 13 件 = design 確定ページ 13 件
- `claude plugin validate --strict` ✔

## 「型化の穴」が塞がっていることの実証

このサンプルは、サンプル案件 sample-auth で起きた以下の問題が**再発しない構造**を示しています:

1. **frontend スキル素通り問題**（B-13 由来）→ `responsibility_split.client` を含む設計で planner が必ず `firebase-auth-frontend` を skill_plan に列挙する
2. **emulator 手動構築問題**（B-12 由来）→ `local_dev_stack=emulator_docker` が既定で、planner が `firebase-auth-emulator` を必ず列挙する
3. **バージョン非互換に途中で気づく問題**（B-11 由来）→ skill_plan の最先頭に `tech-version-check` があり、実装着手前に `version-matrix.md` を作る
4. **DP 決定済み UC が未実装で止まる問題**（B-15 由来）→ skill_plan の最末尾に `auth-e2e-verify` があり、Playwright で全 UC PASS が DoD
5. **recipe 不整合**（PR #154 で発見）→ `architecture.stack=React (Web SPA)` と `firebase-auth-frontend.recipe=nextjs` / `firebase-auth-mfa.recipe=rails+nextjs` が揃う

Closes #155
関連: #154 (B-13), #156 (B-11), #157 (B-12), #158 (B-15), #159 (B-16)

## Test plan

- [x] jsonschema meta-validation
- [x] 3 サンプルファイルのスキーマ検証
- [x] 整合性チェック 7 項目
- [x] plugin validate --strict
- [ ] レビュー後、Notion 反映（規約トラッカー / 全体俯瞰サマリ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)