### PR TITLE
feat(B-07): generate-plugin.sh / validate-plugin.sh (TPL-26/27) を整備

### DIFF
--- a/ai-delivery/CLAUDE.md
+++ b/ai-delivery/CLAUDE.md
@@ -70,8 +70,29 @@ Xtone の開発プロセスを Claude Code プラグインで型化する。中�
 
 ## 検証
 
-> ⚠️ 現状、検証スクリプトは未整備。`scripts/validate-plugin.sh`（TPL-27）作成後、実行コマンドをこのセクションに追記すること。
-> プラグイン実装時は `xtone-shared-plugin/schemas/v1/` の JSON Schema に対するバリデーションを必ず通す（CI の 18 ルール検証 = T-014 と整合させる）。
+プラグイン生成と品質ゲート＋スキーマ検証は `scripts/` 配下のシェルで行う（TPL-26 / TPL-27, B-07）。両スクリプトとも warn_and_document（T-002）— 既定では警告を出しても exit 0、`--strict` で CI 用に exit 1。
+
+```bash
+# 新規プラグイン生成（usecase は小文字英数とハイフンのみ）
+ai-delivery/scripts/generate-plugin.sh <usecase> \
+  --description "<説明>" --author "<著者>" \
+  --domains "<適用ドメイン>" --modules "<MOD-XXX>"
+
+# 既存プラグインの品質ゲート＋デリバリ成果物のスキーマ検証
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/<plugin> [--strict] [--no-schema]
+```
+
+`validate-plugin.sh` は以下を一括チェックする:
+
+1. `.claude-plugin/plugin.json` 必須フィールド・命名規約（CONV-01）
+2. `schemas/` symlink（CONV-14: Single Source of Truth）
+3. `skills/<usecase>-plugin-guide/SKILL.md` と各 `SKILL.md` の frontmatter（SKL-20 / CONV-06 / DP-27）
+4. `hooks/hooks.json` ＋ シェルの実行権限
+5. `.mcp.json.sample` のトークン参照（MCP-08）
+6. テンプレ未置換プレースホルダ `{{...}}` の残存
+7. **デリバリ成果物のスキーマ検証**（`sample-outputs/` / `delivery/` 配下の `requirements*.json`／`design*.yaml`／`implementation-plan*.json` ほか）
+
+依存: `bash`, `jq`, `python3`, `jsonschema`, `PyYAML`。jsonschema/PyYAML は `pip3 install --user jsonschema PyYAML` で導入。
 
 ## ID プレフィックス体系（CONV-19）
 

--- a/ai-delivery/README.md
+++ b/ai-delivery/README.md
@@ -25,6 +25,10 @@ ai-delivery/
 │   ├── plugin-developer-guide.md
 │   ├── environment-setup.md
 │   └── mcp-setup-guide.md
+├── scripts/                        # プラグイン生成・検証ツール（TPL-26/27, B-07）
+│   ├── generate-plugin.sh
+│   ├── validate-plugin.sh
+│   └── lib/validate_schema.py
 ├── xtone-plugin-template/          # 新規プラグインのマスターテンプレ
 ├── xtone-shared-plugin/            # 各プラグインが共有するスキーマ
 │   └── schemas/v1/

--- a/ai-delivery/scripts/generate-plugin.sh
+++ b/ai-delivery/scripts/generate-plugin.sh
@@ -103,8 +103,11 @@ mv "$GUIDE_DIR_DST/SKILL.md.template" "$GUIDE_DIR_DST/SKILL.md"
 # 4. プレースホルダを置換（macOS / GNU sed どちらでも動くよう .bak 経由）。
 replace_in_file() {
   local pattern="$1" replacement="$2" file="$3"
-  # `|` 区切り。replacement に `|` が含まれないことを前提に呼び出し側で配慮。
-  sed -i.bak "s|${pattern}|${replacement}|g" "$file"
+  # replacement 中の sed 特殊文字（デリミタ `|`、後方参照 `&`、エスケープ `\`）を
+  # エスケープしないと `--description "BtoC & BtoB"` 等でマッチ文字列が挿入される。
+  local safe_replacement
+  safe_replacement="$(printf '%s' "$replacement" | sed -e 's/[&\\|]/\\&/g')"
+  sed -i.bak "s|${pattern}|${safe_replacement}|g" "$file"
   rm -f "${file}.bak"
 }
 

