### PR TITLE
docs(plugins): セットアップ手順を /plugin コマンド (Marketplace 経由) に統一

### DIFF
--- a/ai-delivery/plugins/xtone-aid-skill-creator-plugin/README.md
+++ b/ai-delivery/plugins/xtone-aid-skill-creator-plugin/README.md
@@ -17,8 +17,17 @@ Xtone AIデリバリシステムの **aid-skill-creator** プラグイン。マ�
 
 ## はじめかた
 
+Claude Code の **Marketplace 経由でインストール**する（推奨）:
+
+```
+/plugin marketplace add xtone/ai_development_tools
+/plugin install xtone-aid-skill-creator-plugin
+```
+
+インストール後、Claude Code を再起動するとコマンド・スキルが有効になる。本プラグインは **Notion MCP 必須**（16 DB から引いて中身を生成する設計）— `.env` の `NOTION_TOKEN` を設定する（[`docs/usage-guide.md`](./docs/usage-guide.md) §1）。
+
+開発時（本リポジトリで直接編集する場合）は品質ゲートで検証:
+
 ```bash
-cp .env.example .env   # トークンを設定
-ai-delivery/scripts/validate-plugin.sh .   # 品質ゲート
-claude                  # Claude Code を起動し、/req-collect で開始
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-aid-skill-creator-plugin
 ```

--- a/ai-delivery/plugins/xtone-aid-skill-creator-plugin/docs/usage-guide.md
+++ b/ai-delivery/plugins/xtone-aid-skill-creator-plugin/docs/usage-guide.md
@@ -6,17 +6,19 @@ AIデリバリ用プラグインを「中身ごと」起こすメタプラグイ
 
 ## 1. インストール / ロード
 
-開発中はセッション限定でロードして試せる:
+Claude Code の **Marketplace 経由でインストール**する（推奨）:
 
-```bash
-# ai-delivery/ で
-claude --plugin-dir plugins/xtone-aid-skill-creator-plugin
+```
+/plugin marketplace add xtone/ai_development_tools
+/plugin install xtone-aid-skill-creator-plugin
 ```
 
-検証のみ:
+インストール後、Claude Code を再起動するとコマンド・スキルが有効になる。本プラグインは **Notion MCP 必須**（DB から引いて中身を生成する設計）— `.env` の `NOTION_TOKEN` を設定する（下記「Notion MCP の前提」参照）。
+
+開発時（本リポジトリで直接編集する場合）の検証:
 
 ```bash
-bash ai-delivery/scripts/validate-plugin.sh plugins/xtone-aid-skill-creator-plugin --strict
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-aid-skill-creator-plugin --strict
 ```
 
 ### Notion MCP の前提（必須）

--- a/ai-delivery/plugins/xtone-auth-plugin/README.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/README.md
@@ -7,12 +7,19 @@ Xtone AIデリバリシステムの **認証モジュール（MOD-001）** プ�
 
 ## クイックスタート
 
-```bash
-# ai-delivery/ で（セッション限定ロード）
-claude --plugin-dir plugins/xtone-auth-plugin
+Claude Code の **Marketplace 経由でインストール**する（推奨）:
 
-# 検証
-claude plugin validate --strict plugins/xtone-auth-plugin
+```
+/plugin marketplace add xtone/ai_development_tools
+/plugin install xtone-auth-plugin
+```
+
+インストール後、Claude Code を再起動するとコマンド・スキルが有効になる。Firebase Auth を使う案件では `.env` に `FIREBASE_PROJECT_ID` 等を設定する（[`docs/usage-guide.md`](./docs/usage-guide.md)）。
+
+開発時（本リポジトリで直接編集する場合）は品質ゲートで検証:
+
+```bash
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin
 ```
 
 フロー: `/req-collect → /auth-design → /implement`。詳細は [`docs/usage-guide.md`](./docs/usage-guide.md)。

--- a/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
+++ b/ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md
@@ -6,17 +6,19 @@
 
 ## 1. インストール / ロード
 
-開発中はセッション限定でロードして試せる:
+Claude Code の **Marketplace 経由でインストール**する（推奨）:
 
