### PR TITLE
feat(tech-version-check): 複数候補が残った技術判断を pending-decisions に自動起票 (B-25)

### DIFF
--- a/ai-delivery/plugins/xtone-aid-skill-creator-plugin/agents/implementer.md
+++ b/ai-delivery/plugins/xtone-aid-skill-creator-plugin/agents/implementer.md
@@ -28,6 +28,7 @@ model: opus
    - seed / 初期化スクリプト / マスタ生成に影響する DP（ドメインごとに異なる。認証プラグインでは DP-AUTHFLOW-001 等）は、テンプレ側の分岐ブロック（`<% if … %>` 〜 `<% end %>`）を該当する側だけ残して書き出す。
    - 該当 DP が `undecided` の場合は **生成を確定させず**、`docs/pending-decisions.md` に「未確定のため生成しなかった」を残す（warn_and_document, T-002）。
 4. Skill に沿ってコードを生成し、検証（テスト等）を行う。
+   - **tech-version-check 完了時のフック（B-25）**: `tech-version-check`（実装スキルの最先頭）が `delivery/version-matrix.md` を出力したら、その「複数候補が残った技術判断（DP 起票）」節に挙がった DP 候補のうち、まだ `docs/pending-decisions.md` の未決リストに無いものを **append** する。複数バージョン・複数実装方式が残った技術判断を **AI が推奨で独断確定しない**（T-002）。単一候補・自明な公式最新・既に `decision_record[]` で確定済みのものは append しない（誤検知防止）。
 5. 生成戦略の説明を `delivery/seeds-strategy.md`（または対応するドメインの戦略ノート）に残す（出力契約）。
 
 ## warn_and_document（T-002 本決定）

