### PR TITLE
feat(marketplace): ai-delivery 配下の2プラグインを公開対象に追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -67,6 +67,24 @@
             "author": {
                 "name": "TOYOTA, Yoichi"
             }
+        },
+        {
+            "name": "xtone-auth-plugin",
+            "source": "./ai-delivery/plugins/xtone-auth-plugin",
+            "description": "ユーザー認証とセッション管理を型化する Xtone AIデリバリプラグイン（MVP: Firebase Auth、IaaS 差し替え可能設計）。MOD-001 認証モジュール。",
+            "version": "0.1.0",
+            "author": {
+                "name": "Xtone"
+            }
+        },
+        {
+            "name": "xtone-aid-skill-creator-plugin",
+            "source": "./ai-delivery/plugins/xtone-aid-skill-creator-plugin",
+            "description": "AIデリバリ用プラグインを、AIデリバリの型に則って中身ごと生成・育成するためのメタプラグイン。Notion DB を参照して Skill/Subagent/Command/references/DP を対話的に起稿する。",
+            "version": "0.1.0",
+            "author": {
+                "name": "Xtone"
+            }
         }
     ]
 }


### PR DESCRIPTION
## 概要

`ai-delivery/plugins/` 配下の2プラグインを Marketplace で公開できるよう、ルートの `.claude-plugin/marketplace.json` の `plugins` 配列に登録しました。

## 背景・原因

両プラグインの `plugin.json` 自体は `validate-plugin.sh` の必須フィールド（`name` / `version` / `description` / `author.name`、命名規約 `xtone-*-plugin`）を満たしていましたが、Marketplace のインデックス（ルート `marketplace.json`）に `source` エントリが存在しなかったため公開対象外になっていました。

## 変更内容

以下2エントリを既存と同じ形式で追加：

| name | source |
|---|---|
| `xtone-auth-plugin` | `./ai-delivery/plugins/xtone-auth-plugin` |
| `xtone-aid-skill-creator-plugin` | `./ai-delivery/plugins/xtone-aid-skill-creator-plugin` |

## 検証

- `marketplace.json` がJSONとして妥当
- 両 `source` パスの `.claude-plugin/plugin.json` が実在
- 両 `plugin.json` が必須フィールドを充足

🤖 Generated with [Claude Code](https://claude.com/claude-code)