-```bash
-# ai-delivery/ で
-claude --plugin-dir plugins/xtone-auth-plugin
+```
+/plugin marketplace add xtone/ai_development_tools
+/plugin install xtone-auth-plugin
 ```
 
-検証のみ:
+インストール後、Claude Code を再起動するとコマンド・スキルが有効になる。Firebase Auth を使う案件では `.env` に `FIREBASE_PROJECT_ID` / `GOOGLE_APPLICATION_CREDENTIALS` 等を設定する（[`ai-delivery/docs/mcp-setup-guide.md`](../../../docs/mcp-setup-guide.md)）。
+
+開発時（本リポジトリで直接編集する場合）の検証:
 
 ```bash
-claude plugin validate --strict plugins/xtone-auth-plugin
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-auth-plugin
 ```
 
 ## 2. 基本フロー

--- a/ai-delivery/plugins/xtone-project-init-plugin/README.md
+++ b/ai-delivery/plugins/xtone-project-init-plugin/README.md
@@ -17,10 +17,19 @@ Xtone AIデリバリシステムの **案件初期化（プロジェクトブー
 
 ## はじめかた
 
+Claude Code の **Marketplace 経由でインストール**する（推奨）:
+
+```
+/plugin marketplace add xtone/ai_development_tools
+/plugin install xtone-project-init-plugin
+```
+
+インストール後、Claude Code を再起動するとコマンド・スキルが有効になる。MCP（Notion 等）が必要な Skill は `.env`（`NOTION_TOKEN` 等）を設定する（[`ai-delivery/docs/mcp-setup-guide.md`](../../docs/mcp-setup-guide.md)）。
+
+開発時（本リポジトリで直接編集する場合）は品質ゲートで検証:
+
 ```bash
-cp .env.example .env   # トークンを設定
-ai-delivery/scripts/validate-plugin.sh .   # 品質ゲート
-claude                  # Claude Code を起動し、/project-init で開始
+ai-delivery/scripts/validate-plugin.sh ai-delivery/plugins/xtone-project-init-plugin
 ```
 
 フロー: `/project-init`（ヒアリング）→ `/project-modules`（モジュール推奨）→ `/project-scaffold`（スタック選択＋土台セットアップ）→ `/project-load-guide` → `/project-status`。


### PR DESCRIPTION
## Summary

`ai-delivery/plugins/` 配下 3 プラグイン（xtone-project-init / xtone-auth / xtone-aid-skill-creator）の **セットアップ手順を Claude Code の `/plugin` コマンド（Marketplace 経由）に統一**します。PR #210 で Marketplace 配信化が完了したため、README/usage-guide の案内も新方式に揃えます。

## 変更内容

旧方式（`claude --plugin-dir plugins/<name>` / `claude plugin validate --strict ...`）を、新方式に置換:

```
/plugin marketplace add xtone/ai_development_tools
/plugin install xtone-<usecase>-plugin
```

開発時（リポジトリで直接編集する場合）の検証コマンドは `ai-delivery/scripts/validate-plugin.sh` に統一。

### 修正ファイル（5 件）

- `ai-delivery/plugins/xtone-project-init-plugin/README.md`（「はじめかた」）
- `ai-delivery/plugins/xtone-auth-plugin/README.md`（「クイックスタート」）
- `ai-delivery/plugins/xtone-auth-plugin/docs/usage-guide.md`（§1 インストール / ロード）
- `ai-delivery/plugins/xtone-aid-skill-creator-plugin/README.md`（「はじめかた」）
- `ai-delivery/plugins/xtone-aid-skill-creator-plugin/docs/usage-guide.md`（§1 インストール / ロード）

> 注: `docs/re-pilot-report.md` の `claude plugin validate --strict` 記述は **T-021 当時の事実記録（過去レポート）** なので意図的に残しています。

## Test plan

- [x] `validate-plugin.sh` パス（3 プラグインとも ✅ Validation passed）
- [x] 旧形式 (`claude --plugin-dir` / `claude plugin validate`) の残存は履歴レポート 1 箇所のみで意図的（プラグインのセットアップ案内からは全消去）
- [ ] レビュアー（豊田）による文言確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)