--- a/ai-delivery/plugins/xtone-auth-plugin/agents/implementer.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/agents/implementer.md
@@ -39,6 +39,7 @@ model: opus
      ```
    - 他にも seed・bin/setup・テンプレ分岐に影響する DP が出てきたら、本手順で同様に分岐する（DP の追加は固定列挙ではなく decision_record 駆動）。
 4. Skill に沿ってコードを生成し、検証（テスト等）を行う。
+   - **tech-version-check 完了時のフック（B-25）**: `tech-version-check`（実装スキルの最先頭）が `delivery/version-matrix.md` を出力したら、その「複数候補が残った技術判断（DP 起票）」節に挙がった DP 候補のうち、まだ `docs/pending-decisions.md` の未決リストに無いものを **append** する。複数バージョン・複数実装方式（例: Ruby 3.3/3.4、Sidekiq/SolidQueue、googleauth+REST/firebase-auth-rails gem）が残った技術判断を **AI が推奨で独断確定しない**（T-002）。単一候補・自明な公式最新・既に `decision_record[]` で確定済みのものは append しない（誤検知防止）。
    - Rails 案件で seeds.rb を生成する場合は `firebase-auth-setup/templates/rails/db/seeds.rb.template`（B-23）を起点にする。テンプレ内の `<% if invitation_based? %>` … `<% else %>` … `<% end %>` ブロックは、ステップ3で確定した DP-AUTHFLOW-001 に応じて**該当する側だけを残して**書き出す。
 5. 生成戦略の説明を `delivery/seeds-strategy.md` に残す（出力契約）。最低限、次を含める:
    - 採用ブランチ（`invitation_based` / `self_signup`）と根拠の DP-ID

--- a/ai-delivery/plugins/xtone-project-init-plugin/agents/implementer.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/agents/implementer.md
@@ -28,6 +28,7 @@ model: opus
    - seed / 初期化スクリプト / マスタ生成に影響する DP（ドメインごとに異なる。認証プラグインでは DP-AUTHFLOW-001 等）は、テンプレ側の分岐ブロック（`<% if … %>` 〜 `<% end %>`）を該当する側だけ残して書き出す。
    - 該当 DP が `undecided` の場合は **生成を確定させず**、`docs/pending-decisions.md` に「未確定のため生成しなかった」を残す（warn_and_document, T-002）。
 4. Skill に沿ってコードを生成し、検証（テスト等）を行う。
+   - **tech-version-check 完了時のフック（B-25）**: `tech-version-check`（実装スキルの最先頭）が `delivery/version-matrix.md` を出力したら、その「複数候補が残った技術判断（DP 起票）」節に挙がった DP 候補のうち、まだ `docs/pending-decisions.md` の未決リストに無いものを **append** する。複数バージョン・複数実装方式が残った技術判断を **AI が推奨で独断確定しない**（T-002）。単一候補・自明な公式最新・既に `decision_record[]` で確定済みのものは append しない（誤検知防止）。
 5. 生成戦略の説明を `delivery/seeds-strategy.md`（または対応するドメインの戦略ノート）に残す（出力契約）。
 
 ## warn_and_document（T-002 本決定）

--- a/ai-delivery/xtone-plugin-template/agents/implementer.md
+++ b/ai-delivery/xtone-plugin-template/agents/implementer.md
@@ -28,6 +28,7 @@ model: opus
    - seed / 初期化スクリプト / マスタ生成に影響する DP（ドメインごとに異なる。認証プラグインでは DP-AUTHFLOW-001 等）は、テンプレ側の分岐ブロック（`<% if … %>` 〜 `<% end %>`）を該当する側だけ残して書き出す。
    - 該当 DP が `undecided` の場合は **生成を確定させず**、`docs/pending-decisions.md` に「未確定のため生成しなかった」を残す（warn_and_document, T-002）。
 4. Skill に沿ってコードを生成し、検証（テスト等）を行う。
+   - **tech-version-check 完了時のフック（B-25）**: `tech-version-check`（実装スキルの最先頭）が `delivery/version-matrix.md` を出力したら、その「複数候補が残った技術判断（DP 起票）」節に挙がった DP 候補のうち、まだ `docs/pending-decisions.md` の未決リストに無いものを **append** する。複数バージョン・複数実装方式が残った技術判断を **AI が推奨で独断確定しない**（T-002）。単一候補・自明な公式最新・既に `decision_record[]` で確定済みのものは append しない（誤検知防止）。
 5. 生成戦略の説明を `delivery/seeds-strategy.md`（または対応するドメインの戦略ノート）に残す（出力契約）。
 
 ## warn_and_document（T-002 本決定）

--- a/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/SKILL.md
+++ b/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/SKILL.md
@@ -114,7 +114,7 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
 | <YYYY-MM-DD> | DP-JOB-BACKEND | 非同期ジョブ基盤の候補が複数（Sidekiq / SolidQueue）。Redis 依存可否・運用体制で案件が選ぶ。 | 実装 | tech-version-check | 未決 |
 ```
 
-起票したら `version-matrix.md` の該当行（または「6. 採用根拠の要約」）に **`DP-XXX 起票済み（pending-decisions.md 参照）`** を残し、matrix と pending の相互参照を保つ。確定前は version-matrix 上で当該技術を「未確定」と明記し、暫定採用値を断定で書かない。
+起票したら `version-matrix.md` の該当行（または「7. 採用根拠の要約」）に **`DP-XXX 起票済み（pending-decisions.md 参照）`** を残し、matrix と pending の相互参照を保つ。確定前は version-matrix 上で当該技術を「未確定」と明記し、暫定採用値を断定で書かない。
 
 ### 検証シナリオ（受け入れ基準の確認手順）
 

--- a/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/SKILL.md
+++ b/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/SKILL.md
@@ -62,7 +62,9 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
    - **既知の非互換性**（採用最新版で問題があれば公式 issue / リリースノートから抽出）
 3. `delivery/version-matrix.md` に表形式で記録（[`templates/version-matrix.template.md`](./templates/version-matrix.template.md) 参照）。
 4. **`Gemfile` / `package.json` / `Dockerfile`** にコメント形式で「採用根拠（B-11 で確認、日付、根拠 URL）」を残す。固定バージョン値は判断ポイントなので、AI が勝手に固定しない（明示的な要望がある場合のみ pin）。
