### PR TITLE
feat(marketplace): xtone-project-init-plugin を Marketplace 配信プラグインに追加

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -85,6 +85,15 @@
             "author": {
                 "name": "Xtone"
             }
+        },
+        {
+            "name": "xtone-project-init-plugin",
+            "source": "./ai-delivery/plugins/xtone-project-init-plugin",
+            "description": "実案件の初期化（プロジェクトブートストラップ）を担う独立メタプラグイン（T-051）。ドメイン/要件ヒアリング→必要モジュール推奨（AI推奨＋人間確定）→案件ルート delivery 雛形初期化→モジュールプラグイン群のロード手順生成を /project-* 横断コマンドで提供する。xtone-aid-skill-creator-plugin（作る側メタ）と対称の立ち上げる側メタ。",
+            "version": "0.1.0",
+            "author": {
+                "name": "Xtone"
+            }
         }
     ]
 }


### PR DESCRIPTION
## Summary

`xtone-project-init-plugin`（T-051・案件初期化メタプラグイン）を `.claude-plugin/marketplace.json` に登録し、**Marketplace 経由でインストール可能**にします。これにより `/plugin marketplace add xtone/ai_development_tools` 後に `/plugin install xtone-project-init-plugin` で利用可能になります。

## 変更内容

- `.claude-plugin/marketplace.json` の `plugins` 配列末尾に `xtone-project-init-plugin` エントリを追加（既存 `xtone-auth-plugin` / `xtone-aid-skill-creator-plugin` と同形式）。
  - `name`: `xtone-project-init-plugin`
  - `source`: `./ai-delivery/plugins/xtone-project-init-plugin`
  - `description`: plugin.json の description と一致
  - `version`: `0.1.0`
  - `author`: Xtone

## Test plan

- [x] JSON 構文検証（Python `json.load` で全 10 プラグインがパース可能）
- [x] `validate-plugin.sh` パス（プラグイン本体側に影響なし）
- [ ] レビュアー（豊田）による確認・マージ後に Marketplace から実インストールテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)