### PR TITLE
fix(ai-delivery): pre-phase-transition Hook の DP 正規表現を template と auth-plugin にも反映 (Closes #198)

### DIFF
--- a/ai-delivery/plugins/xtone-auth-plugin/hooks/pre-phase-transition.sh
+++ b/ai-delivery/plugins/xtone-auth-plugin/hooks/pre-phase-transition.sh
@@ -20,7 +20,11 @@ root="${CLAUDE_PLUGIN_ROOT:-.}"
 pending="$root/docs/pending-decisions.md"
 count=0
 if [ -f "$pending" ]; then
-  count="$(grep -Eo 'DP-[0-9]+' "$pending" 2>/dev/null | sort -u | wc -l | tr -d ' ')"
+  # ADR-AID-002 で定義した 3 形式すべてを検出する:
+  #   - DP-NNN（既存番号形式・凍結。例: DP-007 / DP-28）
+  #   - DP-<USECASE>-NN / DP-AID-NN（新規プラグイン固有・メタ層。例: DP-PAYMENT-01 / DP-AID-01）
+  #   - DP-<DOMAIN>-<TOPIC>-NNN（既存プレフィックス付き・凍結。例: DP-INVITATION-POLICY-001）
+  count="$(grep -Eo 'DP-[A-Z]+(-[A-Z]+)*-[0-9]+|DP-[0-9]+' "$pending" 2>/dev/null | sort -u | wc -l | tr -d ' ')"
 fi
 
 if [ "${count:-0}" -gt 0 ]; then

--- a/ai-delivery/xtone-plugin-template/hooks/pre-phase-transition.sh
+++ b/ai-delivery/xtone-plugin-template/hooks/pre-phase-transition.sh
@@ -20,7 +20,11 @@ root="${CLAUDE_PLUGIN_ROOT:-.}"
 pending="$root/docs/pending-decisions.md"
 count=0
 if [ -f "$pending" ]; then
-  count="$(grep -Eo 'DP-[0-9]+' "$pending" 2>/dev/null | sort -u | wc -l | tr -d ' ')"
+  # ADR-AID-002 で定義した 3 形式すべてを検出する:
+  #   - DP-NNN（既存番号形式・凍結。例: DP-007 / DP-28）
+  #   - DP-<USECASE>-NN / DP-AID-NN（新規プラグイン固有・メタ層。例: DP-PAYMENT-01 / DP-AID-01）
+  #   - DP-<DOMAIN>-<TOPIC>-NNN（既存プレフィックス付き・凍結。例: DP-INVITATION-POLICY-001）
+  count="$(grep -Eo 'DP-[A-Z]+(-[A-Z]+)*-[0-9]+|DP-[0-9]+' "$pending" 2>/dev/null | sort -u | wc -l | tr -d ' ')"
 fi
 
 if [ "${count:-0}" -gt 0 ]; then


### PR DESCRIPTION
## Summary

PR #197 follow-up。aid-skill-creator プラグインで対応した ADR-AID-002 の 3 形式すべての DP 検出（コミット [81ebab7](../commit/81ebab7)）を、上流の以下 2 ファイルにも反映する。

- `ai-delivery/xtone-plugin-template/hooks/pre-phase-transition.sh` — マスターテンプレ。今後生成される全プラグインに伝搬する起点。
- `ai-delivery/plugins/xtone-auth-plugin/hooks/pre-phase-transition.sh` — 既存 auth プラグイン。`DP-INVITATION-POLICY-001` 等の既存プレフィックス付き形式を検出できていなかった検出漏れを解消。

ADR-AID-002 以前は潜在バグだったが、Rollout 開始前に template 起点で揃えておくのが望ましい。

## 変更内容

両ファイル L23 の正規表現を `DP-[A-Z]+(-[A-Z]+)*-[0-9]+|DP-[0-9]+` に統一し、aid-skill-creator (81ebab7) と完全一致させる。コメント（3 形式の意図）も同梱:

```bash
# ADR-AID-002 で定義した 3 形式すべてを検出する:
#   - DP-NNN（既存番号形式・凍結。例: DP-007 / DP-28）
#   - DP-<USECASE>-NN / DP-AID-NN（新規プラグイン固有・メタ層。例: DP-PAYMENT-01 / DP-AID-01）
#   - DP-<DOMAIN>-<TOPIC>-NNN（既存プレフィックス付き・凍結。例: DP-INVITATION-POLICY-001）
count="$(grep -Eo 'DP-[A-Z]+(-[A-Z]+)*-[0-9]+|DP-[0-9]+' "$pending" 2>/dev/null | sort -u | wc -l | tr -d ' ')"
```

## DoD 達成状況

- [x] `xtone-plugin-template/hooks/pre-phase-transition.sh` を修正
- [x] `xtone-auth-plugin/hooks/pre-phase-transition.sh` を修正
- [x] `validate-plugin.sh --strict ai-delivery/plugins/xtone-auth-plugin` で pass（template はテンプレ性質上 `{{...}}` プレースホルダで通常通り 3 件 warn、本 issue 範囲外）
- [x] PR description に「PR #197 follow-up」と明記

## Test plan

- [x] 3 ファイル間の `diff` で内容一致を確認（template / auth-plugin / aid-skill-creator）
- [x] `bash -n` 構文チェック pass（template / auth-plugin）
- [x] `validate-plugin.sh --strict ai-delivery/plugins/xtone-auth-plugin` → exit 0
- [x] 新正規表現で 4 種のサンプル（`DP-007` / `DP-28` / `DP-PAYMENT-01` / `DP-AID-01` / `DP-INVITATION-POLICY-001`）を `grep -Eo` で検出確認

## 関連

- PR #197（merged）
- Issue #198
- ADR-AID-002（DP 命名規約の拡張）
- 元コミット: 81ebab7

Closes #198

🤖 Generated with [Claude Code](https://claude.com/claude-code)