-5. 非互換が発覚した場合は判断ポイント化（pending-decisions に「採用バージョンを下げるか / 互換ライブラリを変えるか」を起票）。
+5. **判断ポイントを `docs/pending-decisions.md` に起票する（人間判断をスルーさせない / T-002 / B-25）**。次の 2 種は AI が推奨で独断確定せず、必ず案件側の `docs/pending-decisions.md` の「未決リスト」表に **1 件 1 行**で起票する（手順は下記「複数候補が残った技術判断の DP 起票（B-25）」節）:
+   - **複数候補が残った技術判断**: 公式情報源から **2 つ以上の妥当な候補**が得られ、どれを採るかが案件依存（性能・運用・互換性のトレードオフ）な場合。例: Ruby 3.3 / 3.4 並存、Sidekiq vs SolidQueue、googleauth+REST vs firebase-auth-rails gem。
+   - **非互換の解消方針**: 採用最新版に既知の非互換性があり、「採用バージョンを下げるか / 互換ライブラリに替えるか」の選択が必要な場合。
 6. 取得情報を `implementation-plan.json.skill_plan` の本エントリ `called=true` に更新。
 
 ## 出力テンプレ
@@ -76,10 +78,53 @@ description: 採用予定の言語/FW/主要ライブラリの **最新安定版
 3. 主要ライブラリ・SDK 表
 4. ツール / コンテナ表
 5. 既知の非互換性 / 警戒事項
-6. 採用根拠の要約
-7. **Gemfile / package.json / Dockerfile に残すコメント例**（手順 4 で各依存ファイルへ追記する形式の見本）
+6. **複数候補が残った技術判断（DP 起票 / B-25）** — 候補が複数残った技術を列挙し pending-decisions と相互参照
+7. 採用根拠の要約
+8. **Gemfile / package.json / Dockerfile に残すコメント例**（手順 4 で各依存ファイルへ追記する形式の見本）
 
 > SKILL.md にインライン例を二重に持たない（テンプレートとの乖離回避）。Single Source of Truth はテンプレートファイル側。
