### PR TITLE
fix(B-19): Rails テンプレ adapter.rb の Zeitwerk 規約違反を解消 (Issue #178)

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/references/rails.md
@@ -20,13 +20,21 @@ gem "googleauth"   # Admin REST の OAuth2 アクセストークン取得（退�
 
 ## 2. AuthAdapter 契約の実装
 
+> **Zeitwerk 規約**: Rails 6+ は「1 ファイル 1 定数」が原則。共通定数は `app/adapters/auth.rb` に集約し、各クラスは個別ファイルへ分割する（B-19 / Issue #178）。1 ファイルに複数のトップレベル定数を同居させると autoload テーブルから漏れ、起動初回参照で `NameError` が出る。
+
 ```ruby
-# app/adapters/auth/adapter.rb — 抽象（契約）
+# app/adapters/auth.rb — 共通定数（namespace 定義）
 module Auth
   AuthUser = Struct.new(:uid, :email, :provider, :claims, keyword_init: true)
   class Error < StandardError; end
   class InvalidToken < Error; end
+  class NotFoundError < Error; end
+end
+```
 
+```ruby
+# app/adapters/auth/adapter.rb — 抽象（契約）
+module Auth
   class Adapter
     def verify_token(_id_token); raise NotImplementedError; end
     def get_user(_uid);          raise NotImplementedError; end
@@ -130,7 +138,7 @@ def delete_user(uid)
   # Identity Toolkit REST: POST /v1/projects/{pid}/accounts:delete （要 OAuth2 アクセストークン）
   identitytoolkit_post("accounts:delete", localId: uid)
   true
-rescue NotFoundError
+rescue Auth::NotFoundError
   true  # 冪等: 既に存在しない
 end
 ```
@@ -201,18 +209,16 @@ end
 def revoke(uid)
   identitytoolkit_post("accounts:update", localId: uid, validSince: Time.now.to_i.to_s)
   true
-rescue NotFoundError
+rescue Auth::NotFoundError
   true
 end
 ```
 
 ### Admin REST ヘルパー（FirebaseAdapter private）
 
-Ruby に公式 Admin SDK が無いため、Admin 操作（削除・失効）は Identity Toolkit REST ＋ サービスアカウントの OAuth2 アクセストークンで行う。`NotFoundError` も定義する。
+Ruby に公式 Admin SDK が無いため、Admin 操作（削除・失効）は Identity Toolkit REST ＋ サービスアカウントの OAuth2 アクセストークンで行う。404 を表す `Auth::NotFoundError` は共通定数として `app/adapters/auth.rb` 側で定義済み（B-19 / Zeitwerk 規約）。
 
 ```ruby
-class NotFoundError < Auth::Error; end
-
 private
 
 # サービスアカウント鍵から OAuth2 アクセストークンを取得（googleauth gem）。短命なのでキャッシュ。
@@ -234,7 +240,7 @@ def identitytoolkit_post(method, **body)
   req["Content-Type"]  = "application/json"
   req.body = JSON.dump(body)
   res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
-  raise NotFoundError if res.code == "404"
+  raise Auth::NotFoundError if res.code == "404"
   raise Auth::Error, "identitytoolkit #{method}: #{res.code}" unless res.is_a?(Net::HTTPSuccess)
   res.body.to_s.empty? ? {} : JSON.parse(res.body)
 end

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/README.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/README.md
@@ -6,18 +6,30 @@
 
 ## 含まれるもの
 
-| パス | 役割 |
-|---|---|
-| `Gemfile.snippet` | 追加する gem（`jwt` / `googleauth`） |
-| `dotenv.sample` | 必要な ENV 変数（`FIREBASE_PROJECT_ID` / `AUTH_ADAPTER` / `GOOGLE_APPLICATION_CREDENTIALS`） |
-| `app/adapters/auth/adapter.rb` | `Auth::Adapter` 抽象（契約）と `AuthUser` / エラー |
-| `app/adapters/auth/firebase_adapter.rb` | `FirebaseAdapter` 実装（JWT 検証 / 公開鍵キャッシュ / Admin REST） |
-| `app/adapters/auth/test_adapter.rb` | `TestAdapter`（実 Firebase 不要のテスト用） |
-| `app/controllers/concerns/authenticatable.rb` | JWT 認可 concern |
-| `config/initializers/app_auth.rb` | `AppAuth.adapter` 選択（ENV `AUTH_ADAPTER` 切替） |
-| `db/migrate/00000000000000_add_tokens_valid_after_to_users.rb.template` | `users.tokens_valid_after` 追加マイグレーションの雛形 |
+| パス | 役割 | 定義する定数 |
+|---|---|---|
+| `Gemfile.snippet` | 追加する gem（`jwt` / `googleauth`） | — |
+| `dotenv.sample` | 必要な ENV 変数（`FIREBASE_PROJECT_ID` / `AUTH_ADAPTER` / `GOOGLE_APPLICATION_CREDENTIALS`） | — |
+| `app/adapters/auth.rb` | `Auth` namespace と共通定数（AuthUser / Error / InvalidToken / NotFoundError） | `Auth`, `Auth::AuthUser`, `Auth::Error`, `Auth::InvalidToken`, `Auth::NotFoundError` |
+| `app/adapters/auth/adapter.rb` | `Auth::Adapter` 抽象（契約） | `Auth::Adapter` |
+| `app/adapters/auth/firebase_adapter.rb` | `Auth::FirebaseAdapter` 実装（JWT 検証 / 公開鍵キャッシュ / Admin REST） | `Auth::FirebaseAdapter` |
+| `app/adapters/auth/test_adapter.rb` | `Auth::TestAdapter`（実 Firebase 不要のテスト用） | `Auth::TestAdapter` |
+| `app/controllers/concerns/authenticatable.rb` | JWT 認可 concern | `Authenticatable` |
+| `config/initializers/app_auth.rb` | `AppAuth.adapter` 選択（ENV `AUTH_ADAPTER` 切替） | `AppAuth` |
+| `db/migrate/00000000000000_add_tokens_valid_after_to_users.rb.template` | `users.tokens_valid_after` 追加マイグレーションの雛形 | — |
 
 > **契約は `references/rails.md` の「実装契約（言語非依存）」と同一。** 本テンプレは契約を変えずに具体コードを提供するだけ（DP-007 差し替え可能設計を維持）。
+
+### Zeitwerk 規約への準拠（重要）
+
+Rails 6+ の Zeitwerk autoloader は「1 ファイル 1 定数」が原則。**1 つのファイルに複数のトップレベル定数を同居させると autoload テーブルから漏れ**、起動初回の参照で `NameError (uninitialized constant ...)` が出る（B-19 / Issue #178）。本テンプレは以下のように分割している:
+
+- `app/adapters/auth.rb` — `Auth` namespace と「補助的な値・例外クラス」を集約（`AuthUser` / `Error` / `InvalidToken` / `NotFoundError`）。これは Zeitwerk が `Auth` をディレクトリ namespace として認識するための **規約上の正規ファイル**で、同一 namespace 直下の補助定数を同居させるのは規約に準拠する。
+- `app/adapters/auth/adapter.rb` — `Auth::Adapter`（抽象クラス）のみ
+- `app/adapters/auth/firebase_adapter.rb` — `Auth::FirebaseAdapter` のみ
+- `app/adapters/auth/test_adapter.rb` — `Auth::TestAdapter` のみ
+
+検証コマンド: `bin/rails zeitwerk:check` が PASS すること、`bin/rails runner 'puts Auth::AuthUser'` がエラーなく実行できることを **eager_load なしの開発環境** で確認する（`config.eager_load = false` のままで動くことが必須。`true` だと偶然動く可能性がある）。
 
 ## 使い方
 
@@ -36,6 +48,17 @@ cp -r "$PLUGIN"/templates/rails/app/.     ./app/
 cp    "$PLUGIN"/templates/rails/config/initializers/app_auth.rb       ./config/initializers/
 cp    "$PLUGIN"/templates/rails/db/migrate/00000000000000_add_tokens_valid_after_to_users.rb.template \
       ./db/migrate/"$(date +%Y%m%d%H%M%S)"_add_tokens_valid_after_to_users.rb
+```
+
+配置後の `app/adapters/` 配下は次の構造になる（Zeitwerk 規約に準拠する 1 ファイル 1 定数）:
+
+```
+app/adapters/
+├── auth.rb                  # Auth namespace + AuthUser / Error / InvalidToken / NotFoundError
+└── auth/
+    ├── adapter.rb           # Auth::Adapter
+    ├── firebase_adapter.rb  # Auth::FirebaseAdapter
+    └── test_adapter.rb      # Auth::TestAdapter
 ```
 
 `Gemfile.snippet` の内容は `Gemfile` に追記、`dotenv.sample` の項目は `.env` / Secrets に展開（`.env` はコミット禁止）。

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth.rb
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth.rb
@@ -1,0 +1,16 @@
+# DP-007: 認証 IaaS 差し替え可能設計の共通定数（namespace 定義）
+#
+# Zeitwerk 規約: 「1 ファイル 1 定数」。本ファイルは `app/adapters/auth/` ディレクトリ
+# の namespace `Auth` を定義する「ディレクトリと同名のファイル」であり、
+# 同一 namespace に属する補助定数（AuthUser / Error / InvalidToken / NotFoundError）の
+# 集約場所として規約に準拠する。
+#
+# `Auth::Adapter` / `Auth::FirebaseAdapter` / `Auth::TestAdapter` は別ファイル
+# （`auth/adapter.rb` / `auth/firebase_adapter.rb` / `auth/test_adapter.rb`）に分離する。
+module Auth
+  AuthUser = Struct.new(:uid, :email, :provider, :claims, keyword_init: true)
+
+  class Error < StandardError; end
+  class InvalidToken < Error; end
+  class NotFoundError < Error; end
+end

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth/adapter.rb
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth/adapter.rb
@@ -1,11 +1,9 @@
 # DP-007: 認証 IaaS 差し替え可能設計の抽象（契約）
 # 契約の根拠: firebase-auth-setup スキル「実装契約（言語非依存）」
+#
+# Zeitwerk 規約: 本ファイルは `Auth::Adapter` のみを定義する。
+# 共通定数（AuthUser / Error / InvalidToken / NotFoundError）は `../auth.rb` を参照。
 module Auth
-  AuthUser = Struct.new(:uid, :email, :provider, :claims, keyword_init: true)
-
-  class Error < StandardError; end
-  class InvalidToken < Error; end
-
   class Adapter
     def verify_token(_id_token); raise NotImplementedError; end
     def get_user(_uid);          raise NotImplementedError; end

--- a/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth/firebase_adapter.rb
+++ b/ai-delivery/plugins/xtone-auth-plugin/skills/implementation/firebase-auth-setup/templates/rails/app/adapters/auth/firebase_adapter.rb
@@ -10,8 +10,6 @@ module Auth
   class FirebaseAdapter < Adapter
     CERTS_URI = "https://www.googleapis.com/robot/v1/metadata/x509/securetoken@system.gserviceaccount.com".freeze
 
-    class NotFoundError < Auth::Error; end
-
     def initialize(project_id: ENV["FIREBASE_PROJECT_ID"])
       @project_id = project_id.to_s
       raise Auth::Error, "FIREBASE_PROJECT_ID が未設定です" if @project_id.empty?
@@ -57,7 +55,7 @@ module Auth
     def delete_user(uid)
       identitytoolkit_post("accounts:delete", localId: uid)
       true
-    rescue NotFoundError
+    rescue Auth::NotFoundError
       true
     end
 
@@ -65,7 +63,7 @@ module Auth
     def revoke(uid)
       identitytoolkit_post("accounts:update", localId: uid, validSince: Time.now.to_i.to_s)
       true
-    rescue NotFoundError
+    rescue Auth::NotFoundError
       true
     end
 
@@ -111,7 +109,7 @@ module Auth
       req["Content-Type"]  = "application/json"
       req.body = JSON.dump(body)
       res = Net::HTTP.start(uri.host, uri.port, use_ssl: true) { |h| h.request(req) }
-      raise NotFoundError if res.code == "404"
+      raise Auth::NotFoundError if res.code == "404"
       raise Auth::Error, "identitytoolkit #{method}: #{res.code}" unless res.is_a?(Net::HTTPSuccess)
       res.body.to_s.empty? ? {} : JSON.parse(res.body)
     end


### PR DESCRIPTION
## Summary

- `firebase-auth-setup/templates/rails/app/adapters/auth/adapter.rb` に共通定数（`Auth::AuthUser` / `Auth::Error` / `Auth::InvalidToken` / `Auth::NotFoundError`）を同居させていたため Zeitwerk の autoload テーブルから漏れ、開発環境（`config.eager_load = false`）で初回参照時に `NameError (uninitialized constant Auth::AuthUser)` が発生していた問題を修正
- `app/adapters/auth.rb` を新設して共通定数を集約し、各 adapter ファイルは「1 ファイル 1 定数」に整理（B-09 #134 の事後補正）

## 変更内容

| ファイル | 内容 |
|---|---|
| `templates/rails/app/adapters/auth.rb`（新規） | `Auth` namespace と共通定数（`AuthUser` / `Error` / `InvalidToken` / `NotFoundError`）を集約 |
| `templates/rails/app/adapters/auth/adapter.rb` | `Auth::Adapter` のみに整理 |
| `templates/rails/app/adapters/auth/firebase_adapter.rb` | 内部の `class NotFoundError < Auth::Error` を削除し、共通定義 `Auth::NotFoundError` を参照するよう統一 |
| `templates/rails/README.md` | ファイル一覧に定義する定数を併記、配置後の構造例と「Zeitwerk 規約への準拠」節を追加 |
| `references/rails.md` | コードサンプルを修正後の構造に同期、Zeitwerk 規約の注意書きを追記 |

`templates/rails/app/adapters/auth/test_adapter.rb` は元から `Auth::TestAdapter` のみで規約準拠していたため変更なし。

## 検証

実機 Rails アプリを用意する代わりに、Rails と同じ Zeitwerk gem (2.8.2 / Ruby 3.3.6) で autoloader を本テンプレに対して setup → eager_load / lazy 参照を実施。

```
=== 1) zeitwerk:check (eager_load) ===
  OK: eager_load 完了（規約違反なし）

