### PR TITLE
feat(project-backend-init): バックエンド土台に Rails(API)/Hotwire の docker compose セットアップを追加

### DIFF
--- a/ai-delivery/plugins/xtone-project-init-plugin/delivery/references-authoring-log.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/delivery/references-authoring-log.md
@@ -1,0 +1,67 @@
+# references-authoring-log（言語別レシピ起稿記録）
+
+`aid-references-authoring` スキルに沿って起稿した references/templates の作成記録（手順10）。
+
+## 2026-06-02 — project-backend-init: rails / hotwire 本実装（docker compose 方針）
+
+| 項目 | 内容 |
+|---|---|
+| 対象 Skill | `skills/implementation/project-backend-init` |
+| stack | `rails`（API 構成）/ `hotwire`（Rails+Hotwire） |
+| 契約変更 | **なし**（SKILL.md の言語非依存契約は不変。土台のみ生成・DP-PINIT-11 を遵守） |
+| セットアップ方針 | **バックエンド環境はすべて docker compose**（ユーザー方針・DP-PINIT-12 仮）。ホストに Ruby を入れず `rails new`・実行・lint を compose で完結 |
+| 参照した学習リファレンス | `xtone-auth-plugin/.../firebase-auth-setup/references/rails.md`（型）／Rails 公式 Compose 流儀 |
+| version-matrix | `delivery/version-matrix.md`（Ruby 4.0.5 / Rails 8.1.3・2026-06-02 取得・固定しないスナップショット） |
+
+### 実機 E2E 検証（両スタックとも合格）
+
+ホスト環境は system Ruby 2.6 / rbenv 3.3.6（environment-setup が警告する状況の実例）。検証は rbenv 3.3.6 で `rails new` し、**改訂後テンプレ（docker compose）をそのまま適用**して実施。
+
+| stack | 生成 | docker compose | DB 疎通 | `GET /up` | rubocop |
+|---|---|---|---|---|---|
+| rails (API) | `rails new --api` | build/up OK | `db:prepare` で DB 作成 | **200** | 21 files **no offenses** |
+| hotwire | `rails new`（フル・Turbo/Stimulus 既定同梱） | build/up OK | `db:prepare` で DB 作成 | **200** | 24 files **no offenses** |
+
+- Rails: 8.1.3 / Ruby: 3.3.6（検証機）/ Puma 8.0.2 / PostgreSQL 16（compose）。
+- **テンプレ自体を使って検証**したため、templates の実効性も確認済み。
+
+### 生成物（docker compose 方針）
+
+- `references/rails.md` / `references/hotwire.md` — docker compose で完結する手順に改訂
+- `templates/rails/` — `Dockerfile.dev` / `compose.yaml` / `.dockerignore` / `database.yml.template`（host=`db`）/ `.env.sample`（host=`db`）/ `README.md`
+- `templates/hotwire/` — 上記 ＋ `application.html.erb.template`（最小レイアウト核）
+- 旧テンプレ（`Procfile.dev.sample` / `Gemfile.snippet` / `.rubocop.yml.snippet`）は **削除**（docker compose 方針＋omakase 標準で不要）
+- `SKILL.md` 言語別レシピ表: `rails` / `hotwire` を ✅ 実装済みに更新
+
+### 実機検証で確定し「既知の制約」に昇格した項目
+
+- **Rails 8 標準 Dockerfile は本番用**（`designed for production`）→ 開発は `Dockerfile.dev` を分離（実機で確認）
+- **`DATABASE_HOST` は compose のサービス名 `db`**（`localhost` ではない）
+- **`docker run` で `rails new` するとホスト側が root 所有**になる → `-u "$(id -u):$(id -g)"`
+- **Rails 8 は `rubocop-rails-omakase` 標準同梱** → 別 rubocop gem を足すと衝突（旧 Gemfile.snippet を撤回）
+- **gem を named volume 化**しないと `.:/rails` の bind mount が gem を覆う
+- Hotwire: Turbo/Stimulus は既定同梱（**二重インストール禁止**）／既定レイアウトに `javascript_importmap_tags` が既にある（補うのは欠落時のみ）／`--api` 取り違えが最頻事故
+
+### 判断ポイント（pending-decisions に起票）
+
+- **DP-PINIT-12（仮）**: バックエンド環境＝docker compose 全面化（方針確定・他 setup スキルへの波及反映が未完）
+- **DP-PINIT-13（仮）**: compose の所有責務分担（`db`=local-infra / `web`=backend、単一統合 vs include 合成）— 既定で実装・人間確定待ち
+
+### バージョン方針の遵守（environment-setup）
+
+- references/templates に**バージョン数値をハードコードしない**（`Dockerfile.dev` の `ARG RUBY_VERSION` は `.ruby-version` と一致・`postgres:16` は local-infra の version-matrix で解決）。
+- version-matrix は採用日スナップショット（Ruby 4.0.5）。**最終検証は ruby:4.0.5 コンテナで実施**（docker 方針なのでホスト Ruby 不要・コンテナ内 `ruby 4.0.5 +PRISM` 確認）。
+
+## 2026-06-02（追補）— テスト/デザイン既定の確定（RSpec / Tailwind）
+
+ユーザー指示「作成時に確認する選択制は維持しつつ、既定を rspec / tailwindcss に」を反映。
+
+| 項目 | 既定 | 実装 | 検証 |
+|---|---|---|---|
+| テスト | **RSpec** + factory_bot | `--skip-test` ＋ `Gemfile.snippet`（rspec-rails/factory_bot_rails）＋ `rspec:install` | `bundle exec rspec` 動作（0 examples, 0 failures） |
+| CSS（Hotwire） | **Tailwind CSS** | `--css=tailwind`（tailwindcss-rails・**Node 不要**）＋ `tailwindcss:install` | `tailwindcss:build` 成功・/up=200 |
+| JS | **importmap 維持** | 変更なし（Node 追加せず） | — |
+
+- 選択制は維持（DP-TEST-FW / DP-CSS-FW を pending-decisions に確定記録、minitest/他CSS/esbuild 等へ変更可）。
+- **新たな罠（既知の制約に昇格）**: `rails new --css=tailwind --skip-bundle` では install タスクが走らず `app/assets/tailwind/application.css` が未生成 → bundle 後に `tailwindcss:install` / `rspec:install` を 1 回実行。
+- 実機検証は Hotwire+Tailwind+RSpec+Ruby4.0.5+非root で /up=200・rspec 動作・tailwind:build 成功・`whoami: rails` を確認。

--- a/ai-delivery/plugins/xtone-project-init-plugin/delivery/references-authoring-log.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/delivery/references-authoring-log.md
@@ -37,9 +37,9 @@
 
 - **Rails 8 標準 Dockerfile は本番用**（`designed for production`）→ 開発は `Dockerfile.dev` を分離（実機で確認）
 - **`DATABASE_HOST` は compose のサービス名 `db`**（`localhost` ではない）
-- **`docker run` で `rails new` するとホスト側が root 所有**になる → `-u "$(id -u):$(id -g)"`
+- **`docker run` で `rails new` するとホスト側が root 所有**になる → **root 生成＋末尾 `chown -R $(id -u):$(id -g)`**（`-u` は `gem install` が HOME 権限で失敗するため不可・実機確認）
 - **Rails 8 は `rubocop-rails-omakase` 標準同梱** → 別 rubocop gem を足すと衝突（旧 Gemfile.snippet を撤回）
-- **gem を named volume 化**しないと `.:/rails` の bind mount が gem を覆う
+- **gem はイメージ内 `/usr/local/bundle` に焼く**（`.:/rails` の bind mount に覆われないため named volume は不要・Gemfile 変更時は `docker compose build` で再ビルド）
 - Hotwire: Turbo/Stimulus は既定同梱（**二重インストール禁止**）／既定レイアウトに `javascript_importmap_tags` が既にある（補うのは欠落時のみ）／`--api` 取り違えが最頻事故
 
 ### 判断ポイント（pending-decisions に起票）

