### PR TITLE
chore: Claude Code テレメトリのプロジェクト名を付与

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "env": {
+    "OTEL_RESOURCE_ATTRIBUTES": "project.name=ai_development_tools"
+  }
+}


### PR DESCRIPTION
> ## 📌 先に: このPRで、あなたのプロンプトが収集されるようになることはありません
>
> このPRが追加するのは **`OTEL_RESOURCE_ATTRIBUTES` という環境変数1つだけ**です。これは「集計するとき、このリポジトリを何という名前で数えるか」というラベルであり、**送信のスイッチではありません。**
>
> Claude Code がテレメトリを送信するには、次の3つが揃っている必要があります。
>
> | 必要なもの | このPRに含まれるか |
> |---|---|
> | 送信の有効化フラグ（`CLAUDE_CODE_ENABLE_TELEMETRY=1`） | ❌ 含まれない |
> | 送信先の URL（`OTEL_EXPORTER_OTLP_ENDPOINT`） | ❌ 含まれない |
> | 認証トークン（`OTEL_EXPORTER_OTLP_HEADERS` の Bearer） | ❌ 含まれない |
>
> これらは**各自が自分の意思で、自分のマシンのローカル設定に入れるもの**です（同意手続きを経たうえでの opt-in）。収集基盤側も認証トークンのないリクエストは拒否する設定のため、この3つが無い状態では送信は成立しません。
>
> **参加していない人**: 環境変数が1つ増えるだけで、Claude Code の動作は何も変わりません。無害です。
> **すでに参加している人**: 送信される中身は**一切変わりません**。変わるのは集計上のラベルだけで、これまで「未分類」に入っていた分が、このリポジトリの名前で数えられるようになります。

## 対応内容

### 目的

Claude Code はリポジトリ名や作業ディレクトリを OpenTelemetry の属性として送らない。そのため利用分析基盤（[xtone/prompt-improver](https://github.com/xtone/prompt-improver)）でプロジェクト別に集計すると、**このリポジトリでの利用がすべて「未分類」バケットに落ちる**。未分類は黙って除外されず集計に含まれるため、実名バケットと大きな未分類バケットが混在した状態になり、プロジェクト単位のトークン量・コストの把握ができない。

**このPRで達成される状態**: **すでに計測に参加しているメンバーの利用が、「未分類」ではなく本リポジトリの実名で集計されるようになる**

### やったこと

**1. `.claude/settings.json`（変更）**
- `env.OTEL_RESOURCE_ATTRIBUTES` に `project.name=<リポジトリ名>` を付与

### やらないこと

- **テレメトリ送信の有効化** → 冒頭のとおり。本PRは集計ラベルのみで、送信は各自のローカル設定（`~/.claude/settings.local.json` または各リポジトリの `.claude/settings.local.json`・いずれも gitignore 済み）で行う
- **計測への参加の強制** → 参加は個人の opt-in。このリポジトリ設定が参加を発生させることはない
- `client.name` / `unit` の付与 → 案件ごとの人間判断が必要な値のため未指定（分析基盤側では NULL のまま）
- 既存データへの遡及付与 → しない（prompt-improver ADR-016）。設定前の利用は「未分類」のまま残り、以降の分だけ実名で集計される

## テスト

生成物は環境変数の定義のみで、実行されるコードを含まない。

- `prompt-improver` の `scripts/claude-otel/setup-project-name.sh` が生成した内容をそのままコミット（手書きしていない）
- `--dry-run` で導出されるプロジェクト名を事前確認したうえで書き込み
- `.claude/settings.json` が `.gitignore` 対象外であることを `git check-ignore` で確認済み
- コミットしたファイルに送信先・トークン・有効化フラグのいずれも含まれないことを確認済み

## 参考情報

- 分析基盤: [xtone/prompt-improver](https://github.com/xtone/prompt-improver)
- 何を集める / 集めないか（参加前に読むもの）: `docs/otel-poc/phase0-consent.md`（prompt-improver）
- 未分類バケットの扱い: `docs/system/03-data-model.md` §5（prompt-improver）
- 付与手順: `docs/runbooks/project-name-attribution.md`（prompt-improver）

## その他

- `.claude/settings.json` の `env` は**スコープ間でキー単位でマージ**されるため、各自の `~/.claude/settings.local.json` にある送信先やトークンの設定を上書きして消すことはない
