### PR TITLE
docs(B-21): firebase.json テンプレで ui/hub/logging も 0.0.0.0 バインドを明示

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/SKILL.md
@@ -96,6 +96,7 @@ Firebase Auth Emulator を Docker で起動して、`firebase-auth-setup`（back
 
 ## 既知の制約（くりかえし）
 
+- **コンテナ内 emulator は必ず `0.0.0.0` バインド**: `firebase.json` の `emulators.*.host` を **全サブサービス（`auth` / `ui` / `hub` / `logging`）** で `"0.0.0.0"` に明示する。省略のデフォルト `127.0.0.1` バインドでは Docker コンテナ外（ホスト OS のブラウザ / 別コンテナの backend）からの接続が **HTTP 接続リセット**で到達不能になる。`auth` だけ指定すると Emulator UI（`http://localhost:4000`）が開かない罠を踏む。設定例は [`references/docker-compose.md` §1](./references/docker-compose.md)。
 - **TOTP MFA は不可**（#6224）。設計が TOTP 主体でも、ローカル検証は SMS で代替する。
 - ID トークンは **unsigned**。本番経路で署名検証スキップを誤って有効化すると重大なセキュリティ事故になる。**EMULATOR_HOST が立っているときのみ**スキップする条件分岐を必ず置く。
 - Admin REST の `Bearer owner` は **エミュレーター専用**。本番は OAuth2 アクセストークン（サービスアカウント）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-emulator/references/docker-compose.md
@@ -5,20 +5,24 @@
 - 対象: Docker / docker-compose / firebase-tools — **いずれも公式の最新安定版**（バージョン方針は `ai-delivery/docs/environment-setup.md`）
 - 構成: emulator サービス（`firebase-tools` 入り）＋ backend ＋ frontend を1つの compose で起動。
 
+> **前提（コンテナ内 emulator は必ず `0.0.0.0` バインド）**: `firebase.json` の `emulators.*.host` を **全サブサービス（`auth` / `ui` / `hub` / `logging`）** で `"0.0.0.0"` にすること。省略するとデフォルトは `127.0.0.1` バインドになり、Docker コンテナ外（ホスト OS のブラウザ / curl）からは **接続リセット**になる（`auth` だけ指定しても UI の `http://localhost:4000` は開けない）。詳細は SKILL.md「既知の制約」も参照。
+
 ## 1. firebase.json（最小）
 
-emulator のポートだけ指定。auth と UI のみ。
+emulator のポートとバインドアドレスを **全サブサービスで明示**する（前提の繰り返し: 省略不可）。
 
 ```json
 {
   "emulators": {
-    "auth": { "host": "0.0.0.0", "port": 9099 },
-    "ui":   { "enabled": true, "port": 4000 }
+    "auth":    { "host": "0.0.0.0", "port": 9099 },
+    "ui":      { "host": "0.0.0.0", "enabled": true, "port": 4000 },
+    "hub":     { "host": "0.0.0.0", "port": 4400 },
+    "logging": { "host": "0.0.0.0", "port": 4500 }
   }
 }
 ```
 
-> `host: 0.0.0.0` にしておかないと、Docker コンテナ外から接続できない。
+> `host: "0.0.0.0"` を全 emulator サブサービスで揃えないと、Docker コンテナ外から接続できない。`auth` だけ指定したパイロット案件で `http://localhost:4000`（Emulator UI）が接続リセットになりデバッグ工数を消費した実例あり。`hub`（4400）と `logging`（4500）は UI が裏で叩く管理ポート — UI を使うなら一緒に `0.0.0.0` で公開する。
 
 ## 2. emulator サービスの Dockerfile
 


### PR DESCRIPTION
## Summary

Issue #180 (B-21) 対応。`firebase-auth-emulator` スキルの Docker レシピで、`firebase.json` の `auth` だけ `0.0.0.0` バインドが明示されており、`ui` / `hub` / `logging` は host が省略されていたため、デフォルトの `127.0.0.1` バインドで Docker コンテナ越しにホスト OS から Emulator UI (`http://localhost:4000`) に到達できず接続リセットになるパイロット案件由来の罠を解消する。

- `firebase-auth-emulator/references/docker-compose.md` の `firebase.json` 例で **`ui` / `hub` / `logging` も `host: "0.0.0.0"` を明示**（実例の障害事例コメントを併記）
- 同ファイル冒頭の前提節に「コンテナ内 emulator は必ず `0.0.0.0` バインド」の警告を追加（SKILL.md への相互参照付き）
- `firebase-auth-emulator/SKILL.md` の「既知の制約」冒頭に同主旨を**太字で記載**し、references の §1 へリンク

## Test plan

- [x] `ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin` が pass する
- [ ] (実機 E2E は次のパイロット案件着手時に「`docker compose up` 後、ホスト OS の `http://localhost:4000` で Emulator UI が開く（接続リセットしない）」を確認)
- [x] `firebase.json` の `host` 設定が全 emulator サブサービス（`auth` / `ui` / `hub` / `logging`）に揃っている
- [x] SKILL.md に既知の制約として記載される

## 関連

- Issue: #180
- Related backlog: B-12（#157, Firebase Emulator + Docker の既定化）
- 由来: Rails + Hotwire パイロット案件のフィードバック A-3

🤖 Generated with [Claude Code](https://claude.com/claude-code)