+
+## 複数候補が残った技術判断の DP 起票（B-25）
+
+`version-matrix.md` 生成中、公式情報源から **2 つ以上の妥当な候補**が出てどれを採るかが案件依存になる技術判断が頻出する（Ruby 3.3 / 3.4 並存、Sidekiq vs SolidQueue、googleauth+REST vs firebase-auth-rails gem 等）。ここで agent が推奨を独断で確定すると、T-002 warn_and_document（人間判断をスルーさせない）に反する。**version-matrix.md を書き終えた直後**に、残った技術判断を列挙して `docs/pending-decisions.md` に起票する。
+
+### 起票する / しない（誤検知防止）
+
+- **起票する**: 公式情報源から取得した候補が **2 つ以上**あり、選定基準が性能・運用・互換性・将来性などのトレードオフで、案件の事情に依存する判断。
+- **起票しない（誤検知を出さない）**:
+  - 候補が **1 つしかない**（公式最新が一意に定まる）。`environment-setup.md`「公式の最新安定版を採る」で機械的に決まるものは判断ポイントではない。
+  - パッチバージョンだけの違い（例: 3.3.5 vs 3.3.6）など、選定に人間判断が要らないもの。
+  - 既に `design.yaml.decision_record[]` で **確定済み（`chosen` あり）**の判断（重複起票しない）。
+
+> 単一候補で起票しないことは受け入れ基準（誤検知なし）。「迷う余地があるか」を基準にする — 公式最新が一意なら起票しない、複数の安定版・複数の実装方式が並ぶなら起票する。
+
+### DP 仮 ID の命名
+
+確定前なので Notion 採番（DP-NNN）ではなく、**内容が分かる仮 ID** を付ける（pending-watcher / 人間が後で正式採番する）:
+
+- バージョン選定: `DP-<TECH>-VER`（例: `DP-RUBY-VER`, `DP-RAILS-VER`, `DP-NODE-VER`）
+- 実装方式・ライブラリ選定: `DP-<TOPIC>`（例: `DP-JOB-BACKEND`（Sidekiq vs SolidQueue）, `DP-AUTH-RUBY-SDK`（googleauth+REST vs firebase-auth-rails gem））
+
+### 起票フォーマット
+
+案件側 `docs/pending-decisions.md` の「未決リスト」表に **1 候補 1 行**で append する（複数あればマージせず DP ごとに 1 行ずつ）。表ヘッダは当該ファイルの「未決リスト」節に合わせる（プラグインにより `フェーズ` 列か `関連タスク` 列かが異なる — 既存行に倣う）。記載例:
+
+```markdown
+| <YYYY-MM-DD> | DP-RUBY-VER | 言語ランタイム Ruby のバージョン候補が複数（3.3 系 / 3.4 系）。採用 FW の required_ruby_version と運用実績で案件が選ぶ。tech-version-check が公式最新から複数候補を検出。 | 実装 | tech-version-check | 未決 |
+| <YYYY-MM-DD> | DP-JOB-BACKEND | 非同期ジョブ基盤の候補が複数（Sidekiq / SolidQueue）。Redis 依存可否・運用体制で案件が選ぶ。 | 実装 | tech-version-check | 未決 |
+```
+
+起票したら `version-matrix.md` の該当行（または「6. 採用根拠の要約」）に **`DP-XXX 起票済み（pending-decisions.md 参照）`** を残し、matrix と pending の相互参照を保つ。確定前は version-matrix 上で当該技術を「未確定」と明記し、暫定採用値を断定で書かない。
+
+### 検証シナリオ（受け入れ基準の確認手順）
+
+スキル変更時はこのシナリオで挙動を確認する（複数候補が出る代表ケース = Rails 7.x / 8.x 並存期）:
+
+1. `design.yaml.architecture.stack` に Rails を含む案件で本スキルを実行する。
+2. 公式情報源（rubygems.org / リリースノート）に **7.x 系と 8.x 系の両安定版**が並ぶ状況を取得する。
+3. **期待**: `docs/pending-decisions.md` の未決リストに `DP-RAILS-VER`（7.x / 8.x のいずれを採るか）が 1 行起票される。
+4. **誤検知チェック**: 候補が一意（例: Node.js Active LTS が 1 系列のみ）な技術については **起票されない**ことを確認する。
+5. 既に `decision_record[]` に `DP-RAILS-VER` が `chosen` 済みで渡された場合は **重複起票しない**ことを確認する。
 
 ## 判断ポイント（人間判断をスルーさせない）
 

--- a/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
+++ b/ai-delivery/xtone-shared-plugin/skills/implementation/tech-version-check/templates/version-matrix.template.md
@@ -34,12 +34,24 @@
 
 - `<例: connection_pool 3.0.2 が Ruby 3.3 で例外 — リリースノート https://... を参照>`
 