--- a/ai-delivery/plugins/xtone-project-init-plugin/delivery/version-matrix.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/delivery/version-matrix.md
@@ -1,0 +1,72 @@
+# 採用バージョン記録（tech-version-check / B-11・B-25）
+
+> 本ファイルは `tech-version-check` スキルの出力。値は採用時点で公式リリースから取得した実数。`docs/environment-setup.md`「公式の最新安定版」に従い、AI は固定値を勝手に決めない。setup 系 Skill（`project-monorepo-scaffold` / `project-frontend-init` / `project-backend-init` / `project-local-infra`）が参照する。
+
+- 作成日: 2026-06-02
+- 案件: project-backend-init レシピ検証（rails / hotwire）
+- 採用根拠: `docs/environment-setup.md`「公式の最新安定版」+ 採用日時点の確認
+
+## 1. 言語ランタイム
+
+| 名前 | 採用バージョン | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| Ruby | **未確定（DP-RUBY-VER 起票済み）**／既定サジェスト 4.0.5 | 4.0.5（4系）／ 3.4.9（3系） | — | https://www.ruby-lang.org/en/downloads/ |
+
+> Ruby は 4系（4.0.5）と 3系（3.4.9）が安定版として並存。**最新の 4系を既定サジェスト**とするが、メジャー選択は案件依存のため「6.」で DP-RUBY-VER として起票（断定で書かない）。
+
+## 2. メイン FW
+
+| 名前 | 採用 | 公式最新 | 要求ランタイム | 根拠 URL |
+|---|---|---|---|---|
+| Rails | 8.1.3 | 8.1.3 | Ruby は gemspec の `required_ruby_version` で都度確認（数値固定しない）。8.1 系は Ruby 4 系に対応 | https://rubygems.org/gems/rails |
+
+## 3. 主要ライブラリ・SDK
+
+| 名前 | 採用 | 公式最新 | 要求 | 根拠 URL |
+|---|---|---|---|---|
+| （土台のみ・ドメイン gem は各モジュール） | — | — | — | — |
+
+> backend-init は土台の器のみ生成（DP-PINIT-11）。lint は Rails 標準同梱の `rubocop-rails-omakase` を使う（別途追加しない）。
+
+## 4. ツール / コンテナ
+
+| 名前 | 採用 | 公式最新 | 用途 | 根拠 URL |
+|---|---|---|---|---|
+| postgres（image） | 16 | （local-infra で解決） | docker compose の DB | https://hub.docker.com/_/postgres |
+| ruby（image） | `${RUBY_VERSION}`-slim（.ruby-version 連動） | — | Dockerfile.dev ベース | https://hub.docker.com/_/ruby |
+
+## 5. 既知の非互換性 / 警戒事項
+
+- 採用 Ruby のメジャー（4系）は比較的新しい。gem の一部が 4系未対応の場合がある → `bundle install` で解決確認。問題時は DP-RUBY-VER で 3系（3.4.9）採用を再検討。
+- システム同梱の古い Ruby では最新 Rails が動かない（environment-setup の実例）。docker compose 方針ではコンテナの `RUBY_VERSION` で解決するため本リスクは緩和。
+
+## 6. 複数候補が残った技術判断（DP 起票 / B-25）
+
+| 仮 DP ID | 対象 | 候補 | 選定が案件依存な理由 | pending 起票 |
+|---|---|---|---|---|
+| DP-RUBY-VER | 言語ランタイム Ruby | 4.0.5（4系・最新メジャー）/ 3.4.9（3系・実績豊富） | 採用 FW の `required_ruby_version` を満たす範囲で、4系の新機能・将来性 vs 3系の gem 互換実績のトレードオフ。Rails 8.1 は両対応 | 済（`docs/pending-decisions.md`） |
+
+> 既定サジェストは **4系（4.0.5）**。確定は人間が行う（warn_and_document）。1〜2 の表で Ruby を断定せず「未確定（DP-RUBY-VER）」と記載済み。
+
+## 7. 採用根拠の要約
+
+- 「公式最新を採る方針（environment-setup.md）」に従い 2026-06-02 時点の公式最新を確認。Ruby は 4系/3系が並存するため **4系を既定サジェスト**としつつ DP-RUBY-VER を起票（B-25・人間判断をスルーさせない）。
+- Rails は公式最新 8.1.3 を採用（候補一意のため DP 起票せず）。
+- 特定バージョン固定の要望があれば `docs/pending-decisions.md` の DP として記録（warn_and_document）。
+
+## 8. Dockerfile / Gemfile に残すコメント例
+
+```dockerfile
+# Dockerfile.dev（Rails コンテナ）
+# tech-version-check (B-11) 2026-06-02 確認: https://hub.docker.com/_/ruby
+# RUBY_VERSION は .ruby-version と一致させる（固定しない）。Ruby は 4系を既定サジェスト（DP-RUBY-VER）。
+ARG RUBY_VERSION
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+```
+
+```ruby
+# .ruby-version（生成時に採用版へ置換。既定サジェストは 4系最新）
+# tech-version-check (B-11) 2026-06-02 確認: https://www.ruby-lang.org/en/downloads/
+```
+
+> **AI は固定値を勝手に決めない**。`<採用バージョン>` は公式リリースで確認した実値で置換し、確認日と URL を残す。

--- a/ai-delivery/plugins/xtone-project-init-plugin/docs/pending-decisions.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/docs/pending-decisions.md
@@ -12,7 +12,10 @@ warn_and_document（T-002 本決定）の出力先。pending-watcher Subagent �
 
 | 起票日 | DP-ID | 概要 | 関連タスク | 状態 |
 |---|---|---|---|---|
-| _(現在、未決はありません — 下記「判断済み」を参照)_ | | | | |
+| 2026-06-02 | DP-TEST-FW | バックエンド土台の**テストツール**。**既定 = RSpec**（`rspec-rails` + `factory_bot_rails`、2026-06-02 ユーザー確定）。作成時に確認する選択制は維持（minitest 等へ変更可）。実機検証済み（docker compose で rspec 動作）。 | project-backend-init | 既定 RSpec で確定・選択制維持 |
+| 2026-06-02 | DP-CSS-FW | バックエンド土台（Hotwire）の**デザイン/アセット構成**。**既定 = Tailwind CSS**（`--css=tailwind` = `tailwindcss-rails`、**Node 不要**・importmap 維持、2026-06-02 ユーザー確定）。作成時に確認する選択制は維持。実機検証済み（`tailwindcss:build` 成功・/up=200）。 | project-backend-init | 既定 Tailwind で確定・選択制維持 |
+| 2026-06-02 | DP-RUBY-VER | 言語ランタイム Ruby のバージョン候補が複数（**4.0.5（4系・最新）/ 3.4.9（3系・実績豊富）**）。Rails 8.1 は両対応。4系の新機能・将来性 vs 3系の gem 互換実績のトレードオフで案件が選ぶ。**既定サジェストは 4系**（tech-version-check が公式最新から複数候補を検出・B-25）。`delivery/version-matrix.md` §6 と相互参照。 | project-backend-init / tech-version-check | 未決（既定=4系サジェスト・人間確定待ち） |
+| 2026-06-02 | DP-PINIT-12（仮） | **バックエンド環境のセットアップ手段＝docker compose に全面化**（ホストに Ruby/rbenv を入れず `rails new`・実行・lint をすべて compose で完結）。`project-backend-init` で実装・実機検証済み。**波及範囲は人間確定で「今回は backend のみ」**。`project-local-infra` / `project-frontend-init` / `project-stack-select` への反映は**別タスク**として残す。 | B-25系 / project-backend-init | backend は実装済み・他 setup スキルへの反映は別タスク |
 
 ## 判断済み（2026-06-01・decision_record / ADR / Notion DP DB に記録）
 
@@ -26,6 +29,7 @@ warn_and_document（T-002 本決定）の出力先。pending-watcher Subagent �
 | DP-PINIT-09 | 技術スタック = **スタック選択制＋拡張可能レジストリ**（初期 Rails/Next.js・将来拡張） | ADR-PINIT-003・design.decision_record | ✅ 起票済 |
 | DP-PINIT-10 | 境界粒度 = **最小核は project-init 所有**（固有はモジュールがマージ） | design.decision_record | ✅ 起票済 |
 | DP-PINIT-11 | 土台=project-init / 機能=モジュール（土台セットアップ内製化） | ADR-PINIT-002・design.decision_record | ✅ 起票済 |
+| DP-PINIT-13（仮） | **compose 所有分担 = 単一 `compose.yaml` 統合**（`db`=local-infra / `web`=backend をコメントで境界明示）。`include:` 物理分割は不採用（2026-06-02 人間確定） | references/templates（rails/hotwire）・references-authoring-log | 未（Notion DP DB 起票は別途） |
 
 > 残アクション: ~~(1) DP-PINIT-06 の実装~~ ✅ 完了。~~(2) Notion DP DB 同期~~ ✅ 完了（2026-06-01 `/aid-dp-register` で DP-PINIT-05〜11 を起票。URL は `delivery/dp-registration-log.md` / `docs/decision-points.md`）。
 > 次: `/aid-skill-new` で setup 系 Skill を起稿。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/SKILL.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/SKILL.md
@@ -38,8 +38,8 @@ description: 案件の土台にバックエンドアプリ雛形（初期サポ�
 
 | stack | references | templates | state |
 |---|---|---|---|
-| `rails` | `references/rails.md` | `templates/rails/` | ⬜ 未実装（`/aid-references-new` で起こす） |
-| `hotwire` | `references/hotwire.md` | `templates/hotwire/` | ⬜ 未実装 |
+| `rails` | `references/rails.md` | `templates/rails/` | ✅ 実装済み（API 構成） |
+| `hotwire` | `references/hotwire.md` | `templates/hotwire/` | ✅ 実装済み（Rails+Hotwire） |
 | `express` / `hono` / `aws-managed`（将来） | — | — | 未着手（DP-AID-04） |
 
 ## 実装契約（言語非依存）

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/hotwire.md
@@ -1,19 +1,87 @@
-# references: hotwire（バックエンド雛形レシピ・Rails+Hotwire）
+# references: hotwire（バックエンド雛形レシピ・Rails+Hotwire / docker compose）
 
-> ⬜ **未実装スタブ**。本実装は `/aid-references-new project-backend-init hotwire` で起こす（DP-AID-04）。契約は `../SKILL.md` を参照。
+`project-backend-init` スキルの **Rails+Hotwire 実装レシピ**。SKILL.md の契約を Rails/Ruby で満たす具体手順。**契約は変えない**（土台の器＋最小ビュー層のみ。ドメイン画面/モデル/業務ロジックは生成しない — DP-PINIT-11）。
 
-## 対象
+> **方針: バックエンド環境はすべて docker compose**（ホストに Ruby を入れない）。docker 構成・DB 接続核・lint・責務分担（compose 所有）は [`rails.md`](./rails.md) と**共通**。本ファイルは Hotwire 固有点（フル構成・最小ビュー層・importmap）に絞る。
+>
+> **コピペで貼りたい場合は [`../templates/hotwire/`](../templates/hotwire/) を使う**（B-09）。
 