=== 2) 各定数の lazy 参照 (eager_load なし) ===
  OK: Auth::AuthUser, Auth::Error, Auth::InvalidToken, Auth::NotFoundError,
      Auth::Adapter, Auth::FirebaseAdapter, Auth::TestAdapter ← 全件 PASS

=== 3) 継承関係チェック ===
  OK: InvalidToken < Error / NotFoundError < Error
  OK: FirebaseAdapter < Adapter / TestAdapter < Adapter
```

これにより Issue #178 の受け入れ基準（`bin/rails zeitwerk:check` PASS / `rails runner 'puts Auth::AuthUser'` がエラー無し）の同等条件を満たすことを確認。

## Test plan

- [ ] 新規 Rails アプリ（`config.eager_load = false`）にテンプレ一式をコピーし、`bin/rails zeitwerk:check` が PASS することを実機確認
- [ ] `bin/rails runner 'puts Auth::AuthUser; puts Auth::FirebaseAdapter'` がエラー無く実行できること
- [ ] `POST /auth/session` 相当のエンドポイントで `NameError` が出ないこと

## 関連

- Issue: #178
- 関連: #134 (B-09, Rails AuthAdapter テンプレ同梱) の事後補正
- DP-007（認証 IaaS 差し替え可能設計）

🤖 Generated with [Claude Code](https://claude.com/claude-code)