--- a/ai-delivery/scripts/generate-plugin.sh
+++ b/ai-delivery/scripts/generate-plugin.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+# TPL-26 — xtone-plugin-template から新規プラグインスケルトンを生成する。
+# Usage:
+#   ai-delivery/scripts/generate-plugin.sh <usecase> [options]
+#     --description "..."        プラグイン説明
+#     --author "..."             著者名
+#     --domains "BtoCアプリ,..."  適用ドメイン（T-008 ドメインタクソノミー）
+#     --modules "MOD-001,..."    依存モジュール
+#     --force                    既存ディレクトリを上書き
+#   例:
+#     ai-delivery/scripts/generate-plugin.sh auth \
+#       --description "認証モジュール" --author "Xtone"
+#
+# 方針: warn_and_document（T-002）— 未置換プレースホルダ等は警告のみ・exit 0。
+
+set -euo pipefail
+
+usage() {
+  sed -n '2,15p' "$0" >&2
+  exit 1
+}
+
+if [ "$#" -lt 1 ]; then usage; fi
+
+USECASE="$1"
+shift || true
+
+case "$USECASE" in
+  -h|--help) usage ;;
+  -*) echo "❌ usecase 名が必要です（'-' で始まる引数）" >&2; usage ;;
+esac
+
+if ! printf '%s' "$USECASE" | grep -qE '^[a-z][a-z0-9-]*$'; then
+  echo "❌ usecase は小文字英数とハイフンのみ: '$USECASE'" >&2
+  exit 1
+fi
+
+DESCRIPTION=""
+AUTHOR_NAME=""
+APPLICABLE_DOMAINS=""
+DEPENDENT_MODULES=""
+FORCE=0
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --description) DESCRIPTION="${2:-}"; shift 2 ;;
+    --author) AUTHOR_NAME="${2:-}"; shift 2 ;;
+    --domains) APPLICABLE_DOMAINS="${2:-}"; shift 2 ;;
+    --modules) DEPENDENT_MODULES="${2:-}"; shift 2 ;;
+    --force) FORCE=1; shift ;;
+    -h|--help) usage ;;
+    *) echo "❌ 未知のオプション: $1" >&2; usage ;;
+  esac
+done
+
+# このスクリプトは ai-delivery/scripts/ 配下にある想定
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+AI_DELIVERY_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEMPLATE_DIR="$AI_DELIVERY_DIR/xtone-plugin-template"
+PLUGIN_NAME="xtone-${USECASE}-plugin"
+PLUGIN_DIR="$AI_DELIVERY_DIR/plugins/$PLUGIN_NAME"
+
+if [ ! -d "$TEMPLATE_DIR" ]; then
+  echo "❌ テンプレが見つかりません: $TEMPLATE_DIR" >&2
+  exit 1
+fi
+
+if [ -e "$PLUGIN_DIR" ]; then
+  if [ "$FORCE" -ne 1 ]; then
+    echo "❌ 既存のディレクトリがあります: $PLUGIN_DIR （--force で上書き）" >&2
+    exit 1
+  fi
+  echo "⚠️  既存ディレクトリを削除して再生成: $PLUGIN_DIR" >&2
+  rm -rf "$PLUGIN_DIR"
+fi
+
+echo "🛠  Generating $PLUGIN_NAME from template ..."
+mkdir -p "$(dirname "$PLUGIN_DIR")"
+
+# 1. テンプレを丸ごとコピー。シンボリックリンクは再作成のため `-L` を使わない。
+cp -R "$TEMPLATE_DIR/" "$PLUGIN_DIR/"
+
+# テンプレ自身の説明書 README はプラグイン側には不要なので削除し、後段で最小雛形を生成。
+rm -f "$PLUGIN_DIR/README.md"
+
+# 2. schemas symlink を再作成（cp で実体化される場合があるため）。
+SCHEMAS_LINK="$PLUGIN_DIR/schemas"
+rm -rf "$SCHEMAS_LINK"
+ln -s ../../xtone-shared-plugin/schemas/v1 "$SCHEMAS_LINK"
+
+# 3. .template ファイルを実体化。
+#    - plugin.json.template → plugin.json
+#    - skills/plugin-guide/SKILL.md.template → skills/<usecase>-plugin-guide/SKILL.md
+#      （ディレクトリ名も usecase で改名）
+#    - skills/SKILL.md.template はフェーズ別 Skill の骨格なので .template のまま残す。
+mv "$PLUGIN_DIR/.claude-plugin/plugin.json.template" "$PLUGIN_DIR/.claude-plugin/plugin.json"
+
+GUIDE_DIR_SRC="$PLUGIN_DIR/skills/plugin-guide"
+GUIDE_DIR_DST="$PLUGIN_DIR/skills/${USECASE}-plugin-guide"
+mv "$GUIDE_DIR_SRC" "$GUIDE_DIR_DST"
+mv "$GUIDE_DIR_DST/SKILL.md.template" "$GUIDE_DIR_DST/SKILL.md"
+
+# 4. プレースホルダを置換（macOS / GNU sed どちらでも動くよう .bak 経由）。
+replace_in_file() {
+  local pattern="$1" replacement="$2" file="$3"
+  # `|` 区切り。replacement に `|` が含まれないことを前提に呼び出し側で配慮。
+  sed -i.bak "s|${pattern}|${replacement}|g" "$file"
+  rm -f "${file}.bak"
+}
+
+while IFS= read -r -d '' f; do
+  replace_in_file '{{usecase}}' "$USECASE" "$f"
+  [ -n "$DESCRIPTION" ]        && replace_in_file '{{description}}'         "$DESCRIPTION"        "$f" || true
+  [ -n "$AUTHOR_NAME" ]        && replace_in_file '{{author_name}}'         "$AUTHOR_NAME"        "$f" || true
+  [ -n "$APPLICABLE_DOMAINS" ] && replace_in_file '{{applicable_domains}}'  "$APPLICABLE_DOMAINS" "$f" || true
+  [ -n "$DEPENDENT_MODULES" ]  && replace_in_file '{{dependent_modules}}'   "$DEPENDENT_MODULES"  "$f" || true
+done < <(find "$PLUGIN_DIR" -type f \
+  \( -name '*.json' -o -name '*.md' -o -name '*.yaml' -o -name '*.yml' -o -name '*.sh' -o -name '*.template' \) \
+  -print0)
+
+# 5. プラグイン用の最小 README 雛形を生成（テンプレの説明書とは別物）。
+cat > "$PLUGIN_DIR/README.md" <<EOF
+# $PLUGIN_NAME
+
+Xtone AIデリバリシステムの **${USECASE}** プラグイン。マスターテンプレ \`xtone-plugin-template\`（T-019）から生成。
+
+> 運用 context は \`skills/${USECASE}-plugin-guide/SKILL.md\` を参照（DP-27 / CONV-06: ルート CLAUDE.md は置かない）。
+> プロジェクト全体のルールは \`ai-delivery/CLAUDE.md\` を参照。
+
+## 構成
+
+- \`agents/\` — Subagent（基盤6 ＋ ユースケース特化を追加可能）
+- \`commands/\` — Slash Command（基盤8 ＋ 必要に応じて拡張）
+- \`hooks/\` — hooks.json + 4 Hook（warn_and_document）
+- \`skills/${USECASE}-plugin-guide/\` — 本プラグインの作業ガイド
+- \`skills/<phase>/<skill>/\` — フェーズ別 Skill（テンプレは \`skills/SKILL.md.template\`）
+- \`schemas/\` — \`xtone-shared-plugin/schemas/v1\` への symlink（編集不可・CONV-14）
+- \`docs/\` — pending-decisions / adr 等
+
+## はじめかた
+
+\`\`\`bash
+cp .env.example .env   # トークンを設定
+ai-delivery/scripts/validate-plugin.sh .   # 品質ゲート
+claude                  # Claude Code を起動し、/req-collect で開始
+\`\`\`
+EOF
+
+# 6. hook を実行可能に。
+find "$PLUGIN_DIR/hooks" -name '*.sh' -type f -exec chmod +x {} +
+
+# 7. 未置換プレースホルダの検出（warn_and_document, exit 0 を維持）。
+#    実体化済みファイル（*.template を除く）を対象。
+REMAIN="$(grep -rln '{{' "$PLUGIN_DIR" --exclude='*.template' 2>/dev/null || true)"
+if [ -n "$REMAIN" ]; then
+  echo "⚠️  未置換のプレースホルダが残っています（必須項目は手動置換または再生成で対応）:" >&2
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    echo "   - $line" >&2
+  done <<EOF
+$REMAIN
+EOF
+fi
+
+echo "✅ Plugin generated: $PLUGIN_DIR"
+echo
+echo "次の手順:"
+echo "  1. cd $PLUGIN_DIR"
+echo "  2. cp .env.example .env && トークンを設定"
+echo "  3. ai-delivery/scripts/validate-plugin.sh $PLUGIN_DIR で品質ゲートを実行"
+echo "  4. claude で起動し、/req-collect で要件収集を開始"

--- a/ai-delivery/scripts/lib/validate_schema.py
+++ b/ai-delivery/scripts/lib/validate_schema.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""TPL-27 補助 — JSON Schema 検証（YAML 対応）。
+
+Usage:
+    validate_schema.py <schema.json> <data-file.json|.yaml> [--label LABEL]
+
+成果:
+    検証 OK   -> stdout に `✅ <label>: OK`、終了コード 0
+    検証 NG   -> stderr に `⚠️  <label>: <エラー>`、終了コード 1
+    依存欠如  -> stderr に手当案内、終了コード 2（warn_and_document で呼び出し側が握り潰す）
+
+依存:
+    jsonschema, PyYAML（YAML 検証時のみ）。
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+def _load_yaml(path: Path):
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        print(
+            "⚠️  PyYAML 未導入のため YAML 検証をスキップ: "
+            "pip3 install --user PyYAML jsonschema",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _load_data(path: Path):
+    suffix = path.suffix.lower()
+    if suffix in {".yaml", ".yml"}:
+        return _load_yaml(path)
+    with path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="JSON Schema 検証（YAML 可）")
+    parser.add_argument("schema", type=Path, help="JSON Schema ファイル")
+    parser.add_argument("data", type=Path, help="検証対象ファイル（.json / .yaml）")
+    parser.add_argument("--label", default=None, help="出力ラベル（既定: data のパス）")
+    args = parser.parse_args()
+
+    label = args.label or str(args.data)
+
+    try:
+        import jsonschema  # type: ignore
+    except ImportError:
+        print(
+            "⚠️  jsonschema 未導入のためスキーマ検証をスキップ: "
+            "pip3 install --user jsonschema PyYAML",
+            file=sys.stderr,
+        )
+        return 2
+
+    try:
+        schema = json.loads(args.schema.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"⚠️  {label}: スキーマ読み込み失敗 ({args.schema}): {e}", file=sys.stderr)
+        return 1
+
+    try:
+        data = _load_data(args.data)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"⚠️  {label}: データ読み込み失敗: {e}", file=sys.stderr)
+        return 1
+
+    validator_cls = jsonschema.validators.validator_for(schema)
+    validator = validator_cls(schema)
+
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.absolute_path))
+    if not errors:
+        print(f"✅ {label}: OK")
+        return 0
+
+    for err in errors:
+        path = "$" + "".join(f"[{p!r}]" for p in err.absolute_path)
+        print(f"⚠️  {label}: {path} — {err.message}", file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/ai-delivery/scripts/lib/validate_schema.py
+++ b/ai-delivery/scripts/lib/validate_schema.py
@@ -20,16 +20,18 @@ import sys
 from pathlib import Path
 
 
+class DependencyMissing(Exception):
+    """jsonschema / PyYAML 等の依存ライブラリが未導入。warn_and_document で exit 2 に対応。"""
+
+
 def _load_yaml(path: Path):
     try:
         import yaml  # type: ignore
-    except ImportError:
-        print(
-            "⚠️  PyYAML 未導入のため YAML 検証をスキップ: "
-            "pip3 install --user PyYAML jsonschema",
-            file=sys.stderr,
-        )
-        sys.exit(2)
+    except ImportError as e:
+        raise DependencyMissing(
+            "PyYAML 未導入のため YAML 検証をスキップ: "
+            "pip3 install --user PyYAML jsonschema"
+        ) from e
     with path.open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
@@ -69,6 +71,9 @@ def main() -> int:
 
     try:
         data = _load_data(args.data)
+    except DependencyMissing as e:
+        print(f"⚠️  {e}", file=sys.stderr)
+        return 2
     except (OSError, json.JSONDecodeError) as e:
         print(f"⚠️  {label}: データ読み込み失敗: {e}", file=sys.stderr)
         return 1

--- a/ai-delivery/scripts/validate-plugin.sh
+++ b/ai-delivery/scripts/validate-plugin.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# TPL-27 — プラグインの品質ゲート＋デリバリ成果物のスキーマ検証。
+# Usage:
+#   ai-delivery/scripts/validate-plugin.sh [<plugin-dir>] [options]
+#     --strict           1件でも警告があれば exit 1 で終了する（CI 用）
+#     --no-schema        スキーマ検証を行わない（構造チェックのみ）
+#     --deliverable-dir  デリバリ成果物の探索先（既定: <plugin-dir>/sample-outputs と <plugin-dir>/delivery）
+#   例:
+#     ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin
+#
+# 方針: warn_and_document（T-002）。既定では警告を出しても **exit 0**（ブロックしない）。
+#       CI で「警告ゼロ」を強制したい時のみ --strict を付ける。
+# 検証項目:
+#   1. .claude-plugin/plugin.json の必須フィールド（CONV-01）
+#   2. schemas/ が symlink で xtone-shared-plugin を指している（CONV-14）
+#   3. skills/<usecase>-plugin-guide/SKILL.md と他 skills/**/SKILL.md の frontmatter（SKL-20）
+#      ※ プラグインルートの CLAUDE.md は CONV-06 改訂（B-05 / DP-27）で不要
+#   4. hooks/hooks.json + hooks/*.sh の実行権限
+#   5. .mcp.json.sample のトークン参照（MCP-08）
+#   6. プレースホルダ {{...}} の未置換チェック
+#   7. デリバリ成果物（sample-outputs/ / delivery/ 配下）の JSON Schema 検証（B-01/B-13 対応）
+
+set -uo pipefail
+
+PLUGIN_DIR=""
+STRICT=0
+SCHEMA_CHECK=1
+DELIVERABLE_DIRS=()
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --strict) STRICT=1; shift ;;
+    --no-schema) SCHEMA_CHECK=0; shift ;;
+    --deliverable-dir) DELIVERABLE_DIRS+=("${2:-}"); shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0" >&2; exit 0 ;;
+    --) shift; break ;;
+    -*) echo "❌ 未知のオプション: $1" >&2; exit 2 ;;
+    *)
+      if [ -z "$PLUGIN_DIR" ]; then
+        PLUGIN_DIR="$1"
+      else
+        echo "❌ 位置引数は1つだけです" >&2; exit 2
+      fi
+      shift ;;
+  esac
+done
+
+PLUGIN_DIR="${PLUGIN_DIR:-.}"
+
+if [ ! -d "$PLUGIN_DIR" ]; then
+  echo "❌ プラグインディレクトリが見つかりません: $PLUGIN_DIR" >&2
+  exit 2
+fi
+
+PLUGIN_DIR="$(cd "$PLUGIN_DIR" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+WARN=0
+warn() {
+  echo "⚠️  $*" >&2
+  WARN=$((WARN + 1))
+}
+
+echo "🔍 Validating $PLUGIN_DIR"
+
+# --- 1. plugin.json の必須フィールド (CONV-01) ------------------------------
+PLUGIN_JSON="$PLUGIN_DIR/.claude-plugin/plugin.json"
+if [ ! -f "$PLUGIN_JSON" ]; then
+  warn ".claude-plugin/plugin.json がありません（CONV-01）"
+elif ! command -v jq >/dev/null 2>&1; then
+  warn "jq が見つからず plugin.json の検証をスキップ"
+else
+  for field in name version description; do
+    if ! jq -e --arg f "$field" 'has($f)' "$PLUGIN_JSON" >/dev/null; then
+      warn "plugin.json: $field がありません（CONV-01）"
+    fi
+  done
+  if jq -e 'has("author")' "$PLUGIN_JSON" >/dev/null; then
+    if ! jq -e '.author.name? // empty' "$PLUGIN_JSON" >/dev/null; then
+      warn "plugin.json: author.name がありません（CONV-01）"
+    fi
+  else
+    warn "plugin.json: author がありません（CONV-01）"
+  fi
+  # name は xtone-*-plugin 形式（CONV-01 命名規約）
+  name="$(jq -r '.name // ""' "$PLUGIN_JSON")"
+  if ! printf '%s' "$name" | grep -qE '^xtone-[a-z0-9-]+-plugin$'; then
+    warn "plugin.json: name '$name' は xtone-<usecase>-plugin 形式にしてください（CONV-01）"
+  fi
+fi
+
+# --- 2. schemas/ が symlink (CONV-14) ---------------------------------------
+SCHEMAS_PATH="$PLUGIN_DIR/schemas"
+if [ ! -e "$SCHEMAS_PATH" ]; then
+  warn "schemas/ がありません（CONV-14: xtone-shared-plugin/schemas/v1 への symlink を作成）"
+elif [ ! -L "$SCHEMAS_PATH" ]; then
+  warn "schemas/ が symlink ではありません（CONV-14: スキーマは Single Source of Truth）"
+else
+  target="$(readlink "$SCHEMAS_PATH")"
+  case "$target" in
+    *xtone-shared-plugin/schemas/v1*) ;;
+    *) warn "schemas/ の symlink 先が不正です: $target（CONV-14）" ;;
+  esac
+fi
+
+# --- 3. SKILL.md frontmatter (SKL-20) ---------------------------------------
+SKILLS_DIR="$PLUGIN_DIR/skills"
+if [ ! -d "$SKILLS_DIR" ]; then
+  warn "skills/ がありません"
+else
+  # plugin-guide skill の存在（CONV-06 / DP-27: ルート CLAUDE.md ではなく skill に集約）
+  guide_count=$(find "$SKILLS_DIR" -maxdepth 2 -type f -name 'SKILL.md' -path '*-plugin-guide/SKILL.md' 2>/dev/null | wc -l | tr -d ' ')
+  if [ "${guide_count:-0}" -eq 0 ]; then
+    warn "skills/<usecase>-plugin-guide/SKILL.md がありません（CONV-06 / DP-27）"
+  fi
+  while IFS= read -r -d '' skill; do
+    rel="${skill#$PLUGIN_DIR/}"
+    # 先頭の YAML frontmatter を抽出してフィールドを検証
+    if ! head -1 "$skill" | grep -q '^---$'; then
+      warn "$rel: frontmatter (---) で始まっていません（SKL-20）"
+      continue
+    fi
+    fm="$(awk 'NR==1 && /^---$/ {f=1; next} f && /^---$/ {exit} f' "$skill")"
+    for field in name description; do
+      if ! printf '%s\n' "$fm" | grep -qE "^${field}:[[:space:]]"; then
+        warn "$rel: frontmatter に $field がありません（SKL-20）"
+      fi
+    done
+  done < <(find "$SKILLS_DIR" -type f -name 'SKILL.md' -print0)
+fi
+
+# --- 4. hooks ---------------------------------------------------------------
+HOOKS_DIR="$PLUGIN_DIR/hooks"
+if [ -d "$HOOKS_DIR" ]; then
+  if [ ! -f "$HOOKS_DIR/hooks.json" ]; then
+    warn "hooks/hooks.json がありません"
+  fi
+  while IFS= read -r -d '' hook; do
+    if [ ! -x "$hook" ]; then
+      warn "hook が実行可能ではありません: ${hook#$PLUGIN_DIR/}（chmod +x で付与）"
+    fi
+  done < <(find "$HOOKS_DIR" -type f -name '*.sh' -print0)
+fi
+
+# --- 5. .mcp.json.sample の認証トークン参照 (MCP-08) ------------------------
+MCP_SAMPLE="$PLUGIN_DIR/.mcp.json.sample"
+if [ -f "$MCP_SAMPLE" ]; then
+  for token in FIGMA_TOKEN GITHUB_TOKEN NOTION_TOKEN; do
+    if ! grep -q "\${${token}}" "$MCP_SAMPLE"; then
+      warn ".mcp.json.sample: \${${token}} 参照がありません（MCP-08）"
+    fi
+  done
+fi
+
+# --- 6. 未置換プレースホルダ -----------------------------------------------
+# .template ファイルは除外（生成元として残してよい）
+REMAIN="$(grep -rln '{{' "$PLUGIN_DIR" --exclude='*.template' 2>/dev/null \
+  | grep -v -E '(/\.git/|/node_modules/|/schemas/v1/)' || true)"
+if [ -n "$REMAIN" ]; then
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
+    warn "未置換プレースホルダ '{{...}}': ${line#$PLUGIN_DIR/}"
+  done <<EOF
+$REMAIN
+EOF
+fi
+
+# --- 7. デリバリ成果物のスキーマ検証 ---------------------------------------
+if [ "$SCHEMA_CHECK" -eq 1 ]; then
+  SCHEMA_ROOT="$PLUGIN_DIR/schemas"
+  if [ ! -e "$SCHEMA_ROOT" ]; then
+    warn "schemas/ がないためデリバリ成果物のスキーマ検証をスキップ"
+  elif ! command -v python3 >/dev/null 2>&1; then
+    warn "python3 が見つからずスキーマ検証をスキップ"
+  else
+    if [ "${#DELIVERABLE_DIRS[@]}" -eq 0 ]; then
+      DELIVERABLE_DIRS=("$PLUGIN_DIR/sample-outputs" "$PLUGIN_DIR/delivery")
+    fi
+
+    declare_schema_for() {
+      # ファイル名から対応スキーマ名を推定する。
+      local file="$1" base
+      base="$(basename "$file")"
+      case "$base" in
+        requirements*.json|requirements*.yaml|requirements*.yml)
+          echo "requirements.schema.json"; return 0 ;;
+        design*.json|design*.yaml|design*.yml)
+          echo "design.schema.json"; return 0 ;;
+        implementation-plan*.json|implementation-plan*.yaml|implementation-plan*.yml)
+          echo "implementation-plan.schema.json"; return 0 ;;
+        modules*.json) echo "modules.schema.json"; return 0 ;;
+        module*.json)  echo "module.schema.json"; return 0 ;;
+        risks*.json)   echo "risks.schema.json"; return 0 ;;
+        decision-point*.json|decision-points*.json)
+          echo "decision-point.schema.json"; return 0 ;;
+        *) return 1 ;;
+      esac
+    }
+
+    found_any=0
+    for dir in "${DELIVERABLE_DIRS[@]}"; do
+      [ -d "$dir" ] || continue
+      while IFS= read -r -d '' file; do
+        schema_name="$(declare_schema_for "$file" || true)"
+        if [ -z "$schema_name" ]; then
+          continue
+        fi
+        schema_path="$SCHEMA_ROOT/$schema_name"
+        if [ ! -f "$schema_path" ]; then
+          warn "スキーマが見つかりません: $schema_name（対象: ${file#$PLUGIN_DIR/}）"
+          continue
+        fi
+        found_any=1
+        label="${file#$PLUGIN_DIR/}"
+        rc=0
+        python3 "$SCRIPT_DIR/lib/validate_schema.py" "$schema_path" "$file" --label "$label" || rc=$?
+        # validate_schema.py: 0=OK, 1=スキーマ違反, 2=依存欠如（warn にカウントしない）
+        if [ "$rc" -eq 1 ]; then
+          WARN=$((WARN + 1))
+        fi
+      done < <(find "$dir" -maxdepth 2 -type f \
+        \( -name '*.json' -o -name '*.yaml' -o -name '*.yml' \) -print0)
+    done
+
+    if [ "$found_any" -eq 0 ]; then
+      echo "ℹ️  デリバリ成果物（requirements/design/implementation-plan 等）が見つかりませんでした"
+    fi
+  fi
+fi
+
+# --- 結果出力 ---------------------------------------------------------------
+if [ "$WARN" -gt 0 ]; then
+  echo "⚠️  $WARN 件の警告がありました。docs/pending-decisions.md に記録するか修正してください（warn_and_document, T-002）" >&2
+  if [ "$STRICT" -eq 1 ]; then
+    exit 1
+  fi
+  exit 0
+fi
+
+echo "✅ Validation passed"
+exit 0

--- a/ai-delivery/xtone-plugin-template/README.md
+++ b/ai-delivery/xtone-plugin-template/README.md
@@ -18,37 +18,57 @@ Xtone **AIデリバリシステム**の Claude Code プラグイン用マスタ�
 | Skill | 2 | plugin-guide/SKILL.md.template（運用ガイド＝旧 CLAUDE.md, CONV-06）/ SKILL.md.template（フェーズ別雛形） |
 | スクリプト | 2 | generate-plugin.sh / validate-plugin.sh |
 
-## 新規プラグインの作成（手動コピー）
+## 新規プラグインの作成（generate-plugin.sh）
+
+`scripts/generate-plugin.sh`（TPL-26）でテンプレからプラグインスケルトンを生成する。手動コピーは原則不要。
 
 ```bash