-## 6. 採用根拠の要約
+## 6. 複数候補が残った技術判断（DP 起票 / B-25）
+
+公式情報源から **2 つ以上の妥当な候補**が出て、どれを採るかが案件依存になった技術判断を列挙する。各行を `docs/pending-decisions.md` の「未決リスト」に **1 件 1 行**で起票し、ここには起票済みであることと暫定状態を残す（matrix ↔ pending の相互参照）。候補が一意なら本節は空（`_(複数候補なし)_`）でよい — 単一候補で DP を起票しないこと（誤検知防止）。
+
+| 仮 DP ID | 対象 | 候補 | 選定が案件依存な理由 | pending 起票 |
+|---|---|---|---|---|
+| `<例: DP-RUBY-VER>` | `<例: 言語ランタイム Ruby>` | `<例: 3.3 系 / 3.4 系>` | `<例: 採用 FW の required_ruby_version と運用実績で選ぶ>` | 済（`docs/pending-decisions.md`） |
+| `<例: DP-JOB-BACKEND>` | `<例: 非同期ジョブ基盤>` | `<例: Sidekiq / SolidQueue>` | `<例: Redis 依存可否・運用体制で選ぶ>` | 済（`docs/pending-decisions.md`） |
+
+> 起票した技術は、上の 1〜4 の表で当該行の採用バージョンを断定で書かず「未確定（DP-XXX）」と記す。確定後に implementer / 人間が値を埋める。命名・誤検知防止の基準は `SKILL.md`「複数候補が残った技術判断の DP 起票（B-25）」節。
+
+## 7. 採用根拠の要約
 
 - `<例: 「公式最新を採る方針（environment-setup.md）」に従い、context7 で 2026-05-26 時点の最新を確認・採用。特定バージョン固定の要望なし。>`
 - 特定バージョン固定の要望があった場合は `docs/pending-decisions.md` の DP-XXX として記録（warn_and_document）。
+- 複数候補が残った技術判断は「6.」に列挙し、`docs/pending-decisions.md` に起票済みであること（B-25）。
 
-## 7. Gemfile / package.json / Dockerfile に残すコメント例
+## 8. Gemfile / package.json / Dockerfile に残すコメント例
 
 `tech-version-check`（B-11）スキルの「手順 4」で各依存ファイルに採用根拠を**コメント形式**で残す。実装時のレビューと将来の追従に効く。
 


### PR DESCRIPTION
## 概要

Issue #184（B-25）の実装。`tech-version-check` スキルが **複数候補が残った技術判断を起票しない**ため、agent が推奨で独断確定してしまう問題を塞ぐ。これはプロジェクトの中核価値「人間の判断をスルーさせない」（T-002 warn_and_document）に直接抵触していた。

パイロットで DP-RUBY-VER / DP-JOB-BACKEND / DP-AUTH-RUBY-SDK の 3 件が起票されず独断確定された、という由来（フィードバック C-1）。

## 変更内容

| ファイル | 変更 |
|---|---|
| `tech-version-check/SKILL.md` | 手順5を「判断ポイントの起票」に拡張。**「複数候補が残った技術判断の DP 起票（B-25）」節**を新設（起票する/しないの誤検知防止ルール・DP 仮ID命名・起票フォーマット・検証シナリオ）。出力テンプレ節一覧も同期 |
| `templates/version-matrix.template.md` | **「6. 複数候補が残った技術判断（DP 起票）」節**を追加し pending-decisions と相互参照。単一候補なら空でよい（誤検知防止） |
| `agents/implementer.md`（template / auth / project-init / skill-creator） | tech-version-check 完了時に version-matrix の DP 候補を `docs/pending-decisions.md` へ append するフックを追加。確定済み・単一候補は append しない |

## 受け入れ基準の充足

- ✅ 複数バージョン候補が公式情報源から取得できる状況 → DP 候補が起票される（SKILL.md 手順5 + 検証シナリオ）
- ✅ 単一バージョンしか選択肢が無い場合は起票されない（誤検知防止ルールを明記）
- ✅ 既存 `xtone-shared-plugin` の symlink 構造を壊さない（実体編集が symlink 経由で全プラグインへ反映、symlink 健全性確認済み）

## 検証

- 4 プラグインの symlink 健全性 OK（tech-version-check は xtone-shared-plugin の実体を参照）
- `validate-plugin.sh` を全プラグインで実行 → すべて `Validation passed`

## 関連

- Issue: #184（B-25）
- 関連タスク: B-11（#156）/ B-17（#164）tech-version-check / T-002 warn_and_document
- 規約: CONV-14（Single Source of Truth / symlink）

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)