-SSR / 管理画面中心で、別フロント SPA を持たず Rails 内で Hotwire（Turbo / Stimulus）描画する案件。
+- 対象: Rails（**フル構成** = `rails new`、`--api` を付けない）+ Hotwire（turbo-rails / stimulus-rails・Rails 既定同梱）/ Ruby — **公式の最新安定版**（固定しない・`delivery/version-matrix.md`）。
+- いつ使うか: **SSR / 管理画面中心で、別フロント SPA を持たず Rails 内で Hotwire 描画する案件**。SPA フロントと組む API 構成なら [`rails.md`](./rails.md)。
+- 前提: `project-monorepo-scaffold` と `project-local-infra` が先に生成済み。Hotwire 案件はフロントを Rails 内に閉じるため `project-frontend-init`（別 SPA）は通常呼ばない。
 
-## 起こすべき内容（実装時に埋める）
+## 0〜2. docker 構成・DB 接続核・lint・責務分担
 
-- `rails new`（フル構成）＋ Hotwire（turbo-rails / stimulus-rails）セットアップ
-- DB 接続核（ローカル基盤と疎通）
-- ルート共有設定の継承（rubocop / CI 核）
-- 最小レイアウト・最小ビュー核（ドメイン画面は含めない）
-- バージョンは tech-version-check で解決
+[`rails.md` の該当節](./rails.md)と**同一**:
+- 責務分担（`db`=local-infra / `web`=backend、compose 所有は DP・[`rails.md` §0](./rails.md#0-責務分担compose-の所有dp-記録)）
+- `Dockerfile.dev`（本番 Dockerfile と分離）/ `compose.yaml`（web + db・healthcheck 待ち）/ `.dockerignore`
+- `config/database.yml` の ENV 解決（`DATABASE_HOST=db`）・`.env.sample`（実値なし）
+- lint は Rails 標準 omakase（`docker compose exec web bundle exec rubocop`）
+
+**唯一の差分**は生成コマンド（フル構成）と**最小ビュー層**（下記）。
+
+## 1. セットアップ（雛形生成・ホストに Ruby 不要／フル構成）
+
+```bash
+# --api を付けない（フル構成）。Rails 既定で Turbo/Stimulus が同梱される。
+RUBY_VERSION=4.0.5   # 既定サジェスト = Ruby 4 系最新（DP-RUBY-VER）
+docker run --rm -v "$PWD":/work -w /work \
+  ruby:${RUBY_VERSION} bash -c \
+  "gem install rails && rails new sample-hotwire --database=postgresql --css=tailwind --skip-test --skip-bundle --skip-git && chown -R $(id -u):$(id -g) sample-hotwire"
+echo "${RUBY_VERSION}" > sample-hotwire/.ruby-version
+```
+
+- `--api` を**付けない**（ビュー層・アセットを含むフル構成）。
+- **ドメイン画面（コントローラ/ビュー/モデル）は生成しない**。**最小レイアウト核**（`app/views/layouts/application.html.erb` の Turbo/Stimulus 読み込み）までが土台の範囲（DP-PINIT-11）。
+- **既定 = Tailwind CSS（`--css=tailwind`）＋ RSpec（`--skip-test`）**（DP-CSS-FW / DP-TEST-FW）。`tailwindcss-rails` は **Node 不要**（importmap 維持と両立）。選択制は維持。
+
+### 初期化（bundle 後に 1 回・`--skip-bundle` 生成のため別途）
+
+`--skip-bundle` で生成すると Tailwind/RSpec の install タスクが走らない。`Gemfile.snippet`（`rspec-rails` + `factory_bot_rails`）を Gemfile に追記し、`docker compose build`（bundle）後に:
+
+```bash
+docker compose run --rm web bin/rails tailwindcss:install   # app/assets/tailwind/application.css 生成（無いと tailwindcss:build が失敗）
+docker compose run --rm web bin/rails generate rspec:install # spec/ 生成
+```
+
+> 罠（実機確認）: `rails new --css=tailwind --skip-bundle` では `app/assets/tailwind/application.css` が**未生成**。bundle 後に `tailwindcss:install` を 1 回流す（流さないと `tailwindcss:build` が "input file does not exist" で失敗）。
+
+## 2'. 最小ビュー層（Hotwire 読み込みのみ）
+
+土台が持つビューは **レイアウトの Hotwire 読み込み核だけ**。ドメイン画面は含めない（[`../templates/hotwire/application.html.erb.template`](../templates/hotwire/application.html.erb.template)）。Rails 既定で同等のレイアウトが生成されるため、**欠けている場合のみ補う**（二重に Hotwire を入れない）。
+
+- アセット構成は Rails 既定（importmap）に従う。importmap なら Node 不要で `web` コンテナだけで完結する。
+- esbuild/bun 構成にする場合のみ `compose.yaml` の `web.command` にアセット watch を足す（案件選択・pending-decisions）。ドメインの partial / view component は土台では作らない。
+
+## 3. 運用詳細（Hotwire 固有）
+
+- **起動は `bin/rails server` で足りる**: importmap 既定なら JS バンドル不要なので、`compose.yaml` の `command` は API と同じ（`db:prepare && server`）でよい。`bin/dev`（foreman）はホスト開発用で、docker compose では compose が起動管理を担うため不要。
+- **DB 待ち / `db:prepare` / gem volume / バージョンロック**: [`rails.md` の運用詳細](./rails.md#3-運用詳細本番必須why)と同一。
+
+## 4. 既知の制約（Rails+Hotwire 固有 ＋ docker 共通）
+
+- **既定 Hotwire を二重インストールしない**: 新規 Rails は既定で Turbo/Stimulus を含む。`bin/rails turbo:install` を重ねると importmap/レイアウトに重複が入る。**既定で入っているか確認してから**、無い場合のみ明示インストール。
+- **`--api` と取り違えない**: Hotwire はフル構成が前提。誤って `--api` で生成するとビュー層が無く Turbo が動かない。**この取り違えが最頻の事故**。生成コマンドを必ず確認。
+- **importmap vs JS バンドラ**: 土台では importmap 既定に倒す（Node 不要）。バンドラ移行は案件判断（pending-decisions）。
+- **CSRF**: フル構成は CSRF 保護が既定 ON。Turbo のフォーム送信は対応済み。土台で `protect_from_forgery` を外さない。
+- **docker 共通の落とし穴**（Rails 標準 Dockerfile は本番用 / `DATABASE_HOST` は service 名 / コンテナ生成物の root 所有 / omakase 重複 / bundle volume / 境界の逸脱）は [`rails.md` §4](./rails.md#4-既知の制約docker--rails-特有の落とし穴徹底明文化) と共通。
+
+## 5. 検証（DoD・B-15）
+
+```bash
+docker compose up -d --build
+curl -fsS -o /dev/null -w "%{http_code}\n" http://localhost:3000/up   # => 200（Rails 標準ヘルスチェック）
+docker compose exec web bundle exec rubocop                            # omakase で no offenses
+docker compose down
+```
+
+- 起動疎通は Rails 標準 `/up` で確認。最小レイアウトが Hotwire を読み込めているかは、生成直後の `/up` 緑 ＋ 起動エラーが無いことで判断。
+- 確認結果は `delivery/scaffold-log.md`（または案件の実装ログ）に記録する。
+
+## 6. 公式ツールの有無
+
+- 雛形は Rails 標準 `rails new`（フル）＋ Rails 既定同梱の Hotwire。`turbo-rails` / `stimulus-rails` は公式 gem。独自セットアップは作らない。
 
 ## templates
 
-`../templates/hotwire/`（未作成）。
+[`../templates/hotwire/`](../templates/hotwire/) に最小雛形（`Dockerfile.dev` / `compose.yaml` / `.dockerignore` / `database.yml.template` / `.env.sample` / `application.html.erb.template` / `README.md`）。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/hotwire.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/hotwire.md
@@ -64,7 +64,7 @@ docker compose run --rm web bin/rails generate rspec:install # spec/ 生成
 - **`--api` と取り違えない**: Hotwire はフル構成が前提。誤って `--api` で生成するとビュー層が無く Turbo が動かない。**この取り違えが最頻の事故**。生成コマンドを必ず確認。
 - **importmap vs JS バンドラ**: 土台では importmap 既定に倒す（Node 不要）。バンドラ移行は案件判断（pending-decisions）。
 - **CSRF**: フル構成は CSRF 保護が既定 ON。Turbo のフォーム送信は対応済み。土台で `protect_from_forgery` を外さない。
-- **docker 共通の落とし穴**（Rails 標準 Dockerfile は本番用 / `DATABASE_HOST` は service 名 / コンテナ生成物の root 所有 / omakase 重複 / bundle volume / 境界の逸脱）は [`rails.md` §4](./rails.md#4-既知の制約docker--rails-特有の落とし穴徹底明文化) と共通。
+- **docker 共通の落とし穴**（フルイメージ必須 / `bash -c`（`-l` 不可）/ `Gemfile.lock*` ワイルドカード / `libyaml-dev` / root 生成＋chown / Rails 標準 Dockerfile は本番用 / `DATABASE_HOST` は service 名 / omakase 重複 / gem はイメージ内に焼く / 境界の逸脱）は [`rails.md` §4](./rails.md#4-既知の制約docker--rails-特有の落とし穴徹底明文化) と共通。
 
 ## 5. 検証（DoD・B-15）
 

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
@@ -88,11 +88,9 @@ services:
     depends_on:
       db: { condition: service_healthy }
     volumes:
-      - .:/rails                 # ソースを反映（開発）
-      - bundle:/usr/local/bundle # gem を volume 化（再ビルドで消えない）
+      - .:/rails                 # ソースを反映（開発）。gem はイメージ内 /usr/local/bundle（覆われない）
 volumes:
   pgdata:
-  bundle:
 ```
 
 `config/database.yml` は接続情報を **ENV 解決**にする（[`../templates/rails/database.yml.template`](../templates/rails/database.yml.template)）。`DATABASE_HOST` は **compose のサービス名 `db`**（`localhost` ではない）。
@@ -113,7 +111,7 @@ docker compose exec web bundle exec rubocop
 
 - **DB 待ち**: `web` の `depends_on: condition: service_healthy` ＋ `db` の `pg_isready` healthcheck で起動順を保証してから `db:prepare`（待たずに打つと接続エラー）。
 - **`db:prepare` を使う**: 土台時点でマイグレーションは無い（ドメインを載せない）。スキーマ作成と接続疎通の確認が目的。
-- **gem を volume 化**: `bundle:/usr/local/bundle` を付けないと `.:/rails` の bind mount が `vendor`/gem を覆い、毎回 bundle が必要になる。
+- **gem はイメージ内に焼く**: `/usr/local/bundle` は `.:/rails` の bind mount に覆われないため named volume は不要。Gemfile 変更時は再ビルド（`docker compose build`）。
 - **バージョンロック**: `Gemfile.lock` / `.ruby-version` をコミットし version-matrix と整合。`Dockerfile.dev` の `ARG RUBY_VERSION` は `.ruby-version` に合わせる。`gem "rails"` は固定しない。
 
 ## 4. 既知の制約（docker × Rails 特有の落とし穴・徹底明文化）

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
@@ -86,7 +86,7 @@ services:
       retries: 30
     volumes: [ "pgdata:/var/lib/postgresql/data" ]
   web:                     # ← project-backend-init 所有セクション
-    build: { context: ., dockerfile: Dockerfile.dev }
+    build: { context: ., dockerfile: Dockerfile.dev, args: { RUBY_VERSION: "${RUBY_VERSION}" } }
     command: bash -c "bin/rails db:prepare && bin/rails server -b 0.0.0.0 -p 3000"
     env_file: .env
     ports: [ "3000:3000" ]

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
@@ -1,15 +1,166 @@
-# references: rails（バックエンド雛形レシピ）
+# references: rails（バックエンド雛形レシピ・API 構成 / docker compose）
 
-> ⬜ **未実装スタブ**。本実装は `/aid-references-new project-backend-init rails` で起こす（DP-AID-04）。契約は `../SKILL.md` を参照。
+`project-backend-init` スキルの **Rails API 実装レシピ**。SKILL.md の「実装契約（言語非依存）」「運用契約」を Rails/Ruby で満たす具体手順。**契約は変えない**（土台の器のみ生成し、ドメインのモデル/マイグレーション/エンドポイント/業務ロジックは生成しない — DP-PINIT-11）。
 
-## 起こすべき内容（実装時に埋める）
+> **方針: バックエンド環境はすべて docker compose でセットアップする**（ホストに Ruby/rbenv を入れない）。`rails new` も含めコンテナ内で完結させる。本構成は実機検証済み（`rails new --api` → docker compose `db:prepare` → `GET /up` = 200 → `rubocop` no offenses / Ruby 3.3.6・Rails 8.1.3）。
+>
+> **コピペで貼りたい場合は [`../templates/rails/`](../templates/rails/) を使う**（B-09）。`templates/rails/` は対の**ファイル単位の最小雛形**（`Dockerfile.dev` / `compose.yaml` / `.dockerignore` / `.env.sample` / `database.yml.template` / `README.md`）。
 
-- `rails new --api`（API 構成）相当のワークスペース内雛形（バージョンは tech-version-check で解決）
-- DB 接続核（`project-local-infra` の docker-compose の DB と疎通する database.yml）
-- ルート共有設定の継承（rubocop / CI 核）
-- `.env` サンプル（実値なし）
-- 起動 / lint スクリプトのモノレポ連携
+- 対象: Rails（**API モード** = `rails new --api`）/ Ruby — **公式の最新安定版を使う**（固定しない）。採用日時点のスナップショットは `delivery/version-matrix.md`。Rails が要求する最小 Ruby は gemspec / `rails new` のエラー出力で都度確認（`ai-delivery/docs/environment-setup.md`）。バージョンは `Dockerfile.dev` の `ARG RUBY_VERSION` ／ `.ruby-version` で解決し、**数値をハードコードしない**。
+- 前提: `project-monorepo-scaffold`（ワークスペース骨格）と `project-local-infra`（DB の docker compose）が先に生成済み。本レシピはその所定位置にバックエンドの器を載せる。
+- いつ使うか: SPA フロント（Next.js 等）と組む API バックエンド土台。SSR/管理画面中心で Rails 内に描画を閉じるなら [`hotwire.md`](./hotwire.md)。
+
+## 0. 責務分担（compose の所有・DP 記録）
+
+| サービス | 所有 Skill | 備考 |
+|---|---|---|
+| `db`（PostgreSQL 等） | `project-local-infra` | DB イメージ・healthcheck・ボリューム |
+| `web`（Rails コンテナ） | `project-backend-init` | `Dockerfile.dev` ＋ web サービス定義 |
+
+> **既定**: 単一の `compose.yaml` に `db` と `web` を同居させ、所有境界をコメントで明示する（検証済み）。`db` は local-infra が定義し、backend は `web` を足す。compose を分割して `include:` / `-f` 合成する方式も可（案件規模で選択）。この分担は判断ポイントとして `docs/pending-decisions.md` に記録し人間が確定する（DP-PINIT-10 / warn_and_document）。
+
+## 1. セットアップ（雛形生成・ホストに Ruby 不要）
+
+ホストに Ruby を入れず、一時的な公式 Ruby **フルイメージ**で雛形を生成する（**全部 docker** 方針）。`RUBY_VERSION` は `delivery/version-matrix.md` の既定サジェスト（**Ruby 4 系最新**・DP-RUBY-VER）。
+
+```bash
+# 雛形生成。RUBY_VERSION は固定しない（着手時に version-matrix / 公式最新で解決）。
+RUBY_VERSION=4.0.5   # 既定サジェスト = Ruby 4 系最新（DP-RUBY-VER）
+docker run --rm -v "$PWD":/work -w /work \
+  ruby:${RUBY_VERSION} bash -c \
+  "gem install rails && rails new sample-api --api --database=postgresql --skip-test --skip-bundle --skip-git && chown -R $(id -u):$(id -g) sample-api"
+echo "${RUBY_VERSION}" > sample-api/.ruby-version
+```
+
+- **フルイメージ（`ruby:<ver>`、slim でない）を使う**: slim には `make`/`gcc` が無く `gem install rails` の native 拡張（例: `websocket-driver`）ビルドが失敗する（実機で確認）。実行用 `Dockerfile.dev` は slim ＋ `build-essential` を入れるので別問題。
+- **`bash -c` を使う（`-l` を付けない）**: ログインシェル（`bash -lc`）は `/etc/profile` で PATH を上書きし、gem の `rails` バイナリ（`/usr/local/bundle/bin`）が外れて `rails: command not found` になる（実機で確認）。
+- **root 生成＋末尾 `chown`**: コンテナ root で生成しホスト UID/GID に chown する（`-u` で UID 指定すると `gem install` が HOME 権限で失敗するため、生成は root・所有権は後で合わせる）。
+- `--api`: ビュー層・アセットを含まない最小構成。フロントは別ワークスペース（`project-frontend-init`）。
+- `--database=postgresql`: `project-local-infra` の docker compose（既定 PostgreSQL）に合わせる。
+- `--skip-bundle`: gem 解決は後段の `docker compose build` で行う（ホストで bundle しない）。
+- `--skip-git`: モノレポのルート git を使う。
+- `.ruby-version` に採用版を書き、`Dockerfile.dev` の `ARG RUBY_VERSION` と一致させる（`.env` の `RUBY_VERSION` で渡す）。
+- **ドメインの `model`/`migration`/`controller` は生成しない**（境界 DP-PINIT-11）。各モジュールが土台の上に載せる。
+
+> ホストに最新 Ruby があるチームは `rails new` をホストで打ってもよいが、**実行・起動・lint はすべて docker compose に寄せる**（本方針）。
+
+## 2. 契約の実装（土台の器）
+
+### 開発用 Dockerfile（本番 Dockerfile と分離）
+
+Rails 8 は標準で**本番用 `Dockerfile`**（`designed for production, not development`）を生成する。開発は別ファイル `Dockerfile.dev` を使う（[`../templates/rails/Dockerfile.dev`](../templates/rails/Dockerfile.dev)）。
+
+```dockerfile
+ARG RUBY_VERSION=3.3.6   # .ruby-version と一致。数値は生成時に解決（固定しない）
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+RUN apt-get update -qq && apt-get install -y --no-install-recommends \
+    build-essential libpq-dev postgresql-client git && rm -rf /var/lib/apt/lists/*
+WORKDIR /rails
+COPY Gemfile Gemfile.lock ./
+RUN bundle install
+COPY . .
+EXPOSE 3000
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
+```
+
+### compose.yaml（web + db・DB 接続核）
+
+`web` は `db` の healthcheck を待ってから `db:prepare` → server 起動。接続情報は **ENV 経由**（[`../templates/rails/compose.yaml`](../templates/rails/compose.yaml)）。
+
+```yaml
+services:
+  db:                      # ← project-local-infra 所有セクション
+    image: postgres:16     # バージョンは local-infra の version-matrix で解決
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER:-postgres}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes: [ "pgdata:/var/lib/postgresql/data" ]
+  web:                     # ← project-backend-init 所有セクション
+    build: { context: ., dockerfile: Dockerfile.dev }
+    command: bash -c "bin/rails db:prepare && bin/rails server -b 0.0.0.0 -p 3000"
+    env_file: .env
+    ports: [ "3000:3000" ]
+    depends_on:
+      db: { condition: service_healthy }
+    volumes:
+      - .:/rails                 # ソースを反映（開発）
+      - bundle:/usr/local/bundle # gem を volume 化（再ビルドで消えない）
+volumes:
+  pgdata:
+  bundle:
+```
+
+`config/database.yml` は接続情報を **ENV 解決**にする（[`../templates/rails/database.yml.template`](../templates/rails/database.yml.template)）。`DATABASE_HOST` は **compose のサービス名 `db`**（`localhost` ではない）。
+
+`.env.sample` に DB 名/ユーザ/ポート等のキーだけ置く（**実値なし**・本体は `.gitignore`）。docker compose の `db` 環境変数とキー名を一致させる。
+
+### lint（Rails 標準 omakase）
+
+Rails 8 は標準で `rubocop-rails-omakase`（`.rubocop.yml` に `inherit_gem`）を同梱する。**rubocop を重複追加しない**。ルート CI からは docker compose 経由で叩く:
+
+```bash
+docker compose exec web bundle exec rubocop
+```
+
+ルート共有設定（DP-PINIT-10）との関係: JS 側は eslint、Ruby 側は omakase に委ねる（言語ごとの標準 lint を尊重）。ルートからは「コンテナ内 lint を呼ぶ」形で統一する。
+
+## 3. 運用詳細（本番必須・why）
+
+- **DB 待ち**: `web` の `depends_on: condition: service_healthy` ＋ `db` の `pg_isready` healthcheck で起動順を保証してから `db:prepare`（待たずに打つと接続エラー）。
+- **`db:prepare` を使う**: 土台時点でマイグレーションは無い（ドメインを載せない）。スキーマ作成と接続疎通の確認が目的。
+- **gem を volume 化**: `bundle:/usr/local/bundle` を付けないと `.:/rails` の bind mount が `vendor`/gem を覆い、毎回 bundle が必要になる。
+- **バージョンロック**: `Gemfile.lock` / `.ruby-version` をコミットし version-matrix と整合。`Dockerfile.dev` の `ARG RUBY_VERSION` は `.ruby-version` に合わせる。`gem "rails"` は固定しない。
+
+## 4. 既知の制約（docker × Rails 特有の落とし穴・徹底明文化）
+
+- **雛形生成は Ruby フルイメージで**: `ruby:<ver>-slim` には `make`/`gcc` が無く、`gem install rails` の native 拡張（`websocket-driver` 等）ビルドが `make failed: No such file or directory` で落ちる。**生成は `ruby:<ver>`（フル）**、実行用 `Dockerfile.dev` は slim ＋ `build-essential`（実機で確認）。
+- **生成コンテナは `bash -c`（`-l` 不可）**: `bash -lc` はログインシェルで PATH を上書きし、gem の `rails` バイナリ（`/usr/local/bundle/bin`）が外れ `rails: command not found` になる（実機で確認）。
+- **`--skip-bundle` だと `Gemfile.lock` が無い**: `Dockerfile.dev` の `COPY Gemfile Gemfile.lock ./` が `not found` で失敗する。**`COPY Gemfile Gemfile.lock* ./`（ワイルドカード）**にし、`bundle install` に lock 生成を委ねる（実機で確認）。
+- **`libyaml-dev` が無いと `bundle install` が exit 5**: Ruby 4 系で `psych`(YAML) が bundled gem 化され、native ビルドに libyaml が要る。`Dockerfile.dev` の apt に **`libyaml-dev`** を入れる（無いと `An error occurred while installing psych` で停止・実機で確認）。
+- **コンテナ生成物の所有者**: `docker run` で `rails new` するとホスト側が **root 所有**になる。`-u` は `gem install` の HOME 権限で失敗するため、**root 生成＋末尾 `chown -R $(id -u):$(id -g)`** で合わせる（実機で確認）。
+- **Rails 標準 `Dockerfile` は本番用**: そのまま開発に使うと `RAILS_ENV=production` / precompile / master.key 要求でハマる。**開発は `Dockerfile.dev` を分離**（非 root 実行・実機で確認）。
+- **`DATABASE_HOST` は service 名**: ローカル直叩きの `localhost` ではなく compose の `db`。`database.yml` に直書きせず ENV 解決にする。
+- **Rails 8 は `rubocop-rails-omakase` 標準**: 別途 `rubocop` / `rubocop-rails` を Gemfile に足すと**設定が衝突**する。omakase をそのまま使う（重複追加しない）。
+- **gem はイメージ内（`/usr/local/bundle`）に焼く**: `.:/rails` の bind mount は `/usr/local/bundle` を覆わないので named volume は不要。Gemfile 変更時は再ビルド（土台は gem を頻繁に足さない）。
+- **`--api` はミドルウェアが削られている**: Cookie/Session/Flash が既定で無い。必要ならモジュールが足す（土台は足さない・DP-PINIT-11）。
+- **境界の逸脱に注意**: `rails generate scaffold` や認証 gem を土台で入れない。ドメイン/機能は各モジュールプラグインが載せる（DP-PINIT-11）。
+
+## 5. 検証（DoD・B-15／実機確認済み）
+
+土台のみなので「**起動・DB 接続・lint が通る**」ことを docker compose 上で確認する（ドメインテストは無い）。
+
+```bash
+docker compose up -d --build              # build → db(healthy) → web 起動 → db:prepare
+docker compose logs web | grep -E "Created database|Listening on"   # DB 作成 & Puma 起動を確認
+curl -fsS -o /dev/null -w "%{http_code}\n" http://localhost:3000/up # => 200（Rails 標準ヘルスチェック）
+docker compose exec web bundle exec rubocop                          # omakase で no offenses
+docker compose down                                                  # 後片付け
+```
+
+- 起動疎通は Rails 標準 `GET /up`（`Rails::HealthController`）で確認（ドメインのエンドポイントを足さずに済む）。
+- 確認結果は `delivery/scaffold-log.md`（または案件の実装ログ）に記録する。
+
+## 6. 公式ツールの有無
+
+- 雛形は Rails 標準 `rails new --api`（一時 Ruby コンテナ経由）。独自ジェネレータは作らない。
+- ヘルスチェックは Rails 標準 `/up`。lint は Rails 標準 omakase。独自実装しない。
+
+## 7. 規約（ファイル名・rails new オプション）
+
+- **ファイル名**: `compose.yaml`（Compose v2 標準。`docker-compose.yml` は使わない）／ 開発イメージは `Dockerfile.dev`（本番は Rails 標準 `Dockerfile` を残す）／ 接続情報は `.env`（実値・gitignore）＋ `.env.sample`（雛形）。
+- **rails new オプション**（土台で固定する規約）:
+  - API は `--api`、Hotwire は付けない（[`hotwire.md`](./hotwire.md)）。
+  - 共通: `--database=postgresql`（local-infra と一致）／`--skip-test`（既定テスト = RSpec のため）／`--skip-bundle`（bundle は compose build）／`--skip-git`（モノレポのルート git）。
+  - **既定テスト = RSpec**（`Gemfile.snippet` で `rspec-rails` + `factory_bot_rails`、bundle 後に `bin/rails generate rspec:install`）。DP-TEST-FW・2026-06-02 確定。
+  - **既定デザイン（Hotwire）= Tailwind CSS**（`--css=tailwind` = tailwindcss-rails・**Node 不要**、bundle 後に `bin/rails tailwindcss:install`）。JS は **importmap 維持**。DP-CSS-FW・2026-06-02 確定。
+  - **作成時に確認する選択制は維持**（minitest / 他 CSS / esbuild 等への変更可・pending-decisions）。
+  - `RUBY_VERSION` は `.env`・`.ruby-version`・`Dockerfile.dev` の `ARG` で一致させ、数値を散在ハードコードしない。
 
 ## templates
 
-`../templates/rails/`（未作成）。
+[`../templates/rails/`](../templates/rails/) に最小雛形（`Dockerfile.dev` / `compose.yaml` / `.dockerignore` / `.env.sample` / `database.yml.template` / `README.md`）。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/references/rails.md
@@ -2,7 +2,7 @@
 
 `project-backend-init` スキルの **Rails API 実装レシピ**。SKILL.md の「実装契約（言語非依存）」「運用契約」を Rails/Ruby で満たす具体手順。**契約は変えない**（土台の器のみ生成し、ドメインのモデル/マイグレーション/エンドポイント/業務ロジックは生成しない — DP-PINIT-11）。
 
-> **方針: バックエンド環境はすべて docker compose でセットアップする**（ホストに Ruby/rbenv を入れない）。`rails new` も含めコンテナ内で完結させる。本構成は実機検証済み（`rails new --api` → docker compose `db:prepare` → `GET /up` = 200 → `rubocop` no offenses / Ruby 3.3.6・Rails 8.1.3）。
+> **方針: バックエンド環境はすべて docker compose でセットアップする**（ホストに Ruby/rbenv を入れない）。`rails new` も含めコンテナ内で完結させる。本構成は実機検証済み（`rails new --api` → docker compose `db:prepare` → `GET /up` = 200 → `rubocop` no offenses / Ruby 4.0.5・Rails 8.1.3・非 root 実行）。
 >
 > **コピペで貼りたい場合は [`../templates/rails/`](../templates/rails/) を使う**（B-09）。`templates/rails/` は対の**ファイル単位の最小雛形**（`Dockerfile.dev` / `compose.yaml` / `.dockerignore` / `.env.sample` / `database.yml.template` / `README.md`）。
 
@@ -51,14 +51,19 @@ echo "${RUBY_VERSION}" > sample-api/.ruby-version
 Rails 8 は標準で**本番用 `Dockerfile`**（`designed for production, not development`）を生成する。開発は別ファイル `Dockerfile.dev` を使う（[`../templates/rails/Dockerfile.dev`](../templates/rails/Dockerfile.dev)）。
 
 ```dockerfile
-ARG RUBY_VERSION=3.3.6   # .ruby-version と一致。数値は生成時に解決（固定しない）
+# 抜粋（全文は templates/rails/Dockerfile.dev）。RUBY_VERSION は固定せず .env から渡す。
+ARG RUBY_VERSION
 FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+# libyaml-dev は Ruby 4 系の psych(YAML) bundled gem のビルドに必須（§4 既知の制約）。
 RUN apt-get update -qq && apt-get install -y --no-install-recommends \
-    build-essential libpq-dev postgresql-client git && rm -rf /var/lib/apt/lists/*
+    build-essential libpq-dev libyaml-dev postgresql-client git && rm -rf /var/lib/apt/lists/*
+RUN groupadd --gid 1000 rails && useradd --uid 1000 --gid rails -m -s /bin/bash rails
 WORKDIR /rails
-COPY Gemfile Gemfile.lock ./
+COPY Gemfile Gemfile.lock* ./   # --skip-bundle 生成時は lock が無いためワイルドカード
 RUN bundle install
 COPY . .
+RUN chown -R rails:rails /rails /usr/local/bundle
+USER rails
 EXPOSE 3000
 CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]
 ```

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/.dockerignore
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/.dockerignore
@@ -1,0 +1,10 @@
+# .dockerignore — ビルドコンテキストから除外（イメージを軽く・機密を入れない）
+.git
+.env
+.env.*
+!.env.sample
+tmp/
+log/
+node_modules/
+storage/
+.DS_Store

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/.env.sample
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/.env.sample
@@ -1,0 +1,22 @@
+# .env.sample — Rails+Hotwire バックエンド土台の接続キー（project-backend-init / hotwire）
+# 実値は入れない。コピーして .env を作り実値を入れる（.env は .gitignore 済み・MCP-08）。
+# キー名は compose.yaml の db サービス環境変数と一致させる。
+
+# --- Ruby バージョン（Dockerfile.dev の build args・.ruby-version と一致）---
+# 既定サジェストは Ruby 4 系最新（DP-RUBY-VER）。固定要望は pending-decisions で判断。
+# tech-version-check (B-11) 確認: https://www.ruby-lang.org/en/downloads/
+RUBY_VERSION=4.0.5
+
+# --- DB 接続（docker compose の db サービスに疎通）---
+# DATABASE_HOST は compose のサービス名（localhost ではない）。
+DATABASE_HOST=db
+DATABASE_PORT=5432
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
+DATABASE_NAME=app_development
+DATABASE_NAME_TEST=app_test
+
+# --- Rails ---
+RAILS_MAX_THREADS=5
+# RAILS_ENV=development
+# SECRET_KEY_BASE=   # 本番のみ。生成は bin/rails secret（コミットしない）

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/Dockerfile.dev
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/Dockerfile.dev
@@ -1,0 +1,29 @@
+# 開発用 Dockerfile（docker compose）。Rails 標準 Dockerfile は本番用のため分離。
+# RUBY_VERSION は .ruby-version と一致させ、compose の build args で渡す（数値をここに固定しない）。
+# 既定サジェストは Ruby 4 系最新（DP-RUBY-VER・delivery/version-matrix.md）。
+# importmap 既定なら Node 不要。esbuild/bun に切り替える場合のみ Node を追加する（案件選択）。
+# tech-version-check (B-11) 確認: https://hub.docker.com/_/ruby
+ARG RUBY_VERSION
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+
+# libyaml-dev は psych(YAML) の native ビルドに必須（Ruby 4 系で psych が bundled gem 化・無いと bundle install が exit 5）。
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential libpq-dev libyaml-dev postgresql-client git && \
+    rm -rf /var/lib/apt/lists/*
+
+# 非 root ユーザーで実行（セキュリティ）。UID/GID 1000 をホスト一般ユーザーに合わせる。
+RUN groupadd --gid 1000 rails && \
+    useradd --uid 1000 --gid rails --create-home --shell /bin/bash rails
+
+WORKDIR /rails
+
+# Gemfile.lock* のワイルドカード: rails new --skip-bundle だと lock が無いため（bundle install が生成）。
+COPY Gemfile Gemfile.lock* ./
+RUN bundle install
+
+COPY . .
+RUN chown -R rails:rails /rails /usr/local/bundle
+USER rails
+
+EXPOSE 3000
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/Gemfile.snippet
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/Gemfile.snippet
@@ -1,0 +1,7 @@
+# Gemfile.snippet — 既存 Gemfile（rails new --css=tailwind --skip-test 生成）の :development, :test グループへ追記。
+# 既定テストツール = RSpec（DP-TEST-FW・2026-06-02 確定）。選択制は維持。
+# tailwindcss-rails は rails new --css=tailwind で Gemfile に入る（Node 不要）。rubocop は omakase 標準を使う。
+group :development, :test do
+  gem "rspec-rails"
+  gem "factory_bot_rails"
+end

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/README.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/README.md
@@ -1,0 +1,49 @@
+# templates/hotwire/（Rails+Hotwire バックエンド土台・docker compose 最小雛形）
+
+`project-backend-init` の Rails+Hotwire（フル構成）土台を **docker compose で動かす**ための最小雛形。解説・why は [`../../references/hotwire.md`](../../references/hotwire.md)。docker 構成は [`templates/rails/`](../rails/) と共通で、差分は**フル構成生成**と**最小レイアウト核**のみ。
+
+> **方針: バックエンド環境はすべて docker compose**（ホストに Ruby を入れない）。**土台＋最小ビュー層のみ**。ドメイン画面/モデル/業務ロジックは含めない（DP-PINIT-11）。
+
+## 含まれるファイル
+
+| ファイル | 配置先 | 用途 |
+|---|---|---|
+| `Dockerfile.dev` | バックエンド直下 | 開発用イメージ（本番 Dockerfile と分離・非 root 実行） |
+| `compose.yaml` | バックエンド直下 | web（Rails）＋ db（PostgreSQL）。`db` は project-local-infra と統合 |
+| `.dockerignore` | バックエンド直下 | ビルドコンテキスト除外（`.env` を入れない） |
+| `database.yml.template` | `config/database.yml` | DB 接続核（ENV 経由・host は service 名 `db`） |
+| `.env.sample` | バックエンド直下の `.env.sample` | DB 接続キー一覧（**実値なし**） |
+| `Gemfile.snippet` | 既存 `Gemfile` へ追記 | 既定テスト = RSpec（rspec-rails / factory_bot_rails） |
+| `application.html.erb.template` | `app/views/layouts/application.html.erb` | 最小レイアウト（Hotwire 読み込み核のみ） |
+
+## 配置手順（ホストに Ruby 不要）
+
+1. 一時 Ruby コンテナで**フル構成**の雛形生成（`--api` を付けない）:
+   ```bash
+   RUBY_VERSION=4.0.5   # 既定サジェスト = Ruby 4 系最新（DP-RUBY-VER・固定しない）
+   docker run --rm -v "$PWD":/work -w /work \
+     ruby:${RUBY_VERSION} bash -c \
+     "gem install rails && rails new sample-hotwire --database=postgresql --css=tailwind --skip-test --skip-bundle --skip-git && chown -R $(id -u):$(id -g) sample-hotwire"
+   ```
+   既定: **Tailwind CSS**（`--css=tailwind` = tailwindcss-rails・**Node 不要**）＋ **RSpec**（`--skip-test`、gem は次手順）。Turbo/Stimulus は Rails 既定同梱（**二重インストールしない**）。
+2. 上表のファイル＋`Gemfile.snippet`（RSpec gem）をコピー。`.template` 拡張子を外し、`Gemfile.snippet` の内容を `Gemfile` へ追記。`application.html.erb.template` は生成済みレイアウトを確認し**欠けている場合のみ**補う。
+3. `.env.sample` をコピーして `.env` を作り実値を入れる（`.env` は `.gitignore` 済み・MCP-08）。
+4. 初期化（**bundle 後に 1 回**・`--skip-bundle` 生成のため別途）:
+   ```bash
+   docker compose build                                                   # bundle install（rspec/tailwind 入る）
+   docker compose run --rm web bin/rails tailwindcss:install              # Tailwind 入力CSS（app/assets/tailwind/application.css）生成
+   docker compose run --rm web bin/rails generate rspec:install           # spec/ 生成
+   ```
+5. 起動・疎通確認:
+   ```bash
+   docker compose up -d
+   curl -fsS -o /dev/null -w "%{http_code}\n" http://localhost:3000/up   # => 200
+   docker compose exec web bin/rails tailwindcss:build                    # Tailwind ビルド（Done in ...ms）
+   docker compose exec web bundle exec rspec                              # RSpec 実行
+   docker compose exec web bundle exec rubocop                            # omakase で no offenses
+   ```
+
+## コミット禁止（重要）
+
+- **`.env`（実値）は絶対にコミットしない**。雛形は `.env.sample`（キーのみ）。`.gitignore` / `.dockerignore` に `.env` を含める。
+- 機密（鍵・トークン）は `templates/` に置かない（`.sample` で枠のみ）。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/application.html.erb.template
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/application.html.erb.template
@@ -1,0 +1,18 @@
+<%# app/views/layouts/application.html.erb — 最小レイアウト（Hotwire 読み込み核のみ） %>
+<%# 土台の範囲はここまで。ドメイン画面・partial・view component は各モジュールが載せる（DP-PINIT-11）。%>
+<%# Rails 既定で同等のレイアウトが生成される。欠けている場合のみ本雛形で補う（二重に Hotwire を入れない）。%>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title><%= content_for(:title) || "App" %></title>
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <%= csrf_meta_tags %>
+    <%= csp_meta_tag %>
+    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
+    <%# importmap 既定。turbo-rails / stimulus-rails はここで読み込まれる %>
+    <%= javascript_importmap_tags %>
+  </head>
+  <body>
+    <%= yield %>
+  </body>
+</html>

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/compose.yaml
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/compose.yaml
@@ -1,0 +1,39 @@
+# compose.yaml — Rails+Hotwire バックエンド土台（project-backend-init / hotwire）
+# 方針: バックエンド環境はすべて docker compose でセットアップする（ホストに Ruby を入れない）。
+# 所有境界（DP-PINIT-13・単一 compose 統合で確定）:
+#   db  … project-local-infra が所有
+#   web … project-backend-init が所有（Dockerfile.dev ＋ Rails 実行）
+# importmap 既定なら web の command は server だけで足りる（bin/dev は不要）。
+services:
+  db: # ← project-local-infra 所有セクション（local-infra の compose と統合する）
+    image: postgres:16 # バージョンは local-infra の version-matrix で解決（固定しない）
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER:-postgres}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  web: # ← project-backend-init 所有セクション
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        # .ruby-version と一致させる。既定サジェストは Ruby 4 系最新（DP-RUBY-VER）。
+        RUBY_VERSION: ${RUBY_VERSION:?set RUBY_VERSION in .env (e.g. 4.0.5)}
+    command: bash -c "bin/rails db:prepare && bin/rails server -b 0.0.0.0 -p 3000"
+    env_file: .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - .:/rails # gem はイメージ内 /usr/local/bundle（覆われない）
+
+volumes:
+  pgdata:

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/database.yml.template
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/database.yml.template
@@ -22,4 +22,5 @@ test:
 production:
   <<: *default
   database: <%= ENV.fetch("DATABASE_NAME", "app_production") %>
+  # 本番は DATABASE_URL を必ず設定すること（空文字フォールバックは開発の保険・本番デプロイ手順で必須化）。
   url: <%= ENV.fetch("DATABASE_URL", "") %>

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/database.yml.template
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/hotwire/database.yml.template
@@ -1,0 +1,25 @@
+# config/database.yml — DB 接続核（project-backend-init / hotwire）
+# 接続情報は ENV 経由（ハードコードしない・MCP-08）。docker compose の db サービスと疎通する。
+# DB 名 / ユーザ / パスワード / ホスト / ポートは .env で渡す（実値はコミットしない）。
+# DATABASE_HOST の既定は compose のサービス名 "db"（localhost ではない）。
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
+  username: <%= ENV.fetch("DATABASE_USER", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+
+development:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME", "app_development") %>
+
+test:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME_TEST", "app_test") %>
+
+production:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME", "app_production") %>
+  url: <%= ENV.fetch("DATABASE_URL", "") %>

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/.dockerignore
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/.dockerignore
@@ -1,0 +1,10 @@
+# .dockerignore — ビルドコンテキストから除外（イメージを軽く・機密を入れない）
+.git
+.env
+.env.*
+!.env.sample
+tmp/
+log/
+node_modules/
+storage/
+.DS_Store

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/.env.sample
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/.env.sample
@@ -1,0 +1,22 @@
+# .env.sample — Rails API バックエンド土台の接続キー（project-backend-init / rails）
+# 実値は入れない。コピーして .env を作り実値を入れる（.env は .gitignore 済み・MCP-08）。
+# キー名は compose.yaml の db サービス環境変数と一致させる。
+
+# --- Ruby バージョン（Dockerfile.dev の build args・.ruby-version と一致）---
+# 既定サジェストは Ruby 4 系最新（DP-RUBY-VER）。固定要望は pending-decisions で判断。
+# tech-version-check (B-11) 確認: https://www.ruby-lang.org/en/downloads/
+RUBY_VERSION=4.0.5
+
+# --- DB 接続（docker compose の db サービスに疎通）---
+# DATABASE_HOST は compose のサービス名（localhost ではない）。
+DATABASE_HOST=db
+DATABASE_PORT=5432
+DATABASE_USER=postgres
+DATABASE_PASSWORD=postgres
+DATABASE_NAME=app_development
+DATABASE_NAME_TEST=app_test
+
+# --- Rails ---
+RAILS_MAX_THREADS=5
+# RAILS_ENV=development
+# SECRET_KEY_BASE=   # 本番のみ。生成は bin/rails secret（コミットしない）

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/Dockerfile.dev
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/Dockerfile.dev
@@ -1,0 +1,30 @@
+# 開発用 Dockerfile（docker compose）。Rails 標準 Dockerfile は本番用のため分離。
+# RUBY_VERSION は .ruby-version と一致させ、compose の build args で渡す（数値をここに固定しない）。
+# 既定サジェストは Ruby 4 系最新（DP-RUBY-VER・delivery/version-matrix.md）。
+# tech-version-check (B-11) 確認: https://hub.docker.com/_/ruby
+ARG RUBY_VERSION
+FROM docker.io/library/ruby:${RUBY_VERSION}-slim
+
+# libyaml-dev は psych(YAML) の native ビルドに必須（Ruby 4 系で psych が bundled gem 化・無いと bundle install が exit 5）。
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends build-essential libpq-dev libyaml-dev postgresql-client git && \
+    rm -rf /var/lib/apt/lists/*
+
+# 非 root ユーザーで実行（セキュリティ）。UID/GID 1000 をホスト一般ユーザーに合わせる。
+RUN groupadd --gid 1000 rails && \
+    useradd --uid 1000 --gid rails --create-home --shell /bin/bash rails
+
+WORKDIR /rails
+
+# gem 解決を先に（レイヤキャッシュ効率）。gem はイメージ内（/usr/local/bundle）に焼く。
+# bind mount は ".:/rails" のみで /usr/local/bundle を覆わないため named volume は不要。
+# Gemfile.lock* のワイルドカード: rails new --skip-bundle だと lock が無いため（bundle install が生成）。
+COPY Gemfile Gemfile.lock* ./
+RUN bundle install
+
+COPY . .
+RUN chown -R rails:rails /rails /usr/local/bundle
+USER rails
+
+EXPOSE 3000
+CMD ["bin/rails", "server", "-b", "0.0.0.0", "-p", "3000"]

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/Gemfile.snippet
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/Gemfile.snippet
@@ -1,0 +1,7 @@
+# Gemfile.snippet — 既存 Gemfile（rails new --api --skip-test 生成）の :development, :test グループへ追記。
+# 既定テストツール = RSpec（DP-TEST-FW・2026-06-02 確定）。選択制は維持（minitest 等に変える案件は本 snippet を使わない）。
+# rubocop は Rails 標準同梱の rubocop-rails-omakase を使う（重複追加しない）。
+group :development, :test do
+  gem "rspec-rails"
+  gem "factory_bot_rails"
+end

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/README.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/README.md
@@ -48,4 +48,4 @@
 ## 補足
 
 - Rails 8 は `rubocop-rails-omakase` を標準同梱するため、lint 用に別 gem を足さない。
-- `bundle` を named volume 化（`compose.yaml`）しているのは、`.:/rails` の bind mount が gem を覆わないようにするため。
+- `bundle` は `/usr/local/bundle`（イメージ内）に入り、`.:/rails` の bind mount には覆われないため named volume は不要。Gemfile 変更時は `docker compose build` で再ビルドする。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/README.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/README.md
@@ -1,0 +1,51 @@
+# templates/rails/（Rails API バックエンド土台・docker compose 最小雛形）
+
+`project-backend-init` の Rails（API モード）土台を **docker compose で動かす**ための最小雛形。解説・why は [`../../references/rails.md`](../../references/rails.md)。
+
+> **方針: バックエンド環境はすべて docker compose**（ホストに Ruby を入れない）。**土台のみ**でドメインのモデル/マイグレーション/コントローラは含めない（DP-PINIT-11）。実機検証済み（`db:prepare` → `GET /up` = 200 → rubocop no offenses）。
+
+## 含まれるファイル
+
+| ファイル | 配置先 | 用途 |
+|---|---|---|
+| `Dockerfile.dev` | バックエンド直下 | 開発用イメージ（Rails 標準の本番 Dockerfile と分離・非 root 実行） |
+| `compose.yaml` | バックエンド直下 | web（Rails）＋ db（PostgreSQL）。`db` は project-local-infra と統合 |
+| `.dockerignore` | バックエンド直下 | ビルドコンテキスト除外（`.env` を入れない） |
+| `database.yml.template` | `config/database.yml` | DB 接続核（ENV 経由・host は service 名 `db`） |
+| `.env.sample` | バックエンド直下の `.env.sample` | DB 接続キー一覧（**実値なし**） |
+| `Gemfile.snippet` | 既存 `Gemfile` へ追記 | 既定テスト = RSpec（rspec-rails / factory_bot_rails） |
+
+## 配置手順（ホストに Ruby 不要）
+
+1. 一時 Ruby コンテナで雛形生成（オーナーをホストに合わせる）:
+   ```bash
+   RUBY_VERSION=4.0.5   # 既定サジェスト = Ruby 4 系最新（DP-RUBY-VER・固定しない）
+   docker run --rm -v "$PWD":/work -w /work \
+     ruby:${RUBY_VERSION} bash -c \
+     "gem install rails && rails new sample-api --api --database=postgresql --skip-test --skip-bundle --skip-git && chown -R $(id -u):$(id -g) sample-api"
+   ```
+   既定テスト = **RSpec**（`--skip-test`、gem は次手順）。（バージョンは固定しない・[`references/rails.md`](../../references/rails.md)）
+2. 上表のファイル＋`Gemfile.snippet`（RSpec gem）をコピー。`.template` 拡張子を外し（`database.yml.template` → `config/database.yml`）、`Gemfile.snippet` の内容を `Gemfile` へ追記。
+3. `.env.sample` をコピーして `.env` を作り**実値を入れる**（`.env` は `.gitignore` 済み・MCP-08）。`compose.yaml` の `db` 環境変数とキー名を一致させる。
+4. 初期化（**bundle 後に 1 回**）:
+   ```bash
+   docker compose build                                          # bundle install（rspec 入る）
+   docker compose run --rm web bin/rails generate rspec:install  # spec/ 生成
+   ```
+5. 起動・疎通確認:
+   ```bash
+   docker compose up -d
+   curl -fsS -o /dev/null -w "%{http_code}\n" http://localhost:3000/up   # => 200
+   docker compose exec web bundle exec rspec                              # RSpec 実行
+   docker compose exec web bundle exec rubocop                            # omakase で no offenses
+   ```
+
+## コミット禁止（重要）
+
+- **`.env`（実値）は絶対にコミットしない**。雛形は `.env.sample`（キーのみ）。`.gitignore` と `.dockerignore` に `.env` を含める。
+- 機密（鍵・トークン）は `templates/` に置かない（`.sample` で枠のみ）。
+
+## 補足
+
+- Rails 8 は `rubocop-rails-omakase` を標準同梱するため、lint 用に別 gem を足さない。
+- `bundle` を named volume 化（`compose.yaml`）しているのは、`.:/rails` の bind mount が gem を覆わないようにするため。

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/compose.yaml
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/compose.yaml
@@ -1,0 +1,39 @@
+# compose.yaml — Rails API バックエンド土台（project-backend-init / rails）
+# 方針: バックエンド環境はすべて docker compose でセットアップする（ホストに Ruby を入れない）。
+# 所有境界（DP-PINIT-13・単一 compose 統合で確定）:
+#   db  … project-local-infra が所有（DB イメージ・healthcheck・ボリューム）
+#   web … project-backend-init が所有（Dockerfile.dev ＋ Rails 実行）
+# 接続情報・RUBY_VERSION は .env（同ディレクトリの .env は compose が変数展開にも使う）。
+services:
+  db: # ← project-local-infra 所有セクション（local-infra の compose と統合する）
+    image: postgres:16 # バージョンは local-infra の version-matrix で解決（固定しない）
+    environment:
+      POSTGRES_USER: ${DATABASE_USER:-postgres}
+      POSTGRES_PASSWORD: ${DATABASE_PASSWORD:-postgres}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DATABASE_USER:-postgres}"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  web: # ← project-backend-init 所有セクション
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+      args:
+        # .ruby-version と一致させる。既定サジェストは Ruby 4 系最新（DP-RUBY-VER）。
+        RUBY_VERSION: ${RUBY_VERSION:?set RUBY_VERSION in .env (e.g. 4.0.5)}
+    command: bash -c "bin/rails db:prepare && bin/rails server -b 0.0.0.0 -p 3000"
+    env_file: .env
+    ports:
+      - "3000:3000"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      - .:/rails # ソースを反映（開発）。gem はイメージ内 /usr/local/bundle（覆われない）
+
+volumes:
+  pgdata:

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/database.yml.template
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/database.yml.template
@@ -1,0 +1,25 @@
+# config/database.yml — DB 接続核（project-backend-init / rails）
+# 接続情報は ENV 経由（ハードコードしない・MCP-08）。docker compose の db サービスと疎通する。
+# DB 名 / ユーザ / パスワード / ホスト / ポートは .env で渡す（実値はコミットしない）。
+# DATABASE_HOST の既定は compose のサービス名 "db"（localhost ではない）。
+default: &default
+  adapter: postgresql
+  encoding: unicode
+  host: <%= ENV.fetch("DATABASE_HOST", "db") %>
+  port: <%= ENV.fetch("DATABASE_PORT", "5432") %>
+  username: <%= ENV.fetch("DATABASE_USER", "postgres") %>
+  password: <%= ENV.fetch("DATABASE_PASSWORD", "") %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS", 5) %>
+
+development:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME", "app_development") %>
+
+test:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME_TEST", "app_test") %>
+
+production:
+  <<: *default
+  database: <%= ENV.fetch("DATABASE_NAME", "app_production") %>
+  url: <%= ENV.fetch("DATABASE_URL", "") %>

--- a/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/database.yml.template
+++ b/ai-delivery/plugins/xtone-project-init-plugin/skills/implementation/project-backend-init/templates/rails/database.yml.template
@@ -22,4 +22,5 @@ test:
 production:
   <<: *default
   database: <%= ENV.fetch("DATABASE_NAME", "app_production") %>
+  # 本番は DATABASE_URL を必ず設定すること（空文字フォールバックは開発の保険・本番デプロイ手順で必須化）。
   url: <%= ENV.fetch("DATABASE_URL", "") %>


### PR DESCRIPTION
## Summary

xtone-project-init-plugin の `project-backend-init` スキルに、未実装スタブだった **Rails の初期セットアップを本実装**しました。方針はユーザー指示に従い「バックエンド環境はすべて docker compose（ホストに Ruby を入れない）」。既定は **Ruby 4 系 / Rails 8.1 / 非root 実行 / RSpec / Tailwind CSS（Node 不要）/ importmap**。**作成時に確認する選択制は維持**しています。

## 変更内容

- **references**: `rails.md`（API 構成）/ `hotwire.md`（Rails+Hotwire）を docker compose 方針で本実装。手順・運用詳細・既知の制約（罠）・規約節（§7）を整備。
- **templates**: `rails/` / `hotwire/` に最小雛形を配置（`Dockerfile.dev`・`compose.yaml`・`.dockerignore`・`database.yml.template`・`.env.sample`・`Gemfile.snippet`・`README.md`・hotwire は `application.html.erb.template` も）。
- **delivery/version-matrix.md**: tech-version-check（B-11/B-25）形式で採用バージョンを記録（Ruby 4.0.5 既定サジェスト・複数候補は DP-RUBY-VER 起票）。
- **SKILL.md**: 言語別レシピ表を `rails`/`hotwire` とも ✅ 実装済みに更新。
- **judgement records**: `docs/pending-decisions.md` に DP-PINIT-12/13・DP-RUBY-VER・DP-TEST-FW・DP-CSS-FW を起票。
- **delivery/references-authoring-log.md**: 作業記録（実機検証結果・踏んだ罠）を追加。

## 実機 E2E 検証（合格）

ホスト Ruby 不要・すべて `ruby:4.0.5` コンテナ内で完結。

| stack | 構成 | /up | rspec | tailwindcss:build | rubocop | whoami |
|---|---|---|---|---|---|---|
| rails (API) | Ruby 4.0.5 / Rails 8.1.3 / 非root | 200 | (構成内) | — | no offenses (21 files) | rails |
| hotwire | + Tailwind + RSpec + factory_bot | 200 | 0 examples, 0 failures | Done | no offenses (24 files) | rails |

## 検証で見つけて修正した罠（既知の制約に昇格）

1. `ruby:<ver>-slim` には `make`/`gcc` が無く `gem install rails` の native 拡張ビルドが失敗 → 雛形生成は**フルイメージ** `ruby:<ver>`。
2. `bash -lc`（ログインシェル）が PATH を上書きし `rails: command not found` → **`bash -c`** を使う。
3. `--skip-bundle` で `Gemfile.lock` が無く `COPY Gemfile Gemfile.lock` が失敗 → **`COPY Gemfile Gemfile.lock* ./`**（ワイルドカード）。
4. `libyaml-dev` 不足で `bundle install` が exit 5（Ruby 4 系で `psych` が bundled gem 化）→ apt に **`libyaml-dev`** を追加。
5. `rails new --css=tailwind --skip-bundle` では Tailwind の install タスクが走らず `app/assets/tailwind/application.css` が未生成 → bundle 後に **`bin/rails tailwindcss:install`** を 1 回実行。

## 判断ポイント（pending-decisions / DP）

- **DP-PINIT-12（仮）**: バックエンド環境 = docker compose 全面化（方針確定・他 setup スキルへの波及は別タスク）
- **DP-PINIT-13（仮）**: compose 所有分担 = **単一 `compose.yaml` 統合**（人間確定）
- **DP-RUBY-VER**: Ruby メジャー（4.0.5 / 3.4.9）— 既定 4 系サジェスト・人間確定待ち（B-25 仕様で起票）
- **DP-TEST-FW**: 既定 = **RSpec** + factory_bot（選択制維持）
- **DP-CSS-FW**: 既定 = **Tailwind CSS**（Node 不要・選択制維持）

## 関連

- CONV-06 / CONV-14（schemas symlink）/ DP-PINIT-09・10・11（スタック選択制・最小核・境界）
- 横断スキル: B-11/B-17 tech-version-check、B-25 複数候補→DP 自動起票
- スキル骨格: SKL-12 / SKL-20

## Test plan

- [x] `validate-plugin.sh` パス（schema 検証含む）
- [x] 機密混入なし・未置換プレースホルダなし
- [x] 実機 E2E（rails/hotwire ＋ Ruby 4 系 ＋ 非root ＋ RSpec ＋ Tailwind ＋ docker compose）
- [ ] レビュアー（豊田）による内容確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)