-cd ai-delivery
-cp -r xtone-plugin-template plugins/xtone-<usecase>-plugin
-cd plugins/xtone-<usecase>-plugin
+ai-delivery/scripts/generate-plugin.sh <usecase> \
+  --description "<プラグイン説明>" \
+  --author      "<著者>" \
+  --domains     "<適用ドメイン>" \
+  --modules     "<MOD-XXX>"
 
-# symlink を再作成（コピーで実体化された場合）
-rm -rf schemas
-ln -s ../../xtone-shared-plugin/schemas/v1 schemas
-
-# テンプレファイルを実体化
-mv .claude-plugin/plugin.json.template .claude-plugin/plugin.json
-mv skills/plugin-guide/SKILL.md.template skills/plugin-guide/SKILL.md   # 運用ガイド（旧 CLAUDE.md, DP-27）
-mv skills/SKILL.md.template skills/<phase>/<skill>/SKILL.md             # フェーズ別 Skill
-cp .env.example .env                  # トークンを設定
-# ルート CLAUDE.md は作らない（--strict 非対応 / DP-27）。人間向け概要は README.md に置く（任意）。
+# 例
+ai-delivery/scripts/generate-plugin.sh auth \
+  --description "ユーザー認証とセッション管理を型化する Xtone AIデリバリプラグイン" \
+  --author "Xtone" \
+  --domains "BtoCアプリ,MaaS・モビリティ" \
+  --modules "MOD-001"
 ```
 
-### プレースホルダの置換
+スクリプトは次を自動で行う:
 
-実体化した各ファイルの `{{...}}` をすべて置換する（未置換が残らないこと）。`generate-plugin.sh`（TPL-26）で自動化予定。
+- `plugins/xtone-<usecase>-plugin/` を作成（既存時は `--force` で上書き）
+- `schemas/` を `xtone-shared-plugin/schemas/v1` への symlink で作成
+- `.claude-plugin/plugin.json.template` → `plugin.json` に実体化
+- `skills/plugin-guide/` → `skills/<usecase>-plugin-guide/` にディレクトリ改名、`SKILL.md.template` → `SKILL.md` に実体化
+- 各種ファイル中の `{{usecase}}` / `{{description}}` / `{{author_name}}` / `{{applicable_domains}}` / `{{dependent_modules}}` を置換
+- `hooks/*.sh` に実行権限を付与
+- 未置換 `{{...}}` を検出して警告（warn_and_document）
+- プラグイン用の最小 `README.md` 雛形を生成
+
+> ルート `CLAUDE.md` は作らない（DP-27 本決定: Claude Code が context として読まないため）。運用ガイドは `skills/<usecase>-plugin-guide/SKILL.md` に集約する（CONV-06）。
+
+### 生成後の検証
+
+```bash
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-<usecase>-plugin
+```
+
+`validate-plugin.sh`（TPL-27）が `plugin.json` 必須フィールド・`schemas/` symlink・各 `SKILL.md` frontmatter・hook 実行権限・トークン参照・未置換プレースホルダ・**デリバリ成果物のスキーマ検証**（`sample-outputs/` / `delivery/` 配下の requirements/design/implementation-plan ほか）を一括チェックする。
+
+### プレースホルダ一覧
+
+`skills/SKILL.md.template`（フェーズ別 Skill の骨格）は実体化されず残るので、各 Skill を増やすときに手動でコピーして使う。
 
 | プレースホルダ | 置換内容 | 出現ファイル |
 |---|---|---|
 | `{{usecase}}` | ユースケース名（例: `auth`） | plugin.json / plugin-guide / SKILL ほか共通 |
 | `{{description}}` / `{{author_name}}` | プラグイン説明・作者 | `.claude-plugin/plugin.json` |
-| `{{applicable_domains}}` | 適用ドメイン（T-008 ドメインタクソノミーから選択） | `skills/plugin-guide/SKILL.md` |
-| `{{dependent_modules}}` | 依存モジュール（MOD-XXX） | `skills/plugin-guide/SKILL.md` |
-
-確認: `grep -rn '{{' .` で未置換のプレースホルダが残っていないことをチェックする。
+| `{{applicable_domains}}` | 適用ドメイン（T-008 ドメインタクソノミーから選択） | `skills/<usecase>-plugin-guide/SKILL.md` |
+| `{{dependent_modules}}` | 依存モジュール（MOD-XXX） | `skills/<usecase>-plugin-guide/SKILL.md` |
+| `{{phase}}` / `{{skill_name}}` / `{{Skill Title}}` | フェーズ別 Skill 用（手動置換） | `skills/SKILL.md.template` |
 
 ## 中核設計原則
 


### PR DESCRIPTION
## 概要

B-07 / Issue #132 — delivery 成果物のスキーマ検証手段が無く手動だった（F-6）状況を解消し、プラグイン生成と品質ゲートを自動化する。

- **TPL-26** [`scripts/generate-plugin.sh`](./ai-delivery/scripts/generate-plugin.sh): xtone-plugin-template から `xtone-<usecase>-plugin` を生成。symlink 再作成 / `.template` 実体化 / `{{...}}` 置換 / hook 実行権限 / 未置換警告を一括処理。
- **TPL-27** [`scripts/validate-plugin.sh`](./ai-delivery/scripts/validate-plugin.sh): `plugin.json`（CONV-01）/ `schemas/` symlink（CONV-14）/ `SKILL.md` frontmatter（SKL-20）/ hooks / `.mcp.json.sample`（MCP-08）/ 未置換プレースホルダ / **デリバリ成果物のスキーマ検証**（`sample-outputs/` ・ `delivery/` 配下の requirements / design / implementation-plan を `xtone-shared-plugin/schemas/v1` で検証）を一括チェック。
- 補助 [`scripts/lib/validate_schema.py`](./ai-delivery/scripts/lib/validate_schema.py): `jsonschema` + `PyYAML` で JSON/YAML をスキーマ検証。

両スクリプトとも **warn_and_document（T-002）** 既定。`--strict` で CI 用に exit 1。`--no-schema` でスキーマ検証スキップ。

## 関連

- Issue: #132（B-07 / Tooling / Med）
- 由来: T-022 内部パイロット由来の backlog（F-6）
- Notion: [TPL-26](https://www.notion.so/368ceb782fa381f69e11ce0159cc3fce) / [TPL-27](https://www.notion.so/368ceb782fa3810b9908caec443f6401)
- 規約: CONV-01 / CONV-06 / CONV-14 / DP-27 / MCP-08 / SKL-20
- 関連 backlog: B-05（CONV-06 改訂・plugin-guide skill 化）反映済み — `skills/<usecase>-plugin-guide/SKILL.md` を生成・検証

## 変更点

| ファイル | 内容 |
|---|---|
| `ai-delivery/scripts/generate-plugin.sh` | 新規。usecase / description / author / domains / modules を受け取り、テンプレからプラグインを生成 |
| `ai-delivery/scripts/validate-plugin.sh` | 新規。品質ゲート + スキーマ検証を `warn_and_document` で実施 |
| `ai-delivery/scripts/lib/validate_schema.py` | 新規。JSON / YAML を jsonschema で検証する補助 |
| `ai-delivery/CLAUDE.md` | 「検証スクリプト未整備」注記を解消、実行手順を追記 |
| `ai-delivery/xtone-plugin-template/README.md` | 手動コピー手順 → `generate-plugin.sh` の自動化フローに更新 |
| `ai-delivery/README.md` | ディレクトリ構造に `scripts/` を追記 |

## Test plan

- [x] `ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin --strict` で `sample-outputs/requirements.json`、`implementation-plan.json`、`design.yaml`（B-14 で再生成された版）すべて OK
- [x] `ai-delivery/scripts/generate-plugin.sh test --description "テスト用" --author "Xtone" --domains "BtoCアプリ" --modules "MOD-999"` で `xtone-test-plugin` が生成され、未置換プレースホルダ警告ゼロ
- [x] 生成された `xtone-test-plugin` に対して `validate-plugin.sh --strict` が OK
- [x] `plugin.json` を意図的に壊した状態で warn が 4 件出力され、既定では exit 0、`--strict` で exit 1
- [x] スキーマ違反の `requirements.json` を置いた状態で違反箇所が列挙され、`--strict` で exit 1
- [x] 検証対象が無い場合は `ℹ️ デリバリ成果物が見つかりませんでした` を出して OK

## 検証コマンド

```bash
# 既存 auth-plugin の検証
ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin --strict

# 新規プラグイン生成 → 検証
ai-delivery/scripts/generate-plugin.sh sample \
  --description "サンプル" --author "Xtone" \
  --domains "BtoCアプリ" --modules "MOD-999"
ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-sample-plugin --strict
```

## 依存

- `bash`, `jq`, `python3`, `jsonschema`, `PyYAML`
- jsonschema / PyYAML 未導入時は警告のみで該当チェックをスキップ（`pip3 install --user jsonschema PyYAML` を促す）

🤖 Generated with [Claude Code](https://claude.